### PR TITLE
Add coingecko list

### DIFF
--- a/src/custom/constants/lists.ts
+++ b/src/custom/constants/lists.ts
@@ -13,7 +13,7 @@ const WRAPPED_LIST = 'wrapped.tokensoft.eth'
 const SET_LIST = 'https://raw.githubusercontent.com/SetProtocol/uniswap-tokenlist/main/set.tokenlist.json'
 const OPYN_LIST = 'https://raw.githubusercontent.com/opynfinance/opyn-tokenlist/master/opyn-v1.tokenlist.json'
 const ROLL_LIST = 'https://app.tryroll.com/tokens.json'
-// const COINGECKO_LIST = 'https://tokens.coingecko.com/uniswap/all.json'
+const COINGECKO_LIST = 'https://tokens.coingecko.com/uniswap/all.json'
 const CMC_ALL_LIST = 'defi.cmc.eth'
 const CMC_STABLECOIN = 'stablecoin.cmc.eth'
 const KLEROS_LIST = 't2crtokens.eth'
@@ -56,7 +56,7 @@ export const DEFAULT_LIST_OF_LISTS_BY_NETWORK: NetworkLists = {
       SET_LIST,
       OPYN_LIST,
       ROLL_LIST,
-      // COINGECKO_LIST,
+      COINGECKO_LIST,
       CMC_ALL_LIST,
       CMC_STABLECOIN,
       KLEROS_LIST,


### PR DESCRIPTION
Not 100% sure if we should merge, in local it was having some sluggish behaviour. 

This coingecko list is huge! and the token logic is inneficient. We should see if uni-v3 improves or maybe we can do sth ourselves. 

Anyways, I want to see if the PRODUCTION version has better performance.