### PR TITLE
[Error handling] Model UI errors

### DIFF
--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -60,7 +60,6 @@ import { SwapProps } from '.'
 import { useWalletInfo } from 'hooks/useWalletInfo'
 import { HashLink } from 'react-router-hash-link'
 import { logTradeDetails } from 'state/swap/utils'
-import { isInsufficientLiquidityError } from 'state/price/utils'
 import { useGetQuoteAndStatus } from 'state/price/hooks'
 import TradeGp from '@src/custom/state/swap/TradeGp'
 
@@ -552,7 +551,7 @@ export default function Swap({
               <SwitchToWethBtn wrappedToken={wrappedToken} />
             ) : isFeeGreater ? (
               <FeesExceedFromAmountMessage />
-            ) : isInsufficientLiquidityError(quote?.error) ? (
+            ) : quote?.error === 'insufficient-liquidity' ? (
               // ) : noRoute && userHasSpecifiedInputOutput ? (
               <GreyCard style={{ textAlign: 'center' }}>
                 <TYPE.main mb="4px">Insufficient liquidity for this trade.</TYPE.main>

--- a/src/custom/state/price/actions.ts
+++ b/src/custom/state/price/actions.ts
@@ -1,5 +1,4 @@
 import { createAction } from '@reduxjs/toolkit'
-import { ApiErrorCodes } from 'utils/operator/error'
 import { ChainId } from '@uniswap/sdk'
 import { QuoteInformationObject } from './reducer'
 
@@ -18,7 +17,13 @@ export interface SetLoadingQuoteParams {
   quoteData: Pick<QuoteInformationObject, 'sellToken' | 'chainId'>
 }
 
-export type SetQuoteErrorParams = UpdateQuoteParams & { error: ApiErrorCodes }
+export type QuoteError =
+  | 'fetch-quote-error'
+  | 'insufficient-liquidity'
+  | 'fee-exceeds-sell-amount'
+  | 'unsupported-token'
+
+export type SetQuoteErrorParams = UpdateQuoteParams & { error: QuoteError }
 
 export const setNewQuoteLoading = createAction<SetLoadingQuoteParams>('price/setNewQuoteLoading')
 export const setRefreshQuoteLoading = createAction<Pick<SetLoadingQuoteParams, 'loading'>>(

--- a/src/custom/state/price/reducer.ts
+++ b/src/custom/state/price/reducer.ts
@@ -1,10 +1,16 @@
 import { createReducer, PayloadAction } from '@reduxjs/toolkit'
 import { ChainId } from '@uniswap/sdk'
-import { updateQuote, clearQuote, setQuoteError, setNewQuoteLoading, setRefreshQuoteLoading } from './actions'
+import {
+  updateQuote,
+  clearQuote,
+  setQuoteError,
+  setNewQuoteLoading,
+  setRefreshQuoteLoading,
+  QuoteError
+} from './actions'
 import { Writable } from 'custom/types'
 import { PrefillStateRequired } from '../orders/reducer'
 import { FeeQuoteParams } from 'utils/operator'
-import { ApiErrorCodes } from 'utils/operator/error'
 
 // API Doc: https://protocol-rinkeby.dev.gnosisdev.com/api
 
@@ -26,7 +32,7 @@ export interface PriceInformation {
 export interface QuoteInformationObject extends FeeQuoteParams {
   fee?: FeeInformation
   price?: PriceInformation
-  error?: ApiErrorCodes
+  error?: QuoteError
   lastCheck: number
 }
 

--- a/src/custom/state/price/utils.ts
+++ b/src/custom/state/price/utils.ts
@@ -1,9 +1,0 @@
-import { ApiErrorCodes } from 'utils/operator/error'
-
-export function isFeeGreaterThanPriceError(error?: ApiErrorCodes): boolean {
-  return error === ApiErrorCodes.FeeExceedsFrom
-}
-
-export function isInsufficientLiquidityError(error?: ApiErrorCodes): boolean {
-  return error === ApiErrorCodes.NotFound
-}

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -25,7 +25,6 @@ import { ParsedQs } from 'qs'
 import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
 import { WETH_LOGO_URI, XDAI_LOGO_URI } from 'constants/index'
 import { WrappedTokenInfo } from '../lists/hooks'
-import { isFeeGreaterThanPriceError } from '../price/utils'
 import TradeGp from './TradeGp'
 
 export * from '@src/state/swap/hooks'
@@ -276,7 +275,7 @@ export function useIsFeeGreaterThanInput({
   if (!quote || !feeToken) return { isFeeGreater: false, fee: null }
 
   return {
-    isFeeGreater: isFeeGreaterThanPriceError(quote.error),
+    isFeeGreater: quote.error === 'fee-exceeds-sell-amount',
     fee: quote.fee ? stringToCurrency(quote.fee.amount, feeToken) : null
   }
 }


### PR DESCRIPTION
In order to deploy `v0.15` we need to fix some issues with the error handling.

This will be the PR out in tree PRs. Is better not to test the UI until the second one. The only reason I splited this in two was to make it easier to review

## About this PR
The main differents on how the state is managed now are:
- Now, the function that handles errors always calls to clearQuote and setError. Before, it was happening only for some cases.
- This UI error doesn't have to do with the API anymore, we create one error for each thing we handle.
- The QuoteError has this values:
```
export type QuoteError =
  | 'fetch-quote-error'
  | 'insufficient-liquidity'
  | 'fee-exceeds-sell-amount'
  | 'unsupported-token'
```

I added some pointers in the code to explain the changes

## Next PR
#806 Model the actions closer to real UI actions:
* `getNewQuoteStart`:  Signal that now is fetching a new price, invalidating any previous price and activating the loader
* `refreshQuoteStart`: Signal that now is refreshing the current price, activating the loader
* `updateQuote`: We have a new price, this actions updates it and deactivate the loader
* `setQuoteError`: There was an error getting the new price or refreshing, this actions updates it and deactivate the loader

## Context about why this change
This PR is kind of similar to #770, but solves it in a different way. Also, #770 was applied only in develop, and we need this fix in for the release. 

These changes was what I was hinting on doing when I was reviewing the error handling. Basically, model our own errors independently of the API, also model the actions that modify the price state, but not as plain mutators of state functions, but as real actions. Maybe seeing the changes becomes more clear what I mean. 



