### PR TITLE
Error Handling - Quote errors

### DIFF
--- a/src/custom/hooks/useRefetchPriceCallback.ts
+++ b/src/custom/hooks/useRefetchPriceCallback.ts
@@ -97,18 +97,20 @@ function _handleQuoteError({ quoteData, error, addUnsupportedToken, clearQuote, 
           dateAdded: Date.now()
         })
       }
-      case ApiErrorCodes.NotFound: {
-        console.error(`${error.message}: ${error.description}!`)
-        return clearQuote({
-          token: quoteData.sellToken,
-          chainId: quoteData.chainId
-        })
-      }
       case ApiErrorCodes.FeeExceedsFrom: {
         console.error(`${error.message}: ${error.description}!`)
         return updateQuote({
           ...quoteData,
           error: error.type
+        })
+      }
+      // to be explicity tho it's the same as default
+      // we should clear quote if fee/price is invalid due to not found or no liquidity
+      case ApiErrorCodes.NotFound: {
+        console.error(`${error.message}: ${error.description}!`)
+        return clearQuote({
+          token: quoteData.sellToken,
+          chainId: quoteData.chainId
         })
       }
       default: {

--- a/src/custom/hooks/useRefetchPriceCallback.ts
+++ b/src/custom/hooks/useRefetchPriceCallback.ts
@@ -8,11 +8,12 @@ import {
   useIsUnsupportedTokenGp,
   useRemoveGpUnsupportedToken
 } from 'state/lists/hooks/hooksMod'
-import { FeeInformation, PriceInformation } from 'state/price/reducer'
+import { FeeInformation, PriceInformation, QuoteInformationObject } from 'state/price/reducer'
 import { AddGpUnsupportedTokenParams } from 'state/lists/actions'
-import { ChainId } from '@uniswap/sdk'
 import OperatorError, { ApiErrorCodes } from 'utils/operator/error'
 import { onlyResolvesLast } from 'utils/async'
+import { ClearQuoteParams, UpdateQuoteParams } from 'state/price/actions'
+import { checkPromiseStatus } from 'utils'
 
 export interface RefetchQuoteCallbackParmams {
   quoteParams: FeeQuoteParams
@@ -20,13 +21,7 @@ export interface RefetchQuoteCallbackParmams {
   previousFee?: FeeInformation
 }
 
-type WithFeeExceedsPrice = {
-  feeExceedsPrice: boolean
-}
-
-type PriceInformationWithFee = PriceInformation & WithFeeExceedsPrice
-
-type QuoteResult = [PriceInformationWithFee, FeeInformation]
+type QuoteResult = [PromiseSettledResult<PriceInformation>, PromiseSettledResult<FeeInformation>]
 
 async function _getQuote({ quoteParams, fetchFee, previousFee }: RefetchQuoteCallbackParmams): Promise<QuoteResult> {
   const { sellToken, buyToken, amount, kind, chainId } = quoteParams
@@ -34,7 +29,9 @@ async function _getQuote({ quoteParams, fetchFee, previousFee }: RefetchQuoteCal
 
   // Get a new fee quote (if required)
   const feePromise =
-    fetchFee || !previousFee ? getFeeQuote({ chainId, sellToken, buyToken, amount, kind }) : previousFee
+    fetchFee || !previousFee
+      ? getFeeQuote({ chainId, sellToken, buyToken, amount, kind })
+      : Promise.resolve(previousFee)
 
   // Get a new price quote
   let exchangeAmount
@@ -56,18 +53,19 @@ async function _getQuote({ quoteParams, fetchFee, previousFee }: RefetchQuoteCal
   // Get price for price estimation
   const pricePromise =
     !feeExceedsPrice && exchangeAmount
-      ? getPriceQuote({ chainId, baseToken, quoteToken, amount: exchangeAmount, kind }).then(priceInfo => ({
-          ...priceInfo,
-          feeExceedsPrice
-        }))
+      ? getPriceQuote({ chainId, baseToken, quoteToken, amount: exchangeAmount, kind })
       : // fee exceeds our price, is invalid
-        Promise.resolve({
-          feeExceedsPrice,
-          token: sellToken,
-          amount: null
-        })
+        Promise.reject(
+          new OperatorError({
+            errorType: ApiErrorCodes.FeeExceedsFrom,
+            description: OperatorError.apiErrorDetails.FeeExceedsFrom
+          })
+        )
 
-  return Promise.all([pricePromise, feePromise])
+  // Promise.allSettled does NOT throw on 1 promise rejection
+  // instead it returns PromiseSettledResult - which we can decide to consume later
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled
+  return Promise.allSettled([pricePromise, feePromise])
 }
 
 // wrap _getQuote and only resolve once on several calls
@@ -77,31 +75,42 @@ function _isValidOperatorError(error: any): error is OperatorError {
   return error instanceof OperatorError
 }
 
-function _handleUnsupportedToken({
-  chainId,
-  error,
-  addUnsupportedToken
-}: {
-  chainId: ChainId
+interface HandleQuoteErrorParams {
+  quoteData?: QuoteInformationObject
   error: unknown
   addUnsupportedToken: (params: AddGpUnsupportedTokenParams) => void
-}) {
-  if (_isValidOperatorError(error)) {
-    // Unsupported token
-    if (error.type === ApiErrorCodes.UnsupportedToken) {
-      // TODO: will change with introduction of data prop in error responses
-      const unsupportedTokenAddress = error.description.split(' ')[2]
+  clearQuote: (params: ClearQuoteParams) => void
+  updateQuote: (params: UpdateQuoteParams) => void
+}
 
-      console.error(`${error.message}: ${error.description} - disabling.`)
+function _handleQuoteError({ quoteData, error, addUnsupportedToken, clearQuote, updateQuote }: HandleQuoteErrorParams) {
+  if (_isValidOperatorError(error) && quoteData) {
+    switch (error.type) {
+      case ApiErrorCodes.UnsupportedToken: {
+        // TODO: will change with introduction of data prop in error responses
+        const unsupportedTokenAddress = error.description.split(' ')[2]
+        console.error(`${error.message}: ${error.description} - disabling.`)
 
-      addUnsupportedToken({
-        chainId,
-        address: unsupportedTokenAddress,
-        dateAdded: Date.now()
-      })
-    } else {
-      // some other operator error occurred, log it
-      console.error(error)
+        return addUnsupportedToken({
+          chainId: quoteData.chainId,
+          address: unsupportedTokenAddress,
+          dateAdded: Date.now()
+        })
+      }
+      case ApiErrorCodes.NotFound:
+      case ApiErrorCodes.FeeExceedsFrom: {
+        console.error(`${error.message}: ${error.description}!`)
+        return updateQuote({
+          ...quoteData,
+          error: error.type
+        })
+      }
+      default: {
+        // some other operator error occurred, log it
+        console.error(error)
+        // Clear the quote
+        return clearQuote({ chainId: quoteData.chainId, token: quoteData.sellToken })
+      }
     }
   } else {
     // non-operator error log it
@@ -117,6 +126,7 @@ export function useRefetchQuoteCallback() {
   // dispatchers
   const updateQuote = useUpdateQuote()
   const clearQuote = useClearQuote()
+
   const addUnsupportedToken = useAddGpUnsupportedToken()
   const removeGpUnsupportedToken = useRemoveGpUnsupportedToken()
 
@@ -124,7 +134,8 @@ export function useRefetchQuoteCallback() {
 
   return useCallback(
     async (params: RefetchQuoteCallbackParmams) => {
-      const { sellToken, buyToken, amount, chainId, kind } = params.quoteParams
+      let quoteData: QuoteInformationObject | undefined = undefined
+      const { sellToken, buyToken, chainId } = params.quoteParams
       try {
         // Get the quote
         // price can be null if fee > price
@@ -133,7 +144,25 @@ export function useRefetchQuoteCallback() {
           console.debug('[useRefetchPriceCallback] Canceled get quote price for', params)
           return
         }
+
         const [price, fee] = data as QuoteResult
+
+        // promise.allSettled does NOT throw on first reject
+        // we don't want it to, we are waiting for FEE and PRICE, if only one fails, why throw both away?
+        quoteData = {
+          ...params.quoteParams,
+          fee: checkPromiseStatus(fee, undefined),
+          price: checkPromiseStatus(price, undefined),
+          lastCheck: Date.now()
+        }
+
+        // if any of the 2 returns rejected, we need to throw now
+        // that we have the updated quoteData object
+        if (fee.status === 'rejected') {
+          throw fee.reason
+        } else if (price.status === 'rejected') {
+          throw price.reason
+        }
 
         const previouslyUnsupportedToken = isUnsupportedTokenGp(sellToken) || isUnsupportedTokenGp(buyToken)
         // can be a previously unsupported token which is now valid
@@ -147,25 +176,10 @@ export function useRefetchQuoteCallback() {
           })
         }
 
-        const { feeExceedsPrice } = price
-
         // Update quote
-        updateQuote({
-          sellToken,
-          buyToken,
-          amount,
-          price,
-          chainId,
-          lastCheck: Date.now(),
-          fee,
-          feeExceedsPrice,
-          kind
-        })
+        updateQuote(quoteData)
       } catch (error) {
-        _handleUnsupportedToken({ error, chainId, addUnsupportedToken })
-
-        // Clear the quote
-        clearQuote({ chainId, token: sellToken })
+        _handleQuoteError({ error, quoteData, updateQuote, clearQuote, addUnsupportedToken })
       }
     },
     [isUnsupportedTokenGp, updateQuote, removeGpUnsupportedToken, clearQuote, addUnsupportedToken]

--- a/src/custom/hooks/useRefetchPriceCallback.ts
+++ b/src/custom/hooks/useRefetchPriceCallback.ts
@@ -97,7 +97,13 @@ function _handleQuoteError({ quoteData, error, addUnsupportedToken, clearQuote, 
           dateAdded: Date.now()
         })
       }
-      case ApiErrorCodes.NotFound:
+      case ApiErrorCodes.NotFound: {
+        console.error(`${error.message}: ${error.description}!`)
+        return clearQuote({
+          token: quoteData.sellToken,
+          chainId: quoteData.chainId
+        })
+      }
       case ApiErrorCodes.FeeExceedsFrom: {
         console.error(`${error.message}: ${error.description}!`)
         return updateQuote({

--- a/src/custom/state/price/actions.ts
+++ b/src/custom/state/price/actions.ts
@@ -1,4 +1,5 @@
 import { createAction } from '@reduxjs/toolkit'
+import { ApiErrorCodes } from '@src/custom/utils/operator/error'
 import { ChainId } from '@uniswap/sdk'
 import { QuoteInformationObject } from './reducer'
 
@@ -9,7 +10,10 @@ export interface ClearQuoteParams {
   chainId: ChainId
 }
 
+export type SetQuoteErrorParams = UpdateQuoteParams & { error: ApiErrorCodes }
+
 export const updateQuote = createAction<UpdateQuoteParams>('price/updateQuote')
 export const clearQuote = createAction<ClearQuoteParams>('price/clearQuote')
+export const setQuoteError = createAction<SetQuoteErrorParams>('price/setQuoteError')
 
 // TODO: Add actions to update only the price

--- a/src/custom/state/price/hooks.ts
+++ b/src/custom/state/price/hooks.ts
@@ -2,11 +2,19 @@ import { useCallback } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { AppDispatch, AppState } from 'state'
-import { updateQuote, clearQuote, UpdateQuoteParams, ClearQuoteParams } from './actions'
+import {
+  updateQuote,
+  clearQuote,
+  UpdateQuoteParams,
+  ClearQuoteParams,
+  SetQuoteErrorParams,
+  setQuoteError
+} from './actions'
 import { QuoteInformationObject, QuotesMap } from './reducer'
 
 type AddPriceCallback = (addFeeParams: UpdateQuoteParams) => void
 type ClearPriceCallback = (clearFeeParams: ClearQuoteParams) => void
+type SetQuoteErrorCallback = (setQuoteErrorParams: SetQuoteErrorParams) => void
 
 export const useAllQuotes = ({
   chainId
@@ -38,4 +46,11 @@ export const useUpdateQuote = (): AddPriceCallback => {
 export const useClearQuote = (): ClearPriceCallback => {
   const dispatch = useDispatch<AppDispatch>()
   return useCallback((clearQuoteParams: ClearQuoteParams) => dispatch(clearQuote(clearQuoteParams)), [dispatch])
+}
+
+export const useSetQuoteError = (): SetQuoteErrorCallback => {
+  const dispatch = useDispatch<AppDispatch>()
+  return useCallback((setQuoteErrorParams: SetQuoteErrorParams) => dispatch(setQuoteError(setQuoteErrorParams)), [
+    dispatch
+  ])
 }

--- a/src/custom/state/price/reducer.ts
+++ b/src/custom/state/price/reducer.ts
@@ -4,6 +4,7 @@ import { updateQuote, clearQuote } from './actions'
 import { Writable } from 'custom/types'
 import { PrefillStateRequired } from '../orders/reducer'
 import { FeeQuoteParams } from 'utils/operator'
+import { ApiErrorCodes } from 'utils/operator/error'
 
 // API Doc: https://protocol-rinkeby.dev.gnosisdev.com/api
 
@@ -23,10 +24,10 @@ export interface PriceInformation {
 }
 
 export interface QuoteInformationObject extends FeeQuoteParams {
-  fee: FeeInformation
-  price: PriceInformation
+  fee?: FeeInformation
+  price?: PriceInformation
   lastCheck: number
-  feeExceedsPrice: boolean
+  error?: ApiErrorCodes
 }
 
 // Map token addresses to their last quote information

--- a/src/custom/state/price/reducer.ts
+++ b/src/custom/state/price/reducer.ts
@@ -1,6 +1,6 @@
 import { createReducer, PayloadAction } from '@reduxjs/toolkit'
 import { ChainId } from '@uniswap/sdk'
-import { updateQuote, clearQuote } from './actions'
+import { updateQuote, clearQuote, setQuoteError } from './actions'
 import { Writable } from 'custom/types'
 import { PrefillStateRequired } from '../orders/reducer'
 import { FeeQuoteParams } from 'utils/operator'
@@ -26,8 +26,8 @@ export interface PriceInformation {
 export interface QuoteInformationObject extends FeeQuoteParams {
   fee?: FeeInformation
   price?: PriceInformation
-  lastCheck: number
   error?: ApiErrorCodes
+  lastCheck: number
 }
 
 // Map token addresses to their last quote information
@@ -54,6 +54,11 @@ function initializeState(
 
 export default createReducer(initialState, builder =>
   builder
+    .addCase(setQuoteError, (state, action) => {
+      initializeState(state, action)
+      const { sellToken, chainId } = action.payload
+      state[chainId][sellToken] = action.payload
+    })
     .addCase(updateQuote, (state, action) => {
       initializeState(state, action)
       const { sellToken, chainId } = action.payload

--- a/src/custom/state/price/updater.ts
+++ b/src/custom/state/price/updater.ts
@@ -74,8 +74,9 @@ function quoteUsingSameParameters(currentParams: FeeQuoteParams, quoteInfo: Quot
  *  Decides if we need to refetch the fee information given the current parameters (selected by the user), and the current feeInfo (in the state)
  */
 function isRefetchQuoteRequired(currentParams: FeeQuoteParams, quoteInformation?: QuoteInformationObject): boolean {
-  if (!quoteInformation || !quoteInformation.fee) {
-    // If there's no quote/fee information, we always re-fetch
+  // If there's no quote/fee information, we always re-fetch
+  // we need to check that there is also no error otherwise this will loop
+  if (!quoteInformation || (!quoteInformation.fee && !quoteInformation.error)) {
     return true
   }
 
@@ -91,10 +92,12 @@ function isRefetchQuoteRequired(currentParams: FeeQuoteParams, quoteInformation?
   if (wasQuoteCheckedRecently(quoteInformation.lastCheck)) {
     // Don't Re-fetch if it was queried recently
     return false
-  } else {
+  } else if (quoteInformation.fee) {
     // Re-fetch if the fee is expiring soon
     return isFeeExpiringSoon(quoteInformation.fee.expirationDate)
   }
+
+  return false
 }
 
 function unsupportedTokenNeedsRecheck(unsupportedToken: UnsupportedToken[string] | false) {

--- a/src/custom/state/swap/extension.ts
+++ b/src/custom/state/swap/extension.ts
@@ -114,7 +114,7 @@ export function useTradeExactInWithFee({
 
   // make sure we have a typed in amount, a fee, and a price
   // else we can assume the trade will be null
-  if (!parsedInputAmount || !originalTrade || !outputCurrency || !quote?.fee || !quote?.price.amount) return null
+  if (!parsedInputAmount || !originalTrade || !outputCurrency || !quote?.fee || !quote?.price?.amount) return null
 
   const feeAsCurrency = stringToCurrency(quote.fee.amount, parsedInputAmount.currency)
   // Check that fee amount is not greater than the user's input amt
@@ -179,7 +179,7 @@ export function useTradeExactOutWithFee({
   // Original Uni trade hook
   const outTrade = useTradeExactOut(inputCurrency ?? undefined, parsedOutputAmount)
 
-  if (!outTrade || !parsedOutputAmount || !inputCurrency || !quote?.fee || !quote?.price.amount) return null
+  if (!outTrade || !parsedOutputAmount || !inputCurrency || !quote?.fee || !quote?.price?.amount) return null
 
   const feeAsCurrency = stringToCurrency(quote.fee.amount, inputCurrency)
   // set final fee object

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -25,6 +25,7 @@ import { ParsedQs } from 'qs'
 import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
 import { WETH_LOGO_URI, XDAI_LOGO_URI } from 'constants/index'
 import { WrappedTokenInfo } from '../lists/hooks'
+import { ApiErrorCodes } from 'utils/operator/error'
 
 export * from '@src/state/swap/hooks'
 
@@ -274,7 +275,7 @@ export function useIsFeeGreaterThanInput({
   if (!quote?.fee || !feeToken) return { isFeeGreater: false, fee: null }
 
   return {
-    isFeeGreater: quote.feeExceedsPrice,
+    isFeeGreater: quote.error === ApiErrorCodes.FeeExceedsFrom,
     fee: stringToCurrency(quote.fee.amount, feeToken)
   }
 }

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -272,10 +272,12 @@ export function useIsFeeGreaterThanInput({
   const quote = useQuote({ chainId, token: address })
   const feeToken = useCurrency(address)
 
-  if (!quote?.fee || !feeToken) return { isFeeGreater: false, fee: null }
+  return useMemo(() => {
+    if (!quote || !feeToken) return { isFeeGreater: false, fee: null }
 
-  return {
-    isFeeGreater: quote.error === ApiErrorCodes.FeeExceedsFrom,
-    fee: stringToCurrency(quote.fee.amount, feeToken)
-  }
+    return {
+      isFeeGreater: quote.error === ApiErrorCodes.FeeExceedsFrom,
+      fee: quote.fee ? stringToCurrency(quote.fee.amount, feeToken) : null
+    }
+  }, [feeToken, quote])
 }

--- a/src/custom/utils/index.ts
+++ b/src/custom/utils/index.ts
@@ -116,3 +116,8 @@ export function formatOrderId(orderId: string): string {
   // 0x is at index 0 of orderId, shorten. Else return id as is
   return has0x?.index === 0 ? shortenOrderId(orderId, 2, orderId.length) : orderId
 }
+
+// To properly handle PromiseSettleResult which returns and object
+export function checkPromiseStatus<T, E = undefined>(promiseResult: PromiseSettledResult<T>, nonFulfilledReturn: E) {
+  return promiseResult.status === 'fulfilled' ? promiseResult.value : nonFulfilledReturn
+}

--- a/src/custom/utils/index.ts
+++ b/src/custom/utils/index.ts
@@ -117,7 +117,16 @@ export function formatOrderId(orderId: string): string {
   return has0x?.index === 0 ? shortenOrderId(orderId, 2, orderId.length) : orderId
 }
 
+export function isPromiseFulfilled<T>(
+  promiseResult: PromiseSettledResult<T>
+): promiseResult is PromiseFulfilledResult<T> {
+  return promiseResult.status === 'fulfilled'
+}
+
 // To properly handle PromiseSettleResult which returns and object
-export function checkPromiseStatus<T, E = undefined>(promiseResult: PromiseSettledResult<T>, nonFulfilledReturn: E) {
-  return promiseResult.status === 'fulfilled' ? promiseResult.value : nonFulfilledReturn
+export function getPromiseFulfilledValue<T, E = undefined>(
+  promiseResult: PromiseSettledResult<T>,
+  nonFulfilledReturn: E
+) {
+  return isPromiseFulfilled(promiseResult) ? promiseResult.value : nonFulfilledReturn
 }

--- a/src/custom/utils/operator/error.ts
+++ b/src/custom/utils/operator/error.ts
@@ -14,6 +14,7 @@ export enum ApiErrorCodes {
   InsufficientFee = 'InsufficientFee',
   UnsupportedToken = 'UnsupportedToken',
   WrongOwner = 'WrongOwner',
+  // NotFound = InsufficientLiquidity
   NotFound = 'NotFound',
   FeeExceedsFrom = 'FeeExceedsFrom'
 }

--- a/src/custom/utils/operator/index.ts
+++ b/src/custom/utils/operator/index.ts
@@ -117,7 +117,7 @@ export async function postSignedOrder(params: {
   // Handle response
   if (!response.ok) {
     // Raise an exception
-    const errorMessage = await OperatorError.getErrorForUnsuccessfulPostOrder(response)
+    const errorMessage = await OperatorError.getErrorFromStatusCode(response)
     throw new Error(errorMessage)
   }
 


### PR DESCRIPTION
## NOTE: I think i may split this in 2 PRs, it's quite large

This PR addresses part of our many changes required for better handling error messages. It is separate from the loading PRs though it would be nice to have these consolidated

Changes:
1. inside `useRefetchPriceCallback` - don't use `Promise.all()` to resolve both `price` and `fee` promises as there can be independent issues between the 2 calls - e.g we query fee, it's all good, but we query price using fee > price, and that is it's own error
2. edit OperatorError class to accept new error type `NotFound`