### PR TITLE
[Error Handling] PR Comments + handle "unhandled" quote fetch errors

### DIFF
--- a/src/custom/hooks/useRefetchPriceCallback.ts
+++ b/src/custom/hooks/useRefetchPriceCallback.ts
@@ -112,31 +112,18 @@ function _handleQuoteError({
           error: error.type
         })
       }
-      default: {
-        // some other operator error occurred, log it
-        // and set price/fee to undefined
-        console.error(error)
-        return setQuoteError({
-          ...quoteData,
-          fee: undefined,
-          price: undefined,
-          lastCheck: Date.now(),
-          error: QuoteErrorCodes.UNHANDLED_ERROR
-        })
-      }
     }
-  } else {
-    // non-operator error log it
-    // and set price/fee to undefined
-    console.error('An unknown error occurred:', error)
-    return setQuoteError({
-      ...quoteData,
-      fee: undefined,
-      price: undefined,
-      lastCheck: Date.now(),
-      error: QuoteErrorCodes.UNHANDLED_ERROR
-    })
   }
+  // non-operator/quote error
+  // log it and set price/fee to undefined
+  console.error('An unhandled error has occurred:', error)
+  return setQuoteError({
+    ...quoteData,
+    fee: undefined,
+    price: undefined,
+    lastCheck: Date.now(),
+    error: QuoteErrorCodes.UNHANDLED_ERROR
+  })
 }
 
 /**

--- a/src/custom/hooks/useRefetchPriceCallback.ts
+++ b/src/custom/hooks/useRefetchPriceCallback.ts
@@ -177,7 +177,6 @@ export function useRefetchQuoteCallback() {
           price: getPromiseFulfilledValue(price, undefined),
           lastCheck: Date.now()
         }
-        console.debug('setQuoteError quoteData', quoteData)
         // check the promise fulfilled values
         // handle if rejected
         if (!isPromiseFulfilled(fee)) {

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -60,7 +60,7 @@ import { SwapProps } from '.'
 import { useWalletInfo } from 'hooks/useWalletInfo'
 import { HashLink } from 'react-router-hash-link'
 import { logTradeDetails } from 'state/swap/utils'
-import { isInsufficientLiquidityError } from 'state/price/utils'
+import { isFeeGreaterThanPriceError, isInsufficientLiquidityError, isUnhandledQuoteError } from 'state/price/utils'
 import { useGetQuoteAndStatus } from 'state/price/hooks'
 
 export default function Swap({
@@ -543,13 +543,17 @@ export default function Swap({
               </ButtonPrimary>
             ) : !swapInputError && isNativeIn ? (
               <SwitchToWethBtn wrappedToken={wrappedToken} />
-            ) : isFeeGreater ? (
+            ) : isFeeGreaterThanPriceError(quote?.error) ? (
               <FeesExceedFromAmountMessage />
             ) : isInsufficientLiquidityError(quote?.error) ? (
               // ) : noRoute && userHasSpecifiedInputOutput ? (
               <GreyCard style={{ textAlign: 'center' }}>
                 <TYPE.main mb="4px">Insufficient liquidity for this trade.</TYPE.main>
                 {singleHopOnly && <TYPE.main mb="4px">Try enabling multi-hop trades.</TYPE.main>}
+              </GreyCard>
+            ) : isUnhandledQuoteError(quote?.error) ? (
+              <GreyCard style={{ textAlign: 'center' }}>
+                <TYPE.main mb="4px">Error loading quote. Try again later.</TYPE.main>
               </GreyCard>
             ) : showApproveFlow ? (
               <RowBetween>

--- a/src/custom/state/price/utils.ts
+++ b/src/custom/state/price/utils.ts
@@ -7,3 +7,7 @@ export function isFeeGreaterThanPriceError(error?: QuoteErrorCodes): boolean {
 export function isInsufficientLiquidityError(error?: QuoteErrorCodes): boolean {
   return error === QuoteErrorCodes.InsufficientLiquidity
 }
+
+export function isUnhandledQuoteError(error?: QuoteErrorCodes): boolean {
+  return error === QuoteErrorCodes.UNHANDLED_ERROR
+}

--- a/src/custom/utils/operator/errors/OperatorError.ts
+++ b/src/custom/utils/operator/errors/OperatorError.ts
@@ -40,7 +40,7 @@ export default class OperatorError extends Error {
   // https://github.com/gnosis/gp-v2-services/blob/9014ae55412a356e46343e051aefeb683cc69c41/orderbook/openapi.yml#L563
   static apiErrorDetails = ApiErrorCodeDetails
 
-  static async getErrorMessage(response: Response) {
+  private static async _getErrorMessage(response: Response) {
     try {
       const orderPostError: ApiErrorObject = await response.json()
 
@@ -51,7 +51,7 @@ export default class OperatorError extends Error {
         return orderPostError.description
       }
     } catch (error) {
-      console.error('Error handling a 400 error. Likely a problem deserialising the JSON response')
+      console.error('Error handling a 400/404 error. Likely a problem deserialising the JSON response')
       return OperatorError.apiErrorDetails.UNHANDLED_ERROR
     }
   }
@@ -60,7 +60,7 @@ export default class OperatorError extends Error {
     switch (response.status) {
       case 400:
       case 404:
-        return this.getErrorMessage(response)
+        return this._getErrorMessage(response)
 
       case 403:
         return 'The order cannot be accepted. Your account is deny-listed.'
@@ -70,6 +70,10 @@ export default class OperatorError extends Error {
 
       case 500:
       default:
+        console.error(
+          '[OperatorError::getErrorFromStatusCode] Error adding an order, status code:',
+          response.status || 'unknown'
+        )
         return 'Error adding an order'
     }
   }

--- a/src/custom/utils/operator/errors/OperatorError.ts
+++ b/src/custom/utils/operator/errors/OperatorError.ts
@@ -45,7 +45,9 @@ export default class OperatorError extends Error {
       const orderPostError: ApiErrorObject = await response.json()
 
       if (orderPostError.errorType) {
-        return OperatorError.apiErrorDetails[orderPostError.errorType]
+        const errorMessage = OperatorError.apiErrorDetails[orderPostError.errorType]
+        // shouldn't fall through as this error constructor expects the error code to exist but just in case
+        return errorMessage || 'Error type exists but no valid error details found.'
       } else {
         console.error('Unknown reason for bad order submission', orderPostError)
         return orderPostError.description

--- a/src/custom/utils/operator/errors/OperatorError.ts
+++ b/src/custom/utils/operator/errors/OperatorError.ts
@@ -14,7 +14,8 @@ export enum ApiErrorCodes {
   InsufficientFee = 'InsufficientFee',
   UnsupportedToken = 'UnsupportedToken',
   WrongOwner = 'WrongOwner',
-  NotFound = 'NotFound'
+  NotFound = 'NotFound',
+  UNHANDLED_ERROR = 'UNHANDLED_ERROR'
 }
 
 export enum ApiErrorCodeDetails {

--- a/src/custom/utils/operator/errors/QuoteError.ts
+++ b/src/custom/utils/operator/errors/QuoteError.ts
@@ -37,7 +37,7 @@ export default class QuoteError extends Error {
   // https://github.com/gnosis/gp-v2-services/blob/9014ae55412a356e46343e051aefeb683cc69c41/orderbook/openapi.yml#L563
   static quoteErrorDetails = QuoteErrorDetails
 
-  static async getErrorMessage(response: Response) {
+  private static async _getErrorMessage(response: Response) {
     try {
       const orderPostError: QuoteErrorObject = await response.json()
 
@@ -57,10 +57,14 @@ export default class QuoteError extends Error {
     switch (response.status) {
       case 400:
       case 404:
-        return this.getErrorMessage(response)
+        return this._getErrorMessage(response)
 
       case 500:
       default:
+        console.error(
+          '[QuoteError::getErrorFromStatusCode] Error fetching quote, status code:',
+          response.status || 'unknown'
+        )
         return 'Error fetching quote'
     }
   }

--- a/src/custom/utils/operator/errors/QuoteError.ts
+++ b/src/custom/utils/operator/errors/QuoteError.ts
@@ -16,10 +16,10 @@ export enum QuoteErrorCodes {
 export enum QuoteErrorDetails {
   InsufficientLiquidity = 'Token pair selected has insufficient liquidity',
   FeeExceedsFrom = 'Current fee exceeds input "from" amount',
-  UNHANDLED_ERROR = 'An unknown error occurred while fetching the quote'
+  UNHANDLED_ERROR = 'An error occurred while fetching quote information'
 }
 
-export function mapOperatorErrorToQuoteError(errorType: ApiErrorCodes): QuoteErrorObject {
+export function mapOperatorErrorToQuoteError(errorType?: ApiErrorCodes): QuoteErrorObject {
   switch (errorType) {
     case ApiErrorCodes.NotFound:
       return { errorType: QuoteErrorCodes.InsufficientLiquidity, description: QuoteErrorDetails.InsufficientLiquidity }

--- a/src/custom/utils/operator/errors/QuoteError.ts
+++ b/src/custom/utils/operator/errors/QuoteError.ts
@@ -16,7 +16,7 @@ export enum QuoteErrorCodes {
 export enum QuoteErrorDetails {
   InsufficientLiquidity = 'Token pair selected has insufficient liquidity',
   FeeExceedsFrom = 'Current fee exceeds input "from" amount',
-  UNHANDLED_ERROR = 'An error occurred while fetching quote information'
+  UNHANDLED_ERROR = 'An error occurred while fetching the quote information'
 }
 
 export function mapOperatorErrorToQuoteError(errorType?: ApiErrorCodes): QuoteErrorObject {

--- a/src/custom/utils/operator/errors/QuoteError.ts
+++ b/src/custom/utils/operator/errors/QuoteError.ts
@@ -42,7 +42,9 @@ export default class QuoteError extends Error {
       const orderPostError: QuoteErrorObject = await response.json()
 
       if (orderPostError.errorType) {
-        return QuoteError.quoteErrorDetails[orderPostError.errorType]
+        const errorMessage = QuoteError.quoteErrorDetails[orderPostError.errorType]
+        // shouldn't fall through as this error constructor expects the error code to exist but just in case
+        return errorMessage || 'Error type exists but no valid error details found.'
       } else {
         console.error('Unknown reason for bad quote fetch', orderPostError)
         return orderPostError.description

--- a/src/custom/utils/operator/index.ts
+++ b/src/custom/utils/operator/index.ts
@@ -186,21 +186,17 @@ async function _handleQuoteResponse(response: Response) {
 export async function getPriceQuote(params: PriceQuoteParams): Promise<PriceInformation> {
   const { baseToken, quoteToken, amount, kind, chainId } = params
   const [checkedBaseToken, checkedQuoteToken] = [checkIfEther(baseToken, chainId), checkIfEther(quoteToken, chainId)]
-  console.log('[util:operator] Get Price from API', params)
+  console.log('[util:operator] Get price from API', params)
 
-  try {
-    const response = await _fetchGet(
-      chainId,
-      `/markets/${toApiAddress(checkedBaseToken, chainId)}-${toApiAddress(
-        checkedQuoteToken,
-        chainId
-      )}/${kind}/${amount}`
-    )
-
-    return _handleQuoteResponse(response)
-  } catch (error) {
+  const response = await _fetchGet(
+    chainId,
+    `/markets/${toApiAddress(checkedBaseToken, chainId)}-${toApiAddress(checkedQuoteToken, chainId)}/${kind}/${amount}`
+  ).catch(error => {
+    console.error('Error getting price quote:', error)
     throw new QuoteError(UNHANDLED_QUOTE_ERROR)
-  }
+  })
+
+  return _handleQuoteResponse(response)
 }
 
 export async function getFeeQuote(params: FeeQuoteParams): Promise<FeeInformation> {
@@ -208,18 +204,18 @@ export async function getFeeQuote(params: FeeQuoteParams): Promise<FeeInformatio
   const [checkedSellAddress, checkedBuyAddress] = [checkIfEther(sellToken, chainId), checkIfEther(buyToken, chainId)]
   console.log('[util:operator] Get fee from API', params)
 
-  try {
-    const response = await _fetchGet(
-      chainId,
-      `/fee?sellToken=${toApiAddress(checkedSellAddress, chainId)}&buyToken=${toApiAddress(
-        checkedBuyAddress,
-        chainId
-      )}&amount=${amount}&kind=${kind}`
-    )
-    return _handleQuoteResponse(response)
-  } catch (error) {
+  const response = await _fetchGet(
+    chainId,
+    `/fee?sellToken=${toApiAddress(checkedSellAddress, chainId)}&buyToken=${toApiAddress(
+      checkedBuyAddress,
+      chainId
+    )}&amount=${amount}&kind=${kind}`
+  ).catch(error => {
+    console.error('Error getting fee quote:', error)
     throw new QuoteError(UNHANDLED_QUOTE_ERROR)
-  }
+  })
+
+  return _handleQuoteResponse(response)
 }
 
 export async function getOrder(chainId: ChainId, orderId: string): Promise<OrderMetaData | null> {
@@ -234,6 +230,7 @@ export async function getOrder(chainId: ChainId, orderId: string): Promise<Order
       return response.json()
     }
   } catch (error) {
+    console.error('Error getting order information:', error)
     throw new OperatorError(UNHANDLED_ORDER_ERROR)
   }
 }


### PR DESCRIPTION
Closes #738 part about handling quote fetch errors

Addresses comment by @alfetopito in #764 https://github.com/gnosis/cowswap/pull/766#discussion_r651130871

Handles errors for orders and quotes in the respective methods that fetch them. Shows user a message if an "unhandled" error occurs:

![image](https://user-images.githubusercontent.com/21335563/121969734-cd551780-cd6c-11eb-8231-1a7f59e30c2e.png)

## Testing
1. Networks tab: throttling > Offline
2. wait for offline fetch to fail, see message 