### PR TITLE
130/new backend cancellation errors

### DIFF
--- a/src/custom/utils/operator/errors/OperatorError.ts
+++ b/src/custom/utils/operator/errors/OperatorError.ts
@@ -18,6 +18,9 @@ export enum ApiErrorCodes {
   WrongOwner = 'WrongOwner',
   NotFound = 'NotFound',
   OrderNotFound = 'OrderNotFound',
+  AlreadyCancelled = 'AlreadyCancelled',
+  OrderFullyExecuted = 'OrderFullyExecuted',
+  OrderExpired = 'OrderExpired',
   UNHANDLED_GET_ERROR = 'UNHANDLED_GET_ERROR',
   UNHANDLED_CREATE_ERROR = 'UNHANDLED_CREATE_ERROR',
   UNHANDLED_DELETE_ERROR = 'UNHANDLED_DELETE_ERROR'
@@ -34,6 +37,9 @@ export enum ApiErrorCodeDetails {
   WrongOwner = "The signature is invalid.\n\nIt's likely that the signing method provided by your wallet doesn't comply with the standards required by CowSwap.\n\nCheck whether your Wallet app supports off-chain signing (EIP-712 or ETHSIGN).",
   NotFound = 'Token pair selected has insufficient liquidity',
   OrderNotFound = 'The order you are trying to cancel does not exist',
+  AlreadyCancelled = 'Order is already cancelled',
+  OrderFullyExecuted = 'Order is already filled',
+  OrderExpired = 'Order is expired',
   UNHANDLED_GET_ERROR = 'Order fetch failed. This may be due to a server or network connectivity issue. Please try again later.',
   UNHANDLED_CREATE_ERROR = 'The order was not accepted by the network',
   UNHANDLED_DELETE_ERROR = 'The order cancellation was not accepted by the network'
@@ -45,7 +51,6 @@ function _mapActionToErrorDetail(action?: ApiActionType) {
       return ApiErrorCodeDetails.UNHANDLED_GET_ERROR
     case 'create':
       return ApiErrorCodeDetails.UNHANDLED_CREATE_ERROR
-    // default and last case..
     case 'delete':
       return ApiErrorCodeDetails.UNHANDLED_DELETE_ERROR
     default:


### PR DESCRIPTION
# Summary

Adds new errors from backend https://github.com/gnosis/gp-v2-services/pull/716

# Testing

It should not be possible to trigger those errors directly on the UI, only by a race condition or bug.
Still, you can force it locally by setting `isCancellable` to `true` https://github.com/gnosis/cowswap/blob/97b7d37db71cbadd11c17e67eadb61b494a926e1/src/custom/components/AccountDetails/Transaction.tsx#L216
Now every order can be cancelled, no matter the status.

Examples:
![screenshot_2021-06-17_09-47-32](https://user-images.githubusercontent.com/43217/122443562-93df0080-cf54-11eb-9d59-c3e958e9a003.png)
![screenshot_2021-06-17_09-45-19](https://user-images.githubusercontent.com/43217/122443565-94779700-cf54-11eb-8106-226096d0e2c5.png)
