### PR TITLE
[Error Handling 3] Core Logic

### DIFF
--- a/src/custom/hooks/useRefetchPriceCallback.ts
+++ b/src/custom/hooks/useRefetchPriceCallback.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { useCallback } from 'react'
-import { useClearQuote, useUpdateQuote } from 'state/price/hooks'
+import { useClearQuote, useSetQuoteError, useUpdateQuote } from 'state/price/hooks'
 import { getCanonicalMarket, registerOnWindow } from 'utils/misc'
 import { FeeQuoteParams, getFeeQuote, getPriceQuote } from 'utils/operator'
 import {
@@ -8,11 +8,12 @@ import {
   useIsUnsupportedTokenGp,
   useRemoveGpUnsupportedToken
 } from 'state/lists/hooks/hooksMod'
-import { FeeInformation, PriceInformation } from 'state/price/reducer'
+import { FeeInformation, PriceInformation, QuoteInformationObject } from 'state/price/reducer'
 import { AddGpUnsupportedTokenParams } from 'state/lists/actions'
-import { ChainId } from '@uniswap/sdk'
 import OperatorError, { ApiErrorCodes } from 'utils/operator/error'
 import { onlyResolvesLast } from 'utils/async'
+import { ClearQuoteParams, SetQuoteErrorParams } from 'state/price/actions'
+import { getPromiseFulfilledValue, isPromiseFulfilled } from 'utils/misc'
 
 export interface RefetchQuoteCallbackParmams {
   quoteParams: FeeQuoteParams
@@ -20,13 +21,7 @@ export interface RefetchQuoteCallbackParmams {
   previousFee?: FeeInformation
 }
 
-type WithFeeExceedsPrice = {
-  feeExceedsPrice: boolean
-}
-
-type PriceInformationWithFee = PriceInformation & WithFeeExceedsPrice
-
-type QuoteResult = [PriceInformationWithFee, FeeInformation]
+type QuoteResult = [PromiseSettledResult<PriceInformation>, PromiseSettledResult<FeeInformation>]
 
 async function _getQuote({ quoteParams, fetchFee, previousFee }: RefetchQuoteCallbackParmams): Promise<QuoteResult> {
   const { sellToken, buyToken, amount, kind, chainId } = quoteParams
@@ -34,7 +29,9 @@ async function _getQuote({ quoteParams, fetchFee, previousFee }: RefetchQuoteCal
 
   // Get a new fee quote (if required)
   const feePromise =
-    fetchFee || !previousFee ? getFeeQuote({ chainId, sellToken, buyToken, amount, kind }) : previousFee
+    fetchFee || !previousFee
+      ? getFeeQuote({ chainId, sellToken, buyToken, amount, kind })
+      : Promise.resolve(previousFee)
 
   // Get a new price quote
   let exchangeAmount
@@ -56,18 +53,19 @@ async function _getQuote({ quoteParams, fetchFee, previousFee }: RefetchQuoteCal
   // Get price for price estimation
   const pricePromise =
     !feeExceedsPrice && exchangeAmount
-      ? getPriceQuote({ chainId, baseToken, quoteToken, amount: exchangeAmount, kind }).then(priceInfo => ({
-          ...priceInfo,
-          feeExceedsPrice
-        }))
+      ? getPriceQuote({ chainId, baseToken, quoteToken, amount: exchangeAmount, kind })
       : // fee exceeds our price, is invalid
-        Promise.resolve({
-          feeExceedsPrice,
-          token: sellToken,
-          amount: null
-        })
+        Promise.reject(
+          new OperatorError({
+            errorType: ApiErrorCodes.FeeExceedsFrom,
+            description: OperatorError.apiErrorDetails.FeeExceedsFrom
+          })
+        )
 
-  return Promise.all([pricePromise, feePromise])
+  // Promise.allSettled does NOT throw on 1 promise rejection
+  // instead it returns PromiseSettledResult - which we can decide to consume later
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled
+  return Promise.allSettled([pricePromise, feePromise])
 }
 
 // wrap _getQuote and only resolve once on several calls
@@ -77,31 +75,51 @@ function _isValidOperatorError(error: any): error is OperatorError {
   return error instanceof OperatorError
 }
 
-function _handleUnsupportedToken({
-  chainId,
-  error,
-  addUnsupportedToken
-}: {
-  chainId: ChainId
+interface HandleQuoteErrorParams {
+  quoteData: QuoteInformationObject | FeeQuoteParams
   error: unknown
   addUnsupportedToken: (params: AddGpUnsupportedTokenParams) => void
-}) {
+  clearQuote: (params: ClearQuoteParams) => void
+  setQuoteError: (params: SetQuoteErrorParams) => void
+}
+
+function _handleQuoteError({
+  quoteData,
+  error,
+  addUnsupportedToken,
+  clearQuote,
+  setQuoteError
+}: HandleQuoteErrorParams) {
   if (_isValidOperatorError(error)) {
-    // Unsupported token
-    if (error.type === ApiErrorCodes.UnsupportedToken) {
-      // TODO: will change with introduction of data prop in error responses
-      const unsupportedTokenAddress = error.description.split(' ')[2]
+    switch (error.type) {
+      case ApiErrorCodes.UnsupportedToken: {
+        // TODO: will change with introduction of data prop in error responses
+        const unsupportedTokenAddress = error.description.split(' ')[2]
+        console.error(`${error.message}: ${error.description} - disabling.`)
 
-      console.error(`${error.message}: ${error.description} - disabling.`)
-
-      addUnsupportedToken({
-        chainId,
-        address: unsupportedTokenAddress,
-        dateAdded: Date.now()
-      })
-    } else {
-      // some other operator error occurred, log it
-      console.error(error)
+        return addUnsupportedToken({
+          chainId: quoteData.chainId,
+          address: unsupportedTokenAddress,
+          dateAdded: Date.now()
+        })
+      }
+      // Fee/Price query returns error
+      // e.g Insufficient Liquidity or Fee exceeds Price
+      case ApiErrorCodes.FeeExceedsFrom:
+      case ApiErrorCodes.NotFound: {
+        console.error(`${error.message}: ${error.description}!`)
+        return setQuoteError({
+          ...quoteData,
+          lastCheck: Date.now(),
+          error: error.type
+        })
+      }
+      default: {
+        // some other operator error occurred, log it
+        console.error(error)
+        // Clear the quote
+        return clearQuote({ chainId: quoteData.chainId, token: quoteData.sellToken })
+      }
     }
   } else {
     // non-operator error log it
@@ -117,6 +135,8 @@ export function useRefetchQuoteCallback() {
   // dispatchers
   const updateQuote = useUpdateQuote()
   const clearQuote = useClearQuote()
+  const setQuoteError = useSetQuoteError()
+
   const addUnsupportedToken = useAddGpUnsupportedToken()
   const removeGpUnsupportedToken = useRemoveGpUnsupportedToken()
 
@@ -124,7 +144,9 @@ export function useRefetchQuoteCallback() {
 
   return useCallback(
     async (params: RefetchQuoteCallbackParmams) => {
-      const { sellToken, buyToken, amount, chainId, kind } = params.quoteParams
+      let quoteData: FeeQuoteParams | QuoteInformationObject = params.quoteParams
+
+      const { sellToken, buyToken, chainId } = quoteData
       try {
         // Get the quote
         // price can be null if fee > price
@@ -133,7 +155,28 @@ export function useRefetchQuoteCallback() {
           console.debug('[useRefetchPriceCallback] Canceled get quote price for', params)
           return
         }
+
         const [price, fee] = data as QuoteResult
+
+        // Promise.allSettled (L68) does NOT throw whole promise on first reject
+        // we don't want it to, we are waiting for FEE and PRICE, if only one fails, why throw both away?
+        // e.g FEE comes in OK, but Fee > Price, we throw an FEE_EXCEEDS_PRICE error but keep fee promise resolved value
+        // to save into state and use
+        quoteData = {
+          ...params.quoteParams,
+          fee: getPromiseFulfilledValue(fee, undefined),
+          price: getPromiseFulfilledValue(price, undefined),
+          lastCheck: Date.now()
+        }
+
+        // check the PromiseSettledValue/PromiseRejectedResult
+        // returned by Promise.allSettled
+        if (!isPromiseFulfilled(fee)) {
+          // fee error takes precedence
+          throw fee.reason
+        } else if (!isPromiseFulfilled(price)) {
+          throw price.reason
+        }
 
         const previouslyUnsupportedToken = isUnsupportedTokenGp(sellToken) || isUnsupportedTokenGp(buyToken)
         // can be a previously unsupported token which is now valid
@@ -147,27 +190,20 @@ export function useRefetchQuoteCallback() {
           })
         }
 
-        const { feeExceedsPrice } = price
-
         // Update quote
-        updateQuote({
-          sellToken,
-          buyToken,
-          amount,
-          price,
-          chainId,
-          lastCheck: Date.now(),
-          fee,
-          feeExceedsPrice,
-          kind
-        })
+        updateQuote(quoteData)
       } catch (error) {
-        _handleUnsupportedToken({ error, chainId, addUnsupportedToken })
-
-        // Clear the quote
-        clearQuote({ chainId, token: sellToken })
+        // handle any errors in quote fetch
+        // we re-use the quoteData object in scope to save values into state
+        _handleQuoteError({
+          error,
+          quoteData,
+          setQuoteError,
+          clearQuote,
+          addUnsupportedToken
+        })
       }
     },
-    [isUnsupportedTokenGp, updateQuote, removeGpUnsupportedToken, clearQuote, addUnsupportedToken]
+    [isUnsupportedTokenGp, updateQuote, removeGpUnsupportedToken, setQuoteError, clearQuote, addUnsupportedToken]
   )
 }

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -1,4 +1,4 @@
-import { CurrencyAmount, JSBI, Token, Trade, TradeType } from '@uniswap/sdk'
+import { CurrencyAmount, /* JSBI, */ Token, Trade, TradeType } from '@uniswap/sdk'
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { ArrowDown } from 'react-feather'
 import ReactGA from 'react-ga'
@@ -60,6 +60,8 @@ import { SwapProps } from '.'
 import { useWalletInfo } from 'hooks/useWalletInfo'
 import { HashLink } from 'react-router-hash-link'
 import { logTradeDetails } from 'state/swap/utils'
+import { isInsufficientLiquidityError } from 'state/price/utils'
+import { useQuote } from 'state/price/hooks'
 
 export default function Swap({
   history,
@@ -121,6 +123,11 @@ export default function Swap({
     currencies,
     inputError: swapInputError
   } = useDerivedSwapInfo()
+
+  const quote = useQuote({
+    token: INPUT.currencyId,
+    chainId
+  })
 
   // Log all trade information
   logTradeDetails(v2Trade, allowedSlippage)
@@ -229,11 +236,11 @@ export default function Swap({
       : parsedAmounts[dependentField]?.toSignificant(DEFAULT_PRECISION) ?? ''
   }
 
-  const route = trade?.route
-  const userHasSpecifiedInputOutput = Boolean(
-    currencies[Field.INPUT] && currencies[Field.OUTPUT] && parsedAmounts[independentField]?.greaterThan(JSBI.BigInt(0))
-  )
-  const noRoute = !route
+  // const route = trade?.route
+  // const userHasSpecifiedInputOutput = Boolean(
+  //   currencies[Field.INPUT] && currencies[Field.OUTPUT] && parsedAmounts[independentField]?.greaterThan(JSBI.BigInt(0))
+  // )
+  // const noRoute = !route
 
   // check whether the user has approved the router on the input token
   const [approval, approveCallback] = useApproveCallbackFromTrade(trade, allowedSlippage)
@@ -535,15 +542,14 @@ export default function Swap({
               </ButtonPrimary>
             ) : !swapInputError && isNativeIn ? (
               <SwitchToWethBtn wrappedToken={wrappedToken} />
-            ) : noRoute && userHasSpecifiedInputOutput ? (
-              isFeeGreater ? (
-                <FeesExceedFromAmountMessage />
-              ) : (
-                <GreyCard style={{ textAlign: 'center' }}>
-                  <TYPE.main mb="4px">Insufficient liquidity for this trade.</TYPE.main>
-                  {singleHopOnly && <TYPE.main mb="4px">Try enabling multi-hop trades.</TYPE.main>}
-                </GreyCard>
-              )
+            ) : isFeeGreater ? (
+              <FeesExceedFromAmountMessage />
+            ) : isInsufficientLiquidityError(quote?.error) ? (
+              // ) : noRoute && userHasSpecifiedInputOutput ? (
+              <GreyCard style={{ textAlign: 'center' }}>
+                <TYPE.main mb="4px">Insufficient liquidity for this trade.</TYPE.main>
+                {singleHopOnly && <TYPE.main mb="4px">Try enabling multi-hop trades.</TYPE.main>}
+              </GreyCard>
             ) : showApproveFlow ? (
               <RowBetween>
                 <ButtonConfirmed
@@ -624,7 +630,8 @@ export default function Swap({
                   // fontSize={20}
                   fontWeight={500}
                 >
-                  {swapInputError ? swapInputError : 'Swap'
+                  {/* TODO: replace with loader once merged */}
+                  {swapInputError ? swapInputError : trade ? 'Swap' : 'Loading...'
                   // : priceImpactSeverity > 3 && !isExpertMode
                   // ? `Price Impact Too High`
                   // : `Swap${priceImpactSeverity > 2 ? ' Anyway' : ''}`

--- a/src/custom/state/price/reducer.ts
+++ b/src/custom/state/price/reducer.ts
@@ -28,8 +28,6 @@ export interface QuoteInformationObject extends FeeQuoteParams {
   price?: PriceInformation
   error?: ApiErrorCodes
   lastCheck: number
-  // TODO: remove
-  feeExceedsPrice: boolean
 }
 
 // Map token addresses to their last quote information

--- a/src/custom/state/price/updater.ts
+++ b/src/custom/state/price/updater.ts
@@ -74,8 +74,9 @@ function quoteUsingSameParameters(currentParams: FeeQuoteParams, quoteInfo: Quot
  *  Decides if we need to refetch the fee information given the current parameters (selected by the user), and the current feeInfo (in the state)
  */
 function isRefetchQuoteRequired(currentParams: FeeQuoteParams, quoteInformation?: QuoteInformationObject): boolean {
-  if (!quoteInformation || !quoteInformation.fee) {
-    // If there's no quote/fee information, we always re-fetch
+  // If there's no quote/fee information, we always re-fetch
+  // we need to check that there is also no error otherwise this will loop
+  if (!quoteInformation || (!quoteInformation.fee && !quoteInformation.error)) {
     return true
   }
 
@@ -91,10 +92,12 @@ function isRefetchQuoteRequired(currentParams: FeeQuoteParams, quoteInformation?
   if (wasQuoteCheckedRecently(quoteInformation.lastCheck)) {
     // Don't Re-fetch if it was queried recently
     return false
-  } else {
+  } else if (quoteInformation.fee) {
     // Re-fetch if the fee is expiring soon
     return isFeeExpiringSoon(quoteInformation.fee.expirationDate)
   }
+
+  return false
 }
 
 function unsupportedTokenNeedsRecheck(unsupportedToken: UnsupportedToken[string] | false) {

--- a/src/custom/state/price/utils.ts
+++ b/src/custom/state/price/utils.ts
@@ -1,0 +1,9 @@
+import { ApiErrorCodes } from 'utils/operator/error'
+
+export function isFeeGreaterThanPriceError(error?: ApiErrorCodes): boolean {
+  return error === ApiErrorCodes.FeeExceedsFrom
+}
+
+export function isInsufficientLiquidityError(error?: ApiErrorCodes): boolean {
+  return error === ApiErrorCodes.NotFound
+}

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -25,6 +25,7 @@ import { ParsedQs } from 'qs'
 import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
 import { WETH_LOGO_URI, XDAI_LOGO_URI } from 'constants/index'
 import { WrappedTokenInfo } from '../lists/hooks'
+import { isFeeGreaterThanPriceError } from '../price/utils'
 
 export * from '@src/state/swap/hooks'
 
@@ -271,10 +272,10 @@ export function useIsFeeGreaterThanInput({
   const quote = useQuote({ chainId, token: address })
   const feeToken = useCurrency(address)
 
-  if (!quote?.fee || !feeToken) return { isFeeGreater: false, fee: null }
+  if (!quote || !feeToken) return { isFeeGreater: false, fee: null }
 
   return {
-    isFeeGreater: quote.feeExceedsPrice,
-    fee: stringToCurrency(quote.fee.amount, feeToken)
+    isFeeGreater: isFeeGreaterThanPriceError(quote.error),
+    fee: quote.fee ? stringToCurrency(quote.fee.amount, feeToken) : null
   }
 }

--- a/src/custom/utils/misc.ts
+++ b/src/custom/utils/misc.ts
@@ -6,6 +6,20 @@ export const isTruthy = <T>(value: T | null | undefined | false): value is T => 
 export const delay = <T = void>(ms = 100, result?: T): Promise<T> =>
   new Promise(resolve => setTimeout(resolve, ms, result))
 
+export function isPromiseFulfilled<T>(
+  promiseResult: PromiseSettledResult<T>
+): promiseResult is PromiseFulfilledResult<T> {
+  return promiseResult.status === 'fulfilled'
+}
+
+// To properly handle PromiseSettleResult which returns and object
+export function getPromiseFulfilledValue<T, E = undefined>(
+  promiseResult: PromiseSettledResult<T>,
+  nonFulfilledReturn: E
+) {
+  return isPromiseFulfilled(promiseResult) ? promiseResult.value : nonFulfilledReturn
+}
+
 export const registerOnWindow = (registerMapping: Record<string, any>) => {
   Object.entries(registerMapping).forEach(([key, value]) => {
     ;(window as any)[key] = value


### PR DESCRIPTION
Waterfalls in #746 

Handles the core logic changes of error codes for quote fetch

1. `useRefetchPriceCallback` now deals with the `fee` and `price` promises separately via `Promise.allSettled` 
2. `useRefetchPriceCallback` also handles any errors arising from point 1 and saves to state however necessary based on error codes added in #746
3. removes some legacy code from state and fixes types as necessary

### Testing
To test this, you'll need to use redux inspector in chrome tools to check state

#### Checking `FeeExceedsPrice` error
1. [Mainnet] Select WETH sell (or any idc) against DAI buy
2. Input a tiny amt e.g 0.00000003
3. redux inspector should show, inside state > price: `error: FeeExceedsPrice`
4. app may or may not show that in the swap button state (changes to this are incoming but current code "might just work")

#### Checking `NotFound` aka `InsufficientLiquidity` error
This one is easiest on Rinkeby
1. [Rinkeby] Select WETH sell against SUSD or GUSD buy
2. input any amount in the input fields
3. redux inspector should show, inside state > price: `error: NotFound`
4. app may or may not show "Insufficient liquidity" in the swap button state (changes to this are incoming but current code "might just work")