### PR TITLE
Price timeout

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -61,7 +61,7 @@ export const INPUT_OUTPUT_EXPLANATION = 'Only executed swaps incur fees.'
 export const DEFAULT_ORDER_DELAY = 20000 // 20s
 export const PENDING_ORDERS_BUFFER = 60 * 1000 // 60s
 export const CANCELLED_ORDERS_PENDING_TIME = 5 * 60 * 1000 // 5min
-export const PRICE_API_TIMEOUT_MS = 500 // 0.5s
+export const PRICE_API_TIMEOUT_MS = 10000 // 10s
 
 export const WETH_LOGO_URI =
   'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png'

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -61,6 +61,7 @@ export const INPUT_OUTPUT_EXPLANATION = 'Only executed swaps incur fees.'
 export const DEFAULT_ORDER_DELAY = 20000 // 20s
 export const PENDING_ORDERS_BUFFER = 60 * 1000 // 60s
 export const CANCELLED_ORDERS_PENDING_TIME = 5 * 60 * 1000 // 5min
+export const PRICE_API_TIMEOUT_MS = 500 // 0.5s
 
 export const WETH_LOGO_URI =
   'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png'

--- a/src/custom/hooks/useRefetchPriceCallback.ts
+++ b/src/custom/hooks/useRefetchPriceCallback.ts
@@ -91,11 +91,13 @@ async function _getBestPriceQuote(params: PriceQuoteParams): Promise<PriceInform
   }
 
   if (errorsGetPrice.length > 0) {
-    console.error('[hooks::useRefetchPriceCallback] Some API failed or timed out', errorsGetPrice)
+    const sourceNames = errorsGetPrice.map(e => e.source).join(', ')
+    console.error('[hooks::useRefetchPriceCallback] Some API failed or timed out: ' + sourceNames, errorsGetPrice)
   }
-  console.log('[hooks::useRefetchPriceCallback] Get best price', priceQuotes)
 
   if (priceQuotes.length > 0) {
+    const sourceNames = priceQuotes.map(p => p.source).join(', ')
+    console.log('[hooks::useRefetchPriceCallback] Get best price succeeded for ' + sourceNames, priceQuotes)
     const amounts = priceQuotes.map(quote => quote.amount).filter(Boolean) as string[]
 
     // Take the best price: Aggregate all the amounts into a single one.
@@ -107,6 +109,12 @@ async function _getBestPriceQuote(params: PriceQuoteParams): Promise<PriceInform
     const amount = BigNumberJs[aggregationFunction](...amounts).toString(10)
     const token = priceQuotes[0].token
     // console.log('Aggregated amounts', aggregationFunction, amounts, amount)
+
+    const winningPrices = priceQuotes
+      .filter(quote => quote.amount === amount)
+      .map(p => p.source)
+      .join(', ')
+    console.log('[hooks::useRefetchPriceCallback] Winning price: ' + winningPrices)
 
     return { token, amount }
   } else {

--- a/src/custom/hooks/useRefetchPriceCallback.ts
+++ b/src/custom/hooks/useRefetchPriceCallback.ts
@@ -1,7 +1,13 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { useCallback } from 'react'
 import { useQuoteDispatchers } from 'state/price/hooks'
-import { getCanonicalMarket, registerOnWindow } from 'utils/misc'
+import {
+  getCanonicalMarket,
+  registerOnWindow,
+  withTimeout,
+  getPromiseFulfilledValue,
+  isPromiseFulfilled
+} from 'utils/misc'
 import { FeeQuoteParams, getFeeQuote, getPriceQuote, PriceQuoteParams } from 'utils/operator'
 import { getPriceQuote as getPriceQuoteParaswap, toPriceInformation } from 'utils/paraswap'
 import {
@@ -13,11 +19,11 @@ import { FeeInformation, PriceInformation, QuoteInformationObject } from 'state/
 import { AddGpUnsupportedTokenParams } from 'state/lists/actions'
 import { onlyResolvesLast } from 'utils/async'
 import { ClearQuoteParams, SetQuoteErrorParams } from 'state/price/actions'
-import { getPromiseFulfilledValue, isPromiseFulfilled } from 'utils/misc'
 import QuoteError, { QuoteErrorCodes, isValidQuoteError } from 'utils/operator/errors/QuoteError'
 import { ApiErrorCodes, isValidOperatorError } from 'utils/operator/errors/OperatorError'
 import BigNumberJs from 'bignumber.js'
 import { OrderKind } from '@gnosis.pm/gp-v2-contracts'
+import { PRICE_API_TIMEOUT_MS } from 'constants/index'
 
 export interface RefetchQuoteCallbackParams {
   quoteParams: FeeQuoteParams
@@ -49,6 +55,7 @@ class PriceQuoteError extends Error {
 
 type PriceSource = 'gnosis-protocol' | 'paraswap'
 type PriceInformationWithSource = PriceInformation & { source: PriceSource; data?: any }
+type PromiseRejectedResultWithSource = PromiseRejectedResult & { source: PriceSource }
 
 /**
  *
@@ -56,25 +63,37 @@ type PriceInformationWithSource = PriceInformation & { source: PriceSource; data
  */
 async function _getBestPriceQuote(params: PriceQuoteParams): Promise<PriceInformation> {
   // Get price from all API: Gpv2 and Paraswap
-  const pricePromise = getPriceQuote(params) // TODO: Add timeout (another PR)
-  const paraSwapPricePromise = getPriceQuoteParaswap(params) // TODO: Add timeout (another PR)
+  const pricePromise = withTimeout(getPriceQuote(params), PRICE_API_TIMEOUT_MS, 'GPv2: Get Price API')
+  const paraSwapPricePromise = withTimeout(
+    getPriceQuoteParaswap(params),
+    PRICE_API_TIMEOUT_MS,
+    'Paraswap: Get Price API'
+  )
 
   // Get results from API queries
   const [priceResult, paraSwapPriceResult] = await Promise.allSettled([pricePromise, paraSwapPricePromise])
-  const price = getPromiseFulfilledValue(priceResult, null)
-  const paraswapPriceRaw = getPromiseFulfilledValue(paraSwapPriceResult, null)
 
   // Prepare an array with all successful estimations
   const priceQuotes: Array<PriceInformationWithSource> = []
-  if (price) {
-    priceQuotes.push({ ...price, source: 'gnosis-protocol' })
-  }
-  if (paraswapPriceRaw) {
-    const paraswapPrice = toPriceInformation(paraswapPriceRaw)
-    paraswapPrice && priceQuotes.push({ ...paraswapPrice, source: 'paraswap', data: paraswapPriceRaw })
+  const errorsGetPrice: Array<PromiseRejectedResultWithSource> = []
+
+  if (isPromiseFulfilled(priceResult)) {
+    priceQuotes.push({ ...priceResult.value, source: 'gnosis-protocol' })
+  } else {
+    errorsGetPrice.push({ ...priceResult, source: 'gnosis-protocol' })
   }
 
-  console.log('[hooks::useRefetchPriceCallback] _getBestPriceQuote', priceQuotes)
+  if (isPromiseFulfilled(paraSwapPriceResult)) {
+    const paraswapPrice = toPriceInformation(paraSwapPriceResult.value)
+    paraswapPrice && priceQuotes.push({ ...paraswapPrice, source: 'paraswap', data: paraSwapPriceResult.value })
+  } else {
+    errorsGetPrice.push({ ...paraSwapPriceResult, source: 'paraswap' })
+  }
+
+  if (errorsGetPrice.length > 0) {
+    console.error('[hooks::useRefetchPriceCallback] Some API failed or timed out', errorsGetPrice)
+  }
+  console.log('[hooks::useRefetchPriceCallback] Get best price', priceQuotes)
 
   if (priceQuotes.length > 0) {
     const amounts = priceQuotes.map(quote => quote.amount).filter(Boolean) as string[]

--- a/src/custom/utils/misc.ts
+++ b/src/custom/utils/misc.ts
@@ -6,6 +6,15 @@ export const isTruthy = <T>(value: T | null | undefined | false): value is T => 
 export const delay = <T = void>(ms = 100, result?: T): Promise<T> =>
   new Promise(resolve => setTimeout(resolve, ms, result))
 
+export function withTimeout<T>(promise: Promise<T>, ms: number, context?: string): Promise<T> {
+  const failOnTimeout = delay(ms).then(() => {
+    const errorMessage = 'Timeout after ' + ms + ' ms'
+    throw new Error(context ? `${context}. ${errorMessage}` : errorMessage)
+  })
+
+  return Promise.race([promise, failOnTimeout])
+}
+
 export function isPromiseFulfilled<T>(
   promiseResult: PromiseSettledResult<T>
 ): promiseResult is PromiseFulfilledResult<T> {


### PR DESCRIPTION
Part of #780 

This PR adds a timeout for APIs that takes too long to complete. If it takes more than 10 seconds, it for any of the APIs, it will try to get by with the results of the other price estimations.

This PR also improves the logged information. I highlighted in the screenshot the new messages. Basically now you can see:
- The details of the failed price queries. Before it was failing silently! Very bad... 
- It also shows the name of the source that failed
- It shows the name of the sources that succeed
- It show the winning price (or prices if they have the same)

![image](https://user-images.githubusercontent.com/2352112/123105463-20e3f700-d438-11eb-8459-2d89d8eba967.png)
