### PR TITLE
130/cancellation api error responses

### DIFF
--- a/src/custom/utils/operator/error.ts
+++ b/src/custom/utils/operator/error.ts
@@ -8,7 +8,8 @@ export enum ApiErrorCodes {
   InsufficientFunds = 'InsufficientFunds',
   InsufficientFee = 'InsufficientFee',
   UnsupportedToken = 'UnsupportedToken',
-  WrongOwner = 'WrongOwner'
+  WrongOwner = 'WrongOwner',
+  OrderNotFound = 'OrderNotFound'
 }
 
 export interface ApiError {
@@ -30,6 +31,7 @@ const API_ERROR_CODE_DESCRIPTIONS = {
     'One of the tokens you are trading is unsupported. Please read the FAQ for more info.',
   [ApiErrorCodes.WrongOwner]:
     "The signature is invalid.\n\nIt's likely that the signing method provided by your wallet doesn't comply with the standards required by CowSwap.\n\nCheck whether your Wallet app supports off-chain signing (EIP-712 or ETHSIGN).",
+  [ApiErrorCodes.OrderNotFound]: 'The order you are trying to cancel does not exist',
   UNHANDLED_ERROR: 'The order was not accepted by the network'
 }
 

--- a/src/custom/utils/operator/error.ts
+++ b/src/custom/utils/operator/error.ts
@@ -59,7 +59,7 @@ export default class OperatorError extends Error {
       return OperatorError.apiErrorDetails.UNHANDLED_ERROR
     }
   }
-  static async getErrorForUnsuccessfulPostOrder(response: Response) {
+  static async getErrorForUnsuccessfulPostOrder(response: Response, defaultResponse = 'Error performing operation') {
     switch (response.status) {
       case 400:
         return this.getErrorMessage(response)
@@ -72,7 +72,7 @@ export default class OperatorError extends Error {
 
       case 500:
       default:
-        return 'Error adding an order'
+        return defaultResponse
     }
   }
   constructor(apiError: ApiError) {

--- a/src/custom/utils/operator/error.ts
+++ b/src/custom/utils/operator/error.ts
@@ -32,7 +32,8 @@ const API_ERROR_CODE_DESCRIPTIONS = {
   [ApiErrorCodes.WrongOwner]:
     "The signature is invalid.\n\nIt's likely that the signing method provided by your wallet doesn't comply with the standards required by CowSwap.\n\nCheck whether your Wallet app supports off-chain signing (EIP-712 or ETHSIGN).",
   [ApiErrorCodes.OrderNotFound]: 'The order you are trying to cancel does not exist',
-  UNHANDLED_ERROR: 'The order was not accepted by the network'
+  UNHANDLED_CREATE_ERROR: 'The order was not accepted by the network',
+  UNHANDLED_DELETE_ERROR: 'The order cancellation was not accepted by the network'
 }
 
 export default class OperatorError extends Error {
@@ -44,7 +45,7 @@ export default class OperatorError extends Error {
   // https://github.com/gnosis/gp-v2-services/blob/9014ae55412a356e46343e051aefeb683cc69c41/orderbook/openapi.yml#L563
   static apiErrorDetails = API_ERROR_CODE_DESCRIPTIONS
 
-  static async getErrorMessage(response: Response) {
+  static async getErrorMessage(response: Response, action: 'create' | 'delete') {
     try {
       const orderPostError: ApiError = await response.json()
 
@@ -56,23 +57,27 @@ export default class OperatorError extends Error {
       }
     } catch (error) {
       console.error('Error handling a 400 error. Likely a problem deserialising the JSON response')
-      return OperatorError.apiErrorDetails.UNHANDLED_ERROR
+      return action === 'create'
+        ? OperatorError.apiErrorDetails.UNHANDLED_CREATE_ERROR
+        : OperatorError.apiErrorDetails.UNHANDLED_DELETE_ERROR
     }
   }
-  static async getErrorForUnsuccessfulPostOrder(response: Response, defaultResponse = 'Error performing operation') {
+  static async getErrorForUnsuccessfulOperation(response: Response, action: 'create' | 'delete') {
     switch (response.status) {
       case 400:
-        return this.getErrorMessage(response)
+        return this.getErrorMessage(response, action)
 
       case 403:
-        return 'The order cannot be accepted. Your account is deny-listed.'
+        return `The order cannot be ${action === 'create' ? 'accepted' : 'cancelled'}. Your account is deny-listed.`
 
       case 429:
-        return 'The order cannot be accepted. Too many order placements. Please, retry in a minute'
+        return `The order cannot be ${
+          action === 'create' ? 'accepted. Too many order placements' : 'cancelled. Too many order cancellations'
+        }. Please, retry in a minute`
 
       case 500:
       default:
-        return defaultResponse
+        return `Error ${action === 'create' ? 'creating' : 'cancelling'} the order`
     }
   }
   constructor(apiError: ApiError) {

--- a/src/custom/utils/operator/index.ts
+++ b/src/custom/utils/operator/index.ts
@@ -122,7 +122,7 @@ export async function sendSignedOrder(params: {
   // Handle response
   if (!response.ok) {
     // Raise an exception
-    const errorMessage = await OperatorError.getErrorForUnsuccessfulPostOrder(response, 'Error adding order')
+    const errorMessage = await OperatorError.getErrorForUnsuccessfulOperation(response, 'create')
     throw new Error(errorMessage)
   }
 
@@ -150,7 +150,7 @@ export async function sendSignedOrderCancellation(params: OrderCancellationParam
 
   if (!response.ok) {
     // Raise an exception
-    const errorMessage = await OperatorError.getErrorForUnsuccessfulPostOrder(response, 'Error cancelling order')
+    const errorMessage = await OperatorError.getErrorForUnsuccessfulOperation(response, 'delete')
     throw new Error(errorMessage)
   }
 

--- a/src/custom/utils/operator/index.ts
+++ b/src/custom/utils/operator/index.ts
@@ -149,8 +149,9 @@ export async function sendSignedOrderCancellation(params: OrderCancellationParam
   })
 
   if (!response.ok) {
-    // TODO: map responses
-    throw new Error('failed to delete')
+    // Raise an exception
+    const errorMessage = await OperatorError.getErrorForUnsuccessfulPostOrder(response, 'Error cancelling order')
+    throw new Error(errorMessage)
   }
 
   console.log('[utils:operator] Cancelled order', cancellation.orderUid, chainId)

--- a/src/custom/utils/operator/index.ts
+++ b/src/custom/utils/operator/index.ts
@@ -122,7 +122,7 @@ export async function sendSignedOrder(params: {
   // Handle response
   if (!response.ok) {
     // Raise an exception
-    const errorMessage = await OperatorError.getErrorForUnsuccessfulPostOrder(response)
+    const errorMessage = await OperatorError.getErrorForUnsuccessfulPostOrder(response, 'Error adding order')
     throw new Error(errorMessage)
   }
 


### PR DESCRIPTION
# Summary

Part of https://github.com/gnosis/cowswap/pull/733

Improve error handling from API responses

Order cancellation has 3 known error codes https://protocol-rinkeby.dev.gnosisdev.com/api/#/default/delete_api_v1_orders__UID_

2 of them (`InvalidSignature`, `WrongOwner`) are the same as Order creation.
The one missing is `OrderNotFound`.

This PR adds this new error type, and refactors the error handling logic to adapt for both create and delete order queries.