### PR TITLE
[🔥🔥🔥HOTFIX] Adds: Bug fix - buy order fee breakdown incorrect amounts (#756)

### DIFF
--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -410,7 +410,9 @@ export default function Swap({
                   label={exactInLabel}
                   trade={trade}
                   showHelper={independentField === Field.OUTPUT}
-                  amountBeforeFees={trade?.inputAmount.toSignificant(DEFAULT_PRECISION)}
+                  amountBeforeFees={trade?.inputAmountWithFee
+                    .subtract(trade.fee.feeAsCurrency)
+                    .toSignificant(DEFAULT_PRECISION)}
                   amountAfterFees={trade?.inputAmountWithFee.toSignificant(DEFAULT_PRECISION)}
                   type="From"
                   feeAmount={trade?.fee?.feeAsCurrency?.toSignificant(DEFAULT_PRECISION)}


### PR DESCRIPTION
We should have this in prod now: (it's in dev rn)

Fixes issue for buy order fee breakdown showing incorrect amounts:
![image](https://user-images.githubusercontent.com/21335563/121365198-5cf36400-c930-11eb-9fce-06f0f49011ae.png)

Fix:
![image](https://user-images.githubusercontent.com/21335563/121365044-37665a80-c930-11eb-8cec-acc8354a984c.png)