### PR TITLE
[Gas API] - Add fallback sources

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -70,14 +70,3 @@ export const DUNE_DASHBOARD_LINK = 'https://duneanalytics.com/gnosis.protocol/Gn
 
 // 30 minutes
 export const GAS_PRICE_UPDATE_THRESHOLD = 30 * 60 * 1000
-export const GAS_FEE_ENDPOINTS = {
-  [ChainId.MAINNET]: 'https://safe-relay.gnosis.io/api/v1/gas-station/',
-  // No ropsten = main
-  [ChainId.ROPSTEN]: 'https://safe-relay.gnosis.io/api/v1/gas-station/',
-  [ChainId.RINKEBY]: 'https://safe-relay.rinkeby.gnosis.io/api/v1/gas-station/',
-  [ChainId.GÖRLI]: 'https://safe-relay.goerli.gnosis.io/api/v1/gas-station/',
-  // no kovan = main
-  [ChainId.KOVAN]: 'https://safe-relay.kovan.gnosis.io/api/v1/gas-station/',
-  // TODO: xdai? = main
-  [ChainId.XDAI]: 'https://safe-relay.gnosis.io/api/v1/gas-station/'
-}

--- a/src/custom/state/gas/actions.ts
+++ b/src/custom/state/gas/actions.ts
@@ -1,7 +1,6 @@
 import { createAction } from '@reduxjs/toolkit'
 import { WithChainId } from '../lists/actions'
-import { GasFeeEndpointResponse } from './hooks'
 
-export type UpdateGasPrices = GasFeeEndpointResponse & WithChainId
+export type UpdateGasPrices = { lastUpdate: string; price: string } & WithChainId
 
 export const updateGasPrices = createAction<UpdateGasPrices>('gas/updateGasPrices')

--- a/src/custom/state/gas/hooks.ts
+++ b/src/custom/state/gas/hooks.ts
@@ -5,22 +5,6 @@ import { GasState } from './reducer'
 import { updateGasPrices, UpdateGasPrices } from './actions'
 import { AppDispatch } from 'state'
 import { AppState } from '..'
-import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
-import { GAS_FEE_ENDPOINTS } from 'constants/index'
-
-export interface GasFeeEndpointResponse {
-  lastUpdate: string
-  lowest: string
-  safeLow: string
-  standard: string
-  fast: string
-  fastest: string
-}
-
-export async function getGasPrices(chainId: ChainId = DEFAULT_NETWORK_FOR_LISTS): Promise<GasFeeEndpointResponse> {
-  const response = await fetch(GAS_FEE_ENDPOINTS[chainId])
-  return response.json()
-}
 
 export function useGasPrices(chainId?: ChainId) {
   return useSelector<AppState, GasState[ChainId] | null>(state => {

--- a/src/custom/state/gas/updater.tsx
+++ b/src/custom/state/gas/updater.tsx
@@ -1,9 +1,10 @@
 import { useEffect } from 'react'
-import { useGasPrices, useUpdateGasPrices, getGasPrices } from './hooks'
+import { useGasPrices, useUpdateGasPrices } from './hooks'
 import { useActiveWeb3React } from 'hooks'
 import { GAS_PRICE_UPDATE_THRESHOLD } from 'constants/index'
+import { fetchGasPrices } from 'utils/gas'
 
-function needsGasUpdate(now: number, lastUpdated: number, threshold: number) {
+function shouldUpdateGasPrices(now: number, lastUpdated: number, threshold: number) {
   return now - lastUpdated > threshold
 }
 
@@ -14,12 +15,12 @@ export default function GasUpdater(): null {
 
   useEffect(() => {
     const now = Date.now()
-    const updated = gas ? Date.parse(gas.lastUpdate) : null
+    const updated = gas?.lastUpdate ? Date.parse(gas.lastUpdate) : null
 
     // if no gas in local/redux state OR time threshold has passed
     // since last update, then:
-    if (!updated || needsGasUpdate(now, updated, GAS_PRICE_UPDATE_THRESHOLD)) {
-      getGasPrices(chainId)
+    if (!updated || shouldUpdateGasPrices(now, updated, GAS_PRICE_UPDATE_THRESHOLD)) {
+      fetchGasPrices(chainId)
         .then(gas => {
           updateGasPrices({
             ...gas,

--- a/src/custom/utils/gas.ts
+++ b/src/custom/utils/gas.ts
@@ -1,0 +1,105 @@
+import { ChainId } from '@uniswap/sdk'
+import { BigNumber } from 'ethers'
+import { UpdateGasPrices } from 'state/gas/actions'
+import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
+import { fetchData, promiseFirstResolved } from '.'
+import { getChainIdValues } from './misc'
+import { parseUnits } from 'ethers/lib/utils'
+
+export enum GasPriceSources {
+  SAFE = 'SAFE',
+  INFURA = 'INFURA'
+}
+
+export interface GasPriceEndpointData {
+  source: GasPriceSources
+  options?: RequestInit
+  urls: { [chain in ChainId]: string }
+}
+
+export function chainIdToGasLabel(chainId: ChainId) {
+  switch (chainId) {
+    case ChainId.RINKEBY:
+      return 'rinkeby'
+    case ChainId.GÖRLI:
+      return 'goerli'
+    default:
+      return 'mainnet'
+  }
+}
+
+// safe relay endpoint
+export const GAS_FEE_ENDPOINTS: GasPriceEndpointData = {
+  source: GasPriceSources.SAFE,
+  urls: getChainIdValues().reduce((memo, chainId) => {
+    memo[chainId] = `https://safe-rlay.${chainIdToGasLabel(chainId)}.gnosis.io/api/v1/gas-station/`
+    return memo
+  }, {} as GasPriceEndpointData['urls'])
+}
+
+const ETH_GAS_PRICE_REQUEST = JSON.stringify({ jsonrpc: '2.0', method: 'eth_gasPrice', params: [], id: 1 })
+
+// infura gasPrice endpoint
+export const GAS_FEE_ENDPOINTS_BACKUP: GasPriceEndpointData = {
+  source: GasPriceSources.INFURA,
+  options: {
+    method: 'POST',
+    body: ETH_GAS_PRICE_REQUEST
+  },
+  urls: getChainIdValues().reduce((memo, chainId) => {
+    memo[chainId] = `https://${chainIdToGasLabel(chainId)}.infoora.io/v3/27b1a8a99c49447e83d918dad2cb46e9`
+    return memo
+  }, {} as GasPriceEndpointData['urls'])
+}
+
+export const GAS_FEE_FALLBACK = {
+  lastUpdate: new Date().toString(),
+  // format to GWEI
+  price: parseUnits('50', 'gwei').toString()
+}
+
+export const GAS_FEE_ENDPOINT_OPTIONS = [GAS_FEE_ENDPOINTS, GAS_FEE_ENDPOINTS_BACKUP]
+
+async function _normaliseGasResponse({
+  options,
+  response
+}: {
+  options: typeof GAS_FEE_ENDPOINT_OPTIONS
+  response: {
+    id: number | null
+    result: Response | null
+  }
+}): Promise<UpdateGasPrices> {
+  // no response data - fallback
+  if (response.result === null || response.id === null) return GAS_FEE_FALLBACK
+
+  const { result, id } = response
+  const gasPrices = await result.json()
+
+  // get the gas api source
+  // and normalise data as necessary
+  const { source } = options[id]
+  switch (source) {
+    case GasPriceSources.SAFE:
+      return { lastUpdate: gasPrices.lastUpdate, price: gasPrices.standard }
+    case GasPriceSources.INFURA:
+      return { lastUpdate: new Date().toString(), price: BigNumber.from(gasPrices.result).toString() }
+    default:
+      return GAS_FEE_FALLBACK
+  }
+}
+
+// in case all API endpoints are down
+export async function fetchGasPrices(
+  chainId: ChainId | undefined = DEFAULT_NETWORK_FOR_LISTS
+): Promise<UpdateGasPrices> {
+  // map each endpoint map to a function
+  const options = GAS_FEE_ENDPOINT_OPTIONS.map(({ urls, options }) => () => fetchData(urls[chainId], options))
+  // cast fallback gas to a response format
+  // const fallbackResponse = new Response(JSON.stringify(GAS_FEE_FALLBACK))
+  // get first resolving promise
+  const response = await promiseFirstResolved<Response>(options)
+  // we need to check the response as endpoint return different values 🙄🙄
+  // is infura endpoint response, for example
+  return _normaliseGasResponse({ options: GAS_FEE_ENDPOINT_OPTIONS, response })
+}

--- a/src/custom/utils/gas.ts
+++ b/src/custom/utils/gas.ts
@@ -32,7 +32,7 @@ export function chainIdToGasLabel(chainId: ChainId) {
 export const GAS_FEE_ENDPOINTS: GasPriceEndpointData = {
   source: GasPriceSources.SAFE,
   urls: getChainIdValues().reduce((memo, chainId) => {
-    memo[chainId] = `https://safe-rlay.${chainIdToGasLabel(chainId)}.gnosis.io/api/v1/gas-station/`
+    memo[chainId] = `https://safe-relay.${chainIdToGasLabel(chainId)}.gnosis.io/api/v1/gas-station/`
     return memo
   }, {} as GasPriceEndpointData['urls'])
 }
@@ -47,7 +47,7 @@ export const GAS_FEE_ENDPOINTS_BACKUP: GasPriceEndpointData = {
     body: ETH_GAS_PRICE_REQUEST
   },
   urls: getChainIdValues().reduce((memo, chainId) => {
-    memo[chainId] = `https://${chainIdToGasLabel(chainId)}.infoora.io/v3/27b1a8a99c49447e83d918dad2cb46e9`
+    memo[chainId] = `https://${chainIdToGasLabel(chainId)}.infura.io/v3/27b1a8a99c49447e83d918dad2cb46e9`
     return memo
   }, {} as GasPriceEndpointData['urls'])
 }

--- a/src/custom/utils/index.ts
+++ b/src/custom/utils/index.ts
@@ -147,8 +147,8 @@ export async function promiseFirstResolved<T>(
     }
   }
 
-  // using the fallback we can return a promise back with
-  // a defined result
+  // we return id here to determine which of the
+  // list promises resolved
   const finalResult = {
     result: promisedResult?.result ?? null,
     id: promisedResult?.id ?? null


### PR DESCRIPTION
Waterfalls into #525 

Adds fallback sources for the gas APIs via some new `util/gas` functions:
1. `promiseFirstResolved` accepts an array of `Promise` returning functions and accepts the first properly resolved promise
2. `fetchData` and default gas api sources + 1 backup (infura) and a fallback gas price object set at gas 50GWEI

Logic remains the same as #525 just runs through the sources and if any failures happens, logs them, then checks the next until it settles with the fallback