### PR TITLE
Remove red text in the confirmation modal

### DIFF
--- a/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
+++ b/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
@@ -7,7 +7,7 @@ import { Field } from 'state/swap/actions'
 import { TYPE } from 'theme'
 import { ButtonPrimary } from 'components/Button'
 import { isAddress, shortenAddress } from 'utils'
-import { computeSlippageAdjustedAmounts, /* computeTradePriceBreakdown, */ warningSeverity } from 'utils/prices'
+import { computeSlippageAdjustedAmounts /* computeTradePriceBreakdown, warningSeverity */ } from 'utils/prices'
 import { AutoColumn } from 'components/Column'
 import CurrencyLogo from 'components/CurrencyLogo'
 import { RowBetween, RowFixed } from 'components/Row'
@@ -29,7 +29,7 @@ export default function SwapModalHeader({
   allowedSlippage,
   recipient,
   showAcceptChanges,
-  priceImpactWithoutFee,
+  //priceImpactWithoutFee,
   onAcceptChanges
 }: SwapModalHeaderProps) {
   const slippageAdjustedAmounts = useMemo(() => computeSlippageAdjustedAmounts(trade, allowedSlippage), [
@@ -37,7 +37,7 @@ export default function SwapModalHeader({
     allowedSlippage
   ])
   //   const { priceImpactWithoutFee } = useMemo(() => computeTradePriceBreakdown(trade), [trade])
-  const priceImpactSeverity = warningSeverity(priceImpactWithoutFee)
+  const priceImpactSeverity = 0 // warningSeverity(priceImpactWithoutFee)
 
   const theme = useContext(ThemeContext)
 


### PR DESCRIPTION
This PR removes the styles for price impact. We will need to add them back probably when we implement it using USD estimations.

Before this PR (see the output tokens):
<img width="1779" alt="Screenshot at Jun 03 10-58-03" src="https://user-images.githubusercontent.com/2352112/120618144-121eab80-c45b-11eb-9a96-6325aad1929c.png">

After:
<img width="986" alt="Screenshot at Jun 03 10-59-39" src="https://user-images.githubusercontent.com/2352112/120618196-219df480-c45b-11eb-9677-d91a4debe55e.png">
