### PR TITLE
🛑 Global useIsWrapping hook

### DIFF
--- a/src/custom/components/Menu/index.tsx
+++ b/src/custom/components/Menu/index.tsx
@@ -14,7 +14,10 @@ export const StyledMenu = styled(MenuMod)`
   }
 `
 
-const Policy = styled(InternalMenuItem)`
+const Policy = styled(InternalMenuItem).attrs(attrs => ({
+  ...attrs,
+  target: '_blank'
+}))`
   font-size: 0.8em;
   text-decoration: underline;
 `
@@ -23,7 +26,7 @@ const MenuFlyout = styled(MenuFlyoutUni)`
   min-width: 11rem;
 `
 
-const Separator = styled(SeparatorBase)`
+export const Separator = styled(SeparatorBase)`
   background-color: #0000002e;
   margin: 0.3rem auto;
   width: 90%;

--- a/src/custom/components/swap/EthWethWrap/index.tsx
+++ b/src/custom/components/swap/EthWethWrap/index.tsx
@@ -9,7 +9,7 @@ import { useCurrencyBalances } from 'state/wallet/hooks'
 import { SHORT_PRECISION } from 'constants/index'
 import { colors } from 'theme'
 import Loader from 'components/Loader'
-import { useIsTransactionPending } from 'state/transactions/hooks'
+import useIsWrapping from 'hooks/useIsWrapping'
 
 const COLOUR_SHEET = colors(false)
 
@@ -107,9 +107,8 @@ export interface Props {
 export default function EthWethWrap({ account, native, wrapped, wrapCallback }: Props) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
-  const [pendingHash, setPendingHash] = useState<string | undefined>()
 
-  const isWrapPending = useIsTransactionPending(pendingHash)
+  const isWrapPending = useIsWrapping()
   const [nativeBalance, wrappedBalance] = useCurrencyBalances(account, [native, wrapped])
 
   const wrappedSymbol = wrapped.symbol || 'wrapped native token'
@@ -126,8 +125,7 @@ export default function EthWethWrap({ account, native, wrapped, wrapCallback }: 
     setLoading(true)
 
     try {
-      const txResponse = await wrapCallback()
-      setPendingHash(txResponse.hash)
+      await wrapCallback()
     } catch (error) {
       console.error(error)
 

--- a/src/custom/components/swap/EthWethWrap/index.tsx
+++ b/src/custom/components/swap/EthWethWrap/index.tsx
@@ -1,0 +1,144 @@
+import React, { useState, useCallback } from 'react'
+import styled from 'styled-components'
+import { Separator } from 'components/Menu'
+import { ArrowDown, AlertTriangle } from 'react-feather'
+import { ButtonPrimary } from 'components/Button'
+import { Currency, Token } from '@uniswap/sdk'
+import { useCurrencyBalances } from 'state/wallet/hooks'
+import { SHORT_PRECISION } from 'constants/index'
+import { colors } from 'theme'
+import Loader from 'components/Loader'
+
+const COLOUR_SHEET = colors(false)
+
+const Wrapper = styled.div`
+  ${({ theme }) => theme.flexColumnNoWrap}
+  background: ${({ theme }) => theme.bg2};
+  align-items: center;
+  justify-content: center;
+  margin: 0.3rem auto 0;
+  padding: 1rem;
+  width: 100%;
+
+  border-radius: ${({ theme }) => theme.buttonPrimary.borderRadius};
+  font-size: smaller;
+
+  > ${Separator} {
+      margin: -0.3rem 0 0.6rem 0;
+      width: 83%;
+  }
+
+  > ${ButtonPrimary} {
+      // TODO: @biocom themed
+      background: #62d9ff;
+      width: 75%;
+      padding: 0.4rem;
+      margin-top: 0.3rem;
+
+      &:disabled {
+        // TODO: @biocom disabled prop should already do this
+        background-color: ${({ theme }) => theme.disabled}
+      }
+  }
+`
+const WarningWrapper = styled(Wrapper)`
+  ${({ theme }) => theme.flexRowNoWrap}
+  padding: 0rem;
+
+  color: ${({ theme }) => theme.red1};
+  font-weight: 600;
+  font-size: small;
+
+  // warning logo
+  > svg {
+    margin-right: 0.5rem;
+  }
+
+  // warning text
+  > div {
+    ${({ theme }) => theme.flexColumnNoWrap}
+    align-items: flex-start;
+    justify-content: center;
+    font-size: 90%;
+  }
+`
+
+const BalanceLabel = styled.p<{ background?: string }>`
+  display: flex;
+  justify-content: space-between;
+  width: 90%;
+  padding: 0.5rem 0.7rem;
+  margin: 0.5rem 0;
+
+  border-radius: ${({ theme }) => theme.buttonPrimary.borderRadius};
+
+  background: ${({ background = 'initial' }) => background};
+
+  > span {
+    &:first-child {
+      margin-right: auto;
+    }
+  }
+`
+
+export interface Props {
+  account?: string
+  native: Currency
+  wrapped: Token
+  wrapCallback: () => Promise<void>
+}
+
+export default function EthWethWrap({ account, native, wrapped, wrapCallback }: Props) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+  const [nativeBalance, wrappedBalance] = useCurrencyBalances(account, [native, wrapped])
+
+  const wrappedSymbol = wrapped.symbol || 'wrapped native token'
+  const nativeSymbol = native.symbol || 'native token'
+
+  const handleWrap = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+
+      await wrapCallback()
+    } catch (error) {
+      console.error('Error wrapping ETH:', error)
+
+      setError(new Error(error))
+    } finally {
+      setLoading(false)
+    }
+  }, [wrapCallback])
+
+  return (
+    <Wrapper>
+      <WarningWrapper>
+        <AlertTriangle size={30} />
+        <div>
+          <span>Only {wrappedSymbol} can be used to swap.</span>
+          <span>
+            Wrap your {nativeSymbol} first or switch to {wrappedSymbol}
+          </span>
+          {error && (
+            <span>
+              <strong>{error.message}</strong>
+            </span>
+          )}
+        </div>
+      </WarningWrapper>
+      <BalanceLabel>
+        <span>{nativeSymbol} balance:</span> <span>{nativeBalance?.toSignificant(SHORT_PRECISION) || '-'}</span>
+      </BalanceLabel>
+      <Separator />
+      <ArrowDown size={18} color={COLOUR_SHEET.primary1} />
+      <BalanceLabel background={COLOUR_SHEET.bg1}>
+        <span>{wrappedSymbol} balance:</span>
+        <span>{wrappedBalance?.toSignificant(SHORT_PRECISION) || '-'}</span>
+      </BalanceLabel>
+      <ButtonPrimary disabled={loading} padding="0.5rem" onClick={handleWrap}>
+        {loading ? <Loader /> : `Wrap my ${nativeSymbol}`}
+      </ButtonPrimary>
+    </Wrapper>
+  )
+}

--- a/src/custom/components/swap/EthWethWrap/index.tsx
+++ b/src/custom/components/swap/EthWethWrap/index.tsx
@@ -122,9 +122,10 @@ export default function EthWethWrap({ account, native, wrapped, wrapCallback }: 
   }, [isWrapPending])
 
   const handleWrap = useCallback(async () => {
-    try {
-      setError(null)
+    setError(null)
+    setLoading(true)
 
+    try {
       const txResponse = await wrapCallback()
       setPendingHash(txResponse.hash)
     } catch (error) {

--- a/src/custom/components/swap/EthWethWrap/index.tsx
+++ b/src/custom/components/swap/EthWethWrap/index.tsx
@@ -132,6 +132,7 @@ export default function EthWethWrap({ account, native, wrapped, wrapCallback }: 
       console.error(error)
 
       setError(error)
+      setLoading(false)
     }
   }, [wrapCallback])
 

--- a/src/custom/hooks/useIsWrapping.ts
+++ b/src/custom/hooks/useIsWrapping.ts
@@ -1,0 +1,18 @@
+import { useAllTransactions, isTransactionRecent } from 'state/transactions/hooks'
+import { useActiveWeb3React } from 'hooks'
+import { TransactionDetails } from 'state/transactions/reducer'
+
+export default function useIsWrapping() {
+  const { chainId } = useActiveWeb3React()
+  const transactions = useAllTransactions()
+
+  if (!chainId || !transactions) return false
+
+  const txValues: TransactionDetails[] = Object.values(transactions)
+
+  // filter for any tx with Wrap in the summary
+  // then at least 1 without a receipt (pending) that is recent
+  return txValues
+    .filter(({ summary }) => summary?.includes('Wrap'))
+    .some((tx: TransactionDetails) => !tx.receipt && isTransactionRecent(tx))
+}

--- a/src/custom/hooks/useWrapCallback.ts
+++ b/src/custom/hooks/useWrapCallback.ts
@@ -86,7 +86,8 @@ function _getWrapUnwrapCallback(params: GetWrapUnwrapCallback): WrapUnwrapCallba
 export default function useWrapCallback(
   inputCurrency: Currency | undefined,
   outputCurrency: Currency | undefined,
-  typedValue: string | undefined
+  typedValue: string | undefined,
+  isEthTradeOverride?: boolean
 ): WrapUnwrapCallback {
   const { chainId, account } = useActiveWeb3React()
   const wethContract = useWETHContract()
@@ -98,7 +99,8 @@ export default function useWrapCallback(
   return useMemo(() => {
     if (!wethContract || !chainId || !inputCurrency || !outputCurrency) return NOT_APPLICABLE
 
-    const isWrappingEther = inputCurrency === ETHER && currencyEquals(WETH[chainId], outputCurrency)
+    const isWrappingEther =
+      inputCurrency === ETHER && (isEthTradeOverride || currencyEquals(WETH[chainId], outputCurrency))
     const isUnwrappingWeth = currencyEquals(WETH[chainId], inputCurrency) && outputCurrency === ETHER
 
     if (!isWrappingEther && !isUnwrappingWeth) {
@@ -112,5 +114,5 @@ export default function useWrapCallback(
         wethContract
       })
     }
-  }, [wethContract, chainId, inputCurrency, outputCurrency, inputAmount, balance, addTransaction])
+  }, [wethContract, chainId, inputCurrency, outputCurrency, isEthTradeOverride, balance, inputAmount, addTransaction])
 }

--- a/src/custom/hooks/useWrapCallback.ts
+++ b/src/custom/hooks/useWrapCallback.ts
@@ -18,7 +18,7 @@ export enum WrapType {
 
 interface WrapUnwrapCallback {
   wrapType: WrapType
-  execute?: () => Promise<void>
+  execute?: () => Promise<TransactionResponse>
   inputError?: string
 }
 
@@ -46,7 +46,7 @@ function _getWrapUnwrapCallback(params: GetWrapUnwrapCallback): WrapUnwrapCallba
   const inputError = isZero ? `Enter an amount` : !sufficientBalance ? `Insufficient ${symbol} balance` : undefined
 
   // Create wrap/unwrap callback if sufficient balance
-  let wrapUnwrapCallback: (() => Promise<void>) | undefined
+  let wrapUnwrapCallback: (() => Promise<TransactionResponse>) | undefined
   if (sufficientBalance && inputAmount) {
     let wrapUnwrap: () => TransactionResponse
     let summary: string
@@ -63,9 +63,13 @@ function _getWrapUnwrapCallback(params: GetWrapUnwrapCallback): WrapUnwrapCallba
       try {
         const txReceipt = await wrapUnwrap()
         addTransaction(txReceipt, { summary })
+
+        return txReceipt
       } catch (error) {
         const actionName = WrapType.WRAP ? 'wrapping' : 'unwrapping'
         console.error(`Error ${actionName} ${symbol}`, error)
+
+        throw error.message ? error : new Error(error)
       }
     }
   }

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -1,4 +1,4 @@
-import { CurrencyAmount, ETHER, JSBI, Token, Trade } from '@uniswap/sdk'
+import { CurrencyAmount, JSBI, Token, Trade } from '@uniswap/sdk'
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { ArrowDown } from 'react-feather'
 import ReactGA from 'react-ga'
@@ -11,7 +11,7 @@ import Column, { AutoColumn } from 'components/Column'
 import ConfirmSwapModal from 'components/swap/ConfirmSwapModal'
 import CurrencyInputPanel from 'components/CurrencyInputPanel'
 import { SwapPoolTabs } from 'components/NavigationTabs'
-import { AutoRow, RowBetween, RowFixed } from 'components/Row'
+import { AutoRow, RowBetween } from 'components/Row'
 import AdvancedSwapDetailsDropdown from 'components/swap/AdvancedSwapDetailsDropdown'
 import BetterTradeLink, { DefaultVersionLink } from 'components/swap/BetterTradeLink'
 import confirmPriceImpactWithoutFee from 'components/swap/confirmPriceImpactWithoutFee'
@@ -33,10 +33,9 @@ import useWrapCallback, { WrapType } from 'hooks/useWrapCallback'
 import { useToggleSettingsMenu, useWalletModalToggle } from 'state/application/hooks'
 import { Field } from 'state/swap/actions'
 import {
-  useShouldDisableEth,
+  useDetectNativeToken,
   useDefaultsFromURLSearch,
   useDerivedSwapInfo,
-  useReplaceSwapState,
   useSwapActionHandlers,
   useSwapState,
   useIsFeeGreaterThanInput
@@ -51,11 +50,16 @@ import Loader from 'components/Loader'
 import { useIsTransactionUnsupported } from 'hooks/Trades'
 import UnsupportedCurrencyFooter from 'components/swap/UnsupportedCurrencyFooter'
 import { isTradeBetter } from 'utils/trades'
-import QuestionHelper from 'components/QuestionHelper'
 import FeeInformationTooltip from 'components/swap/FeeInformationTooltip'
-import { RouteComponentProps } from 'react-router-dom'
+import { SwapProps } from '.'
 
-export default function Swap({ history }: RouteComponentProps) {
+export default function Swap({
+  history,
+  FeeGreaterMessage,
+  EthWethWrapMessage,
+  SwitchToWethBtn,
+  FeesExceedFromAmountMessage
+}: SwapProps) {
   const loadedUrlParams = useDefaultsFromURLSearch()
 
   // token warning stuff
@@ -107,15 +111,16 @@ export default function Swap({ history }: RouteComponentProps) {
     inputError: swapInputError
   } = useDerivedSwapInfo()
 
-  // MOD: adds this fn
-  const replaceSwapState = useReplaceSwapState()
-
   // Checks if either currency is native ETH
   // MOD: adds this hook
-  const { showEthDisabled, weth } = useShouldDisableEth(
+  const { isNativeIn, isWrappedOut, native, wrappedToken } = useDetectNativeToken(
     { currency: currencies.INPUT, address: INPUT.currencyId },
-    { currency: currencies.OUTPUT, address: OUTPUT.currencyId }
+    { currency: currencies.OUTPUT, address: OUTPUT.currencyId },
+    chainId
   )
+
+  // Is user swapping Eth as From token and not wrapping to WETH?
+  const isNativeInSwap = isNativeIn && !isWrappedOut
 
   // Is fee greater than input?
   const { isFeeGreater, fee } = useIsFeeGreaterThanInput({ chainId, address: INPUT.currencyId, parsedAmount })
@@ -123,9 +128,12 @@ export default function Swap({ history }: RouteComponentProps) {
   const { wrapType, execute: onWrap, inputError: wrapInputError } = useWrapCallback(
     currencies[Field.INPUT],
     currencies[Field.OUTPUT],
-    typedValue
+    typedValue,
+    // should override and get wrapCallback?
+    isNativeInSwap
   )
-  const showWrap: boolean = wrapType !== WrapType.NOT_APPLICABLE
+
+  const showWrap: boolean = !isNativeInSwap && wrapType !== WrapType.NOT_APPLICABLE
   const { address: recipientAddress } = useENSAddress(recipient)
   const toggledVersion = useToggledVersion()
   const tradesByVersion = {
@@ -461,18 +469,14 @@ export default function Swap({ history }: RouteComponentProps) {
                       </ClickableText>
                     </RowBetween>
                   )}
-                  {isFeeGreater && fee && (
-                    <RowBetween>
-                      <RowFixed>
-                        <TYPE.black fontSize={14} fontWeight={400} color={theme.text2}>
-                          GP/Gas Fee
-                        </TYPE.black>
-                        <QuestionHelper text="GP Swap has 0 gas fees. A portion of the sell amount in each trade goes to the GP Protocol." />
-                      </RowFixed>
-                      <TYPE.black fontSize={14} color={theme.text1}>
-                        {fee.toSignificant(4)} {fee.currency.symbol}
-                      </TYPE.black>
-                    </RowBetween>
+                  {isFeeGreater && fee && <FeeGreaterMessage fee={fee} />}
+                  {isNativeIn && onWrap && (
+                    <EthWethWrapMessage
+                      account={account ?? undefined}
+                      native={native}
+                      wrapped={wrappedToken}
+                      wrapCallback={onWrap}
+                    />
                   )}
                 </AutoColumn>
               </Card>
@@ -492,20 +496,11 @@ export default function Swap({ history }: RouteComponentProps) {
                 {wrapInputError ??
                   (wrapType === WrapType.WRAP ? 'Wrap' : wrapType === WrapType.UNWRAP ? 'Unwrap' : null)}
               </ButtonPrimary>
-            ) : // MOD: disable ETH trading
-            showEthDisabled ? (
-              <ButtonPrimary buttonSize={ButtonSize.BIG} id="swap-button" disabled={true}>
-                <TYPE.main mb="4px">ETH cannot be traded. Use WETH</TYPE.main>
-              </ButtonPrimary>
+            ) : !swapInputError && isNativeIn ? (
+              <SwitchToWethBtn wrappedToken={wrappedToken} />
             ) : noRoute && userHasSpecifiedInputOutput ? (
               isFeeGreater ? (
-                <RowBetween>
-                  <ButtonError buttonSize={ButtonSize.BIG} error id="swap-button" disabled>
-                    <Text fontSize={20} fontWeight={500}>
-                      Fees exceed from amount
-                    </Text>
-                  </ButtonError>
-                </RowBetween>
+                <FeesExceedFromAmountMessage />
               ) : (
                 <GreyCard style={{ textAlign: 'center' }}>
                   <TYPE.main mb="4px">Insufficient liquidity for this trade.</TYPE.main>
@@ -604,62 +599,7 @@ export default function Swap({ history }: RouteComponentProps) {
           </BottomGrouping>
         </Wrapper>
       </AppBody>
-      {/* MOD */}
-      {showEthDisabled ? (
-        <UnsupportedCurrencyFooter
-          detailsText={
-            <>
-              <div>
-                Ether (ETH) is not tradable as a native token. Please use Wrapped Ether (WETH) instead. ETH can still be
-                wrapped/unwrapped into WETH by selecting one as the input and the other as the output.
-              </div>
-
-              {/* Offer option to trade using WETH and same user set amounts */}
-              {weth && (
-                <ButtonConfirmed
-                  onClick={() =>
-                    replaceSwapState({
-                      inputCurrencyId: currencies.INPUT === ETHER ? weth.address : INPUT.currencyId,
-                      outputCurrencyId: currencies.OUTPUT === ETHER ? weth.address : OUTPUT.currencyId,
-                      typedValue,
-                      recipient: null,
-                      field: independentField
-                    })
-                  }
-                  disabled={!weth?.address}
-                  marginTop="1.5rem"
-                  padding="0.65rem"
-                  altDisabledStyle
-                >
-                  Trade with WETH
-                </ButtonConfirmed>
-              )}
-
-              <ButtonConfirmed
-                onClick={() =>
-                  replaceSwapState({
-                    inputCurrencyId: 'ETH',
-                    outputCurrencyId: weth?.address,
-                    typedValue: '0.1',
-                    recipient: null,
-                    field: Field.INPUT
-                  })
-                }
-                disabled={!weth?.address}
-                marginTop="1.5rem"
-                padding="0.65rem"
-                altDisabledStyle
-              >
-                Wrap ETH
-              </ButtonConfirmed>
-            </>
-          }
-          detailsTitle="Ether and GP Swap"
-          showDetailsText="Learn more about using ETH on GP Swap"
-          show={showEthDisabled}
-          currencies={[currencies.INPUT, currencies.OUTPUT]}
-        />
-      ) : !swapIsUnsupported ? (
+      {!swapIsUnsupported ? (
         <AdvancedSwapDetailsDropdown trade={trade} />
       ) : (
         <UnsupportedCurrencyFooter show={swapIsUnsupported} currencies={[currencies.INPUT, currencies.OUTPUT]} />

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -52,6 +52,7 @@ import UnsupportedCurrencyFooter from 'components/swap/UnsupportedCurrencyFooter
 import { isTradeBetter } from 'utils/trades'
 import FeeInformationTooltip from 'components/swap/FeeInformationTooltip'
 import { SwapProps } from '.'
+import useIsWrapping from 'hooks/useIsWrapping'
 
 export default function Swap({
   history,
@@ -132,6 +133,8 @@ export default function Swap({
     // should override and get wrapCallback?
     isNativeInSwap
   )
+
+  const isWrapPending = useIsWrapping()
 
   const showWrap: boolean = !isNativeInSwap && wrapType !== WrapType.NOT_APPLICABLE
   const { address: recipientAddress } = useENSAddress(recipient)
@@ -492,9 +495,17 @@ export default function Swap({
                 Connect Wallet
               </ButtonLight>
             ) : showWrap ? (
-              <ButtonPrimary buttonSize={ButtonSize.BIG} disabled={Boolean(wrapInputError)} onClick={onWrap}>
-                {wrapInputError ??
-                  (wrapType === WrapType.WRAP ? 'Wrap' : wrapType === WrapType.UNWRAP ? 'Unwrap' : null)}
+              <ButtonPrimary
+                buttonSize={ButtonSize.BIG}
+                disabled={isWrapPending || Boolean(wrapInputError)}
+                onClick={onWrap}
+              >
+                {isWrapPending ? (
+                  <Loader />
+                ) : (
+                  wrapInputError ??
+                  (wrapType === WrapType.WRAP ? 'Wrap' : wrapType === WrapType.UNWRAP ? 'Unwrap' : null)
+                )}
               </ButtonPrimary>
             ) : !swapInputError && isNativeIn ? (
               <SwitchToWethBtn wrappedToken={wrappedToken} />

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -1,1 +1,102 @@
-export { default } from './SwapMod'
+import React, { useContext } from 'react'
+import { RouteComponentProps } from 'react-router-dom'
+import { ThemeContext } from 'styled-components'
+import { CurrencyAmount, Token } from '@uniswap/sdk'
+import { Text } from 'rebass'
+
+import { ButtonSize, TYPE } from 'theme/index'
+
+import SwapMod from './SwapMod'
+import { RowBetween, RowFixed } from 'components/Row'
+import QuestionHelper from 'components/QuestionHelper'
+import { ButtonError, ButtonPrimary } from 'components/Button'
+import EthWethWrap, { Props as EthWethWrapProps } from 'components/swap/EthWethWrap'
+import { useReplaceSwapState, useSwapState } from 'state/swap/hooks'
+
+interface FeeGreaterMessageProp {
+  fee: CurrencyAmount
+}
+
+export interface SwapProps extends RouteComponentProps {
+  FeeGreaterMessage: React.FC<FeeGreaterMessageProp>
+  EthWethWrapMessage: React.FC<EthWethWrapProps>
+  SwitchToWethBtn: React.FC<SwitchToWethBtnProps>
+  FeesExceedFromAmountMessage: React.FC
+}
+
+function FeeGreaterMessage({ fee }: FeeGreaterMessageProp) {
+  const theme = useContext(ThemeContext)
+
+  return (
+    <RowBetween>
+      <RowFixed>
+        <TYPE.black fontSize={14} fontWeight={400} color={theme.text2}>
+          Fee
+        </TYPE.black>
+        <QuestionHelper text="GP Swap has 0 gas fees. A portion of the sell amount in each trade goes to the GP Protocol." />
+      </RowFixed>
+      <TYPE.black fontSize={14} color={theme.text1}>
+        {fee.toSignificant(4)} {fee.currency.symbol}
+      </TYPE.black>
+    </RowBetween>
+  )
+}
+
+function EthWethWrapMessage({ account, native, wrapped, wrapCallback }: EthWethWrapProps) {
+  return (
+    <RowBetween>
+      <EthWethWrap account={account ?? undefined} native={native} wrapped={wrapped} wrapCallback={wrapCallback} />
+    </RowBetween>
+  )
+}
+
+interface SwitchToWethBtnProps {
+  wrappedToken: Token
+}
+
+function SwitchToWethBtn({ wrappedToken }: SwitchToWethBtnProps) {
+  const replaceSwapState = useReplaceSwapState()
+  const { independentField, typedValue, OUTPUT } = useSwapState()
+
+  return (
+    <ButtonPrimary
+      buttonSize={ButtonSize.BIG}
+      id="swap-button"
+      onClick={() =>
+        replaceSwapState({
+          inputCurrencyId: wrappedToken.address,
+          outputCurrencyId: OUTPUT.currencyId,
+          typedValue,
+          recipient: null,
+          field: independentField
+        })
+      }
+    >
+      <TYPE.main mb="4px">Switch to {wrappedToken.symbol}</TYPE.main>
+    </ButtonPrimary>
+  )
+}
+
+function FeesExceedFromAmountMessage() {
+  return (
+    <RowBetween>
+      <ButtonError buttonSize={ButtonSize.BIG} error id="swap-button" disabled>
+        <Text fontSize={20} fontWeight={500}>
+          Fees exceed from amount
+        </Text>
+      </ButtonError>
+    </RowBetween>
+  )
+}
+
+export default function Swap(props: RouteComponentProps) {
+  return (
+    <SwapMod
+      FeeGreaterMessage={FeeGreaterMessage}
+      EthWethWrapMessage={EthWethWrapMessage}
+      SwitchToWethBtn={SwitchToWethBtn}
+      FeesExceedFromAmountMessage={FeesExceedFromAmountMessage}
+      {...props}
+    />
+  )
+}

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -22,8 +22,8 @@ import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useDispatch } from 'react-redux'
 import { SwapState } from 'state/swap/reducer'
 import { ParsedQs } from 'qs'
-import { useWETHContract } from 'hooks/useContract'
 import { BigNumber } from 'ethers'
+import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
 
 export * from '@src/state/swap/hooks'
 
@@ -228,14 +228,26 @@ interface CurrencyWithAddress {
   address?: string
 }
 
-export function useShouldDisableEth(input?: CurrencyWithAddress, output?: CurrencyWithAddress) {
-  const weth = useWETHContract()
-  return useMemo(() => {
-    const [isEthIn, isEthOut] = [input?.currency === ETHER, output?.currency === ETHER]
-    const [isWethIn, isWethOut] = [input?.address === weth?.address, output?.address === weth?.address]
+export function useDetectNativeToken(input?: CurrencyWithAddress, output?: CurrencyWithAddress, chainId?: ChainId) {
+  const wrappedToken = WETH[chainId || DEFAULT_NETWORK_FOR_LISTS]
+  const native = ETHER
 
-    return { showEthDisabled: (isEthIn && !isWethOut) || (isEthOut && !isWethIn), weth }
-  }, [input, output, weth])
+  return useMemo(() => {
+    const [isNativeIn, isNativeOut] = [input?.currency === native, output?.currency === native]
+    const [isWrappedIn, isWrappedOut] = [
+      input?.address === wrappedToken.address,
+      output?.address === wrappedToken.address
+    ]
+
+    return {
+      isNativeIn: isNativeIn && !isWrappedOut,
+      isNativeOut: isNativeOut && !isWrappedIn,
+      isWrappedIn,
+      isWrappedOut,
+      wrappedToken,
+      native
+    }
+  }, [input, output, native, wrappedToken])
 }
 
 export function useIsFeeGreaterThanInput({


### PR DESCRIPTION
Part of #464 

Global `useIsWrapping` hook to keep swap direct wrap and ethwethswap `button` state in sync

When ETH selling and wrapping then switching to ETH/WETH direct wrap WHILE a wrapping tx is pending:

First:
![Screenshot from 2021-04-20 15-46-04](https://user-images.githubusercontent.com/21335563/115416447-b45a3b00-a1ef-11eb-98c3-c749021576b7.png)

Immediately switch to WETH as buy while pending tx:
![Screenshot from 2021-04-20 15-46-14](https://user-images.githubusercontent.com/21335563/115416490-bb814900-a1ef-11eb-84b5-b4fab0d0087e.png)
