### PR TITLE
[739] Flashing insufficient liquidity message

### DIFF
--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -370,6 +370,8 @@ export default function Swap({
     [independentField, showWrap, trade]
   )
 
+  const swapBlankState = !swapInputError && !trade
+
   return (
     <>
       <TokenWarningModal
@@ -594,7 +596,7 @@ export default function Swap({
                   }
                   // error={isValid && priceImpactSeverity > 2}
                 >
-                  <SwapButton isHardLoading={isGettingNewQuote}>Swap</SwapButton>
+                  <SwapButton showLoading={swapBlankState || isGettingNewQuote}>Swap</SwapButton>
                   {/* <Text fontSize={16} fontWeight={500}>
                     {priceImpactSeverity > 3 && !isExpertMode
                       ? `Price Impact High`
@@ -623,7 +625,7 @@ export default function Swap({
                 disabled={!isValid /*|| (priceImpactSeverity > 3 && !isExpertMode) */ || !!swapCallbackError}
                 // error={isValid && priceImpactSeverity > 2 && !swapCallbackError}
               >
-                <SwapButton isHardLoading={isGettingNewQuote}>{swapInputError ? swapInputError : 'Swap'}</SwapButton>
+                <SwapButton showLoading={swapBlankState || isGettingNewQuote}>{swapInputError || 'Swap'}</SwapButton>
                 {/* <Text fontSize={20} fontWeight={500}>
                   {swapInputError ? swapInputError : 'Swap'
                   // : priceImpactSeverity > 3 && !isExpertMode

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -275,12 +275,12 @@ const TradeLoading = ({ showButton = false }: TradeLoadingProps) => {
 }
 
 interface SwapButtonProps extends TradeLoadingProps {
-  isHardLoading: boolean
+  showLoading: boolean
   children: React.ReactNode
 }
 
-const SwapButton = ({ children, isHardLoading, showButton = false }: SwapButtonProps) =>
-  isHardLoading ? (
+const SwapButton = ({ children, showLoading, showButton = false }: SwapButtonProps) =>
+  showLoading ? (
     <TradeLoading showButton={showButton} />
   ) : (
     <Text fontSize={16} fontWeight={500}>


### PR DESCRIPTION
Closes #730 

Sets default blank state to loader

Testing:

1. select any token pair
2. mess with amounts etc
3. insufficient liquidity shouldn't flash
4. point 3 only shows when redux inspector shows NotFound error. i.e it shows when it should