### PR TITLE
Fix cow loader icon click parent.

### DIFF
--- a/src/custom/components/ArrowWrapperLoader/index.tsx
+++ b/src/custom/components/ArrowWrapperLoader/index.tsx
@@ -1,29 +1,29 @@
 import React from 'react'
 import styled, { css } from 'styled-components'
 import loadingCowGif from 'assets/cow-swap/cow-load.gif'
+import { ArrowDown } from 'react-feather'
 import useLoadingWithTimeout from 'hooks/useLoadingWithTimeout'
 import { useIsQuoteRefreshing } from 'state/price/hooks'
 import { LONG_LOAD_THRESHOLD } from 'constants/index'
 
-export interface ArrowWrapperProps {
-  children: React.ReactNode
-}
+const ArrowDownIcon = styled(ArrowDown)<{ showLoader: boolean }>`
+  stroke: ${({ theme }) => theme.swap.arrowDown.color};
+  backface-visibility: hidden;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  padding: 4px;
+  margin: 0;
+  position: absolute;
 
-export function ArrowWrapperLoader({ children }: ArrowWrapperProps) {
-  const isRefreshingQuote = useIsQuoteRefreshing()
-  const showLoader = useLoadingWithTimeout(isRefreshingQuote, LONG_LOAD_THRESHOLD)
-
-  return (
-    <Wrapper showLoader={showLoader}>
-      {children}
-      {showLoader && (
-        <div>
-          <img src={loadingCowGif} alt="Loading prices..." />
-        </div>
-      )}
-    </Wrapper>
-  )
-}
+  ${({ showLoader }) =>
+    showLoader
+      ? css`
+          height: 0;
+          width: 0;
+        `
+      : null}
+`
 
 export const Wrapper = styled.div<{ showLoader: boolean }>`
   position: absolute;
@@ -42,28 +42,9 @@ export const Wrapper = styled.div<{ showLoader: boolean }>`
   transition: transform 0.25s;
 
   &:hover {
-    > svg {
+    ${ArrowDownIcon} {
       stroke: ${({ theme }) => theme.swap.arrowDown.colorHover};
     }
-  }
-
-  > svg {
-    stroke: ${({ theme }) => theme.swap.arrowDown.color};
-    backface-visibility: hidden;
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-    padding: 4px;
-    margin: 0;
-    position: absolute;
-
-    ${({ showLoader }) =>
-      showLoader
-        ? css`
-            height: 0;
-            width: 0;
-          `
-        : null}
   }
 
   > div {
@@ -93,7 +74,6 @@ export const Wrapper = styled.div<{ showLoader: boolean }>`
           overflow: visible;
           padding: 0;
           border: transparent;
-          cursor: initial;
           transform: translateX(-100%) rotateY(-180deg);
 
           &::before,
@@ -137,3 +117,28 @@ export const Wrapper = styled.div<{ showLoader: boolean }>`
         `
       : null}
 `
+
+export interface ArrowWrapperLoaderProps {
+  onSwitchTokens: () => void
+  setApprovalSubmitted: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+export function ArrowWrapperLoader({ onSwitchTokens, setApprovalSubmitted }: ArrowWrapperLoaderProps) {
+  const isRefreshingQuote = useIsQuoteRefreshing()
+  const showLoader = useLoadingWithTimeout(isRefreshingQuote, LONG_LOAD_THRESHOLD)
+  const handleClick = () => {
+    setApprovalSubmitted(false) // reset 2 step UI for approvals
+    onSwitchTokens()
+  }
+
+  return (
+    <Wrapper showLoader={showLoader} onClick={handleClick}>
+      <ArrowDownIcon showLoader={showLoader} />
+      {showLoader && (
+        <div>
+          <img src={loadingCowGif} alt="Loading prices..." />
+        </div>
+      )}
+    </Wrapper>
+  )
+}

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -430,8 +430,7 @@ export default function Swap({
                 justify={isExpertMode ? 'space-between' : 'center'}
                 // style={{ padding: '0 1rem' }}
               >
-                {/* <ArrowWrapper clickable> */}
-                <ArrowWrapperLoader>
+                {/* <ArrowWrapper clickable>
                   <ArrowDown
                     size="16"
                     onClick={() => {
@@ -440,8 +439,9 @@ export default function Swap({
                     }}
                     color={currencies[Field.INPUT] && currencies[Field.OUTPUT] ? theme.primary1 : theme.text2}
                   />
-                  {/* </ArrowWrapper> */}
-                </ArrowWrapperLoader>
+                  </ArrowWrapper> */}
+
+                <ArrowWrapperLoader onSwitchTokens={onSwitchTokens} setApprovalSubmitted={setApprovalSubmitted} />
                 {recipient === null && !showWrap && isExpertMode ? (
                   <LinkStyledButton id="add-recipient-button" onClick={() => onChangeRecipient('')}>
                     + Add a send (optional)

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -19,7 +19,7 @@ import QuestionHelper from 'components/QuestionHelper'
 import { ButtonError, ButtonPrimary } from 'components/Button'
 import EthWethWrap, { Props as EthWethWrapProps } from 'components/swap/EthWethWrap'
 import { useReplaceSwapState, useSwapState } from 'state/swap/hooks'
-import { ArrowWrapperLoader, ArrowWrapperProps, Wrapper as ArrowWrapper } from 'components/ArrowWrapperLoader'
+import { ArrowWrapperLoader, ArrowWrapperLoaderProps, Wrapper as ArrowWrapper } from 'components/ArrowWrapperLoader'
 import { LONG_LOAD_THRESHOLD } from 'constants/index'
 
 interface FeeGreaterMessageProp {
@@ -105,7 +105,7 @@ export interface SwapProps extends RouteComponentProps {
   BottomGrouping: React.FC
   TradeLoading: React.FC<TradeLoadingProps>
   SwapButton: React.FC<SwapButtonProps>
-  ArrowWrapperLoader: React.FC<ArrowWrapperProps>
+  ArrowWrapperLoader: React.FC<ArrowWrapperLoaderProps>
   className?: string
 }
 


### PR DESCRIPTION
This fix makes sure the whole parent container, holding both the switch icon and the COW animation, has a click event, switching the from/to fields.