### PR TITLE
Fix latest metamask release

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
   },
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@gnosis.pm/gp-v2-contracts": "^0.0.1-alpha.18",
+    "@gnosis.pm/gp-v2-contracts": "^0.0.1-alpha.20",
     "@gnosis.pm/cow-runner-game": "^0.2.2",
     "@uniswap/default-token-list": "^2.0.0",
     "@web3-react/walletconnect-connector": "^6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1679,10 +1679,10 @@
   resolved "https://registry.yarnpkg.com/@gnosis.pm/cow-runner-game/-/cow-runner-game-0.2.7.tgz#b4646e3dc6c890f2cf662b24533ec6e1ef111521"
   integrity sha512-tw84gdlRCzmdb/c9tEmqHZ7rvrMR9/+N4sMAz6BsArbA8Kve6adUN9UKkhdN2htlKnOqlTRqJZW9VPrCx9ZSNA==
 
-"@gnosis.pm/gp-v2-contracts@^0.0.1-alpha.18":
-  version "0.0.1-alpha.18"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/gp-v2-contracts/-/gp-v2-contracts-0.0.1-alpha.18.tgz#317ec588724713d067158293748cb1057a9d02a3"
-  integrity sha512-jOh0UHYA6W5q2840CKR6FWNxc0ARGs6ijSjPXbX6ytPU5c7uH5yrXM0Qvkogp4KWrnxtZQ9ptdA+nsVAgyDmRQ==
+"@gnosis.pm/gp-v2-contracts@^0.0.1-alpha.20":
+  version "0.0.1-alpha.20"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/gp-v2-contracts/-/gp-v2-contracts-0.0.1-alpha.20.tgz#8a53a1495c9dc356080b3ec3ec4f29808726952b"
+  integrity sha512-+R+JKMbzC4SDEdbg86yRbWEBom5ZW0eRGfvNCJ3qUg5KSNKJvA/2bCYHpfWBiQ7fETKHyYH2mlO3XziWplwa2A==
 
 "@hapi/address@2.x.x":
   version "2.1.4"


### PR DESCRIPTION
# Summary

On latest Metamask release (9.6.0), chainId is expected to be always a number.
See https://github.com/MetaMask/metamask-extension/issues/11308 for more details.

This causes the signature to fail:
![screenshot_2021-06-15_07-17-18](https://user-images.githubusercontent.com/43217/122104613-b34b2180-cdcc-11eb-9a5d-ca422b928d15.png)

And fallback to ETHSIGN:
![screenshot_2021-06-15_07-12-00](https://user-images.githubusercontent.com/43217/122104634-ba722f80-cdcc-11eb-892b-fe1dc076c94c.png)

This change uses the latest release of the contracts lib (https://github.com/gnosis/gp-v2-contracts/pull/692) that has a workaround to force chainId to be a number.

Hopefully, Metamask will release their fix (https://github.com/MetaMask/metamask-extension/pull/11309) faster than us, making this change unnecessary :crossed_fingers: 

# Testing

1. Place an order using Metamask - IMPORTANT: make sure you are on latest Metamask version (9.6.0)
- [ ] Message signature pop up should include all the typed data to be signed.
