### PR TITLE
Re-enable TokenPocket wallet via WalletConnect

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -30,13 +30,7 @@ export const SUPPORTED_WALLETS = Object.keys(SUPPORTED_WALLETS_UNISWAP).reduce((
 }, {} as { [key: string]: WalletInfo })
 
 // Smart contract wallets are filtered out by default, no need to add them to this list
-export const UNSUPPORTED_WC_WALLETS = new Set([
-  'DeFi Wallet',
-  'TokenPocket',
-  '1inch Wallet',
-  'Pillar Wallet',
-  'WallETH'
-])
+export const UNSUPPORTED_WC_WALLETS = new Set(['DeFi Wallet', '1inch Wallet', 'Pillar Wallet', 'WallETH'])
 
 // TODO: When contracts are deployed, we can load this from the NPM package
 export const GP_SETTLEMENT_CONTRACT_ADDRESS: Partial<Record<ChainId, string>> = {


### PR DESCRIPTION
# Update 2021/06/15

TokenPocket has released their update and it's now working flawlessly :)

# Summary

Closes #673 

## Note

I'm opening this PR to allow TP team to test their fix(https://github.com/TP-Lab/tp-android/issues/16), since the wallet was disabled via WalletConnect on https://github.com/gnosis/gp-swap-ui/pull/597

# Testing

Using the PR's url:
1. Connect via WalletConnect using TokenPocket wallet
- [ ] The wallet should not be disabled