### PR TITLE
🧪 Add all WC wallets

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -38,7 +38,7 @@ export const SUPPORTED_WALLETS = Object.keys(SUPPORTED_WALLETS_UNISWAP).reduce((
 }, {} as { [key: string]: WalletInfo })
 
 // Smart contract wallets are filtered out by default, no need to add them to this list
-export const UNSUPPORTED_WC_WALLETS = new Set(['DeFi Wallet', '1inch Wallet', 'WallETH'])
+export const UNSUPPORTED_WC_WALLETS = new Set() // new Set(['DeFi Wallet', '1inch Wallet', 'WallETH'])
 
 export const GP_SETTLEMENT_CONTRACT_ADDRESS: Partial<Record<number, string>> = {
   [ChainId.MAINNET]: GPv2Settlement[ChainId.MAINNET].address,


### PR DESCRIPTION
## 🙅 Dont't merge

This PR is just to leave open while wallet apps address the issue with CowSwap. 

It removes the filter of not supported Wallet Connect wallets, so we can use any EOA wallet with WC support.



