### PR TITLE
Add decimals to fix issue with Paraswap

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -5,6 +5,7 @@ import { SUPPORTED_WALLETS as SUPPORTED_WALLETS_UNISWAP, WalletInfo } from '@src
 export const RADIX_DECIMAL = 10
 export const RADIX_HEX = 16
 
+export const DEFAULT_DECIMALS = 18
 export const DEFAULT_PRECISION = 6
 export const SHORT_PRECISION = 4
 export const SHORTEST_PRECISION = 3

--- a/src/custom/hooks/useRefetchPriceCallback.ts
+++ b/src/custom/hooks/useRefetchPriceCallback.ts
@@ -123,13 +123,13 @@ async function _getBestPriceQuote(params: PriceQuoteParams): Promise<PriceInform
 }
 
 async function _getQuote({ quoteParams, fetchFee, previousFee }: RefetchQuoteCallbackParams): Promise<QuoteResult> {
-  const { sellToken, buyToken, amount, kind, chainId } = quoteParams
+  const { sellToken, buyToken, fromDecimals, toDecimals, amount, kind, chainId } = quoteParams
   const { baseToken, quoteToken } = getCanonicalMarket({ sellToken, buyToken, kind })
 
   // Get a new fee quote (if required)
   const feePromise =
     fetchFee || !previousFee
-      ? getFeeQuote({ chainId, sellToken, buyToken, amount, kind })
+      ? getFeeQuote({ chainId, sellToken, buyToken, fromDecimals, toDecimals, amount, kind })
       : Promise.resolve(previousFee)
 
   // Get a new price quote
@@ -152,7 +152,7 @@ async function _getQuote({ quoteParams, fetchFee, previousFee }: RefetchQuoteCal
   // Get price for price estimation
   const pricePromise =
     !feeExceedsPrice && exchangeAmount
-      ? _getBestPriceQuote({ chainId, baseToken, quoteToken, amount: exchangeAmount, kind })
+      ? _getBestPriceQuote({ chainId, baseToken, quoteToken, fromDecimals, toDecimals, amount: exchangeAmount, kind })
       : // fee exceeds our price, is invalid
         Promise.reject(
           new OperatorError({

--- a/src/custom/hooks/useRefetchPriceCallback.ts
+++ b/src/custom/hooks/useRefetchPriceCallback.ts
@@ -27,6 +27,7 @@ import BigNumberJs from 'bignumber.js'
 import { OrderKind } from '@gnosis.pm/gp-v2-contracts'
 import { PRICE_API_TIMEOUT_MS } from 'constants/index'
 import { isOnline } from 'hooks/useIsOnline'
+import { formatAtoms } from 'utils/format'
 
 export interface RefetchQuoteCallbackParams {
   quoteParams: FeeQuoteParams
@@ -132,6 +133,12 @@ async function _getQuote({ quoteParams, fetchFee, previousFee }: RefetchQuoteCal
       ? getFeeQuote({ chainId, sellToken, buyToken, fromDecimals, toDecimals, amount, kind })
       : Promise.resolve(previousFee)
 
+  // Log fee for debugging
+  feePromise.then(fee => {
+    console.log(`Fee: ${formatAtoms(fee.amount, fromDecimals)} (in atoms ${fee.amount})`)
+    return fee
+  })
+
   // Get a new price quote
   let exchangeAmount
   let feeExceedsPrice = false
@@ -140,6 +147,8 @@ async function _getQuote({ quoteParams, fetchFee, previousFee }: RefetchQuoteCal
     // we need to check for 0/negative exchangeAmount should fee >= amount
     const { amount: fee } = await feePromise
     const result = BigNumber.from(amount).sub(fee)
+    console.log(`Sell amount before fee: ${formatAtoms(amount, fromDecimals)}  (in atoms ${amount})`)
+    console.log(`Sell amount after fee: ${formatAtoms(result.toString(), fromDecimals)}  (in atoms ${result})`)
 
     feeExceedsPrice = result.lte('0')
 

--- a/src/custom/state/price/reducer.ts
+++ b/src/custom/state/price/reducer.ts
@@ -67,7 +67,7 @@ export default createReducer(initialState, builder =>
      */
     .addCase(getNewQuoteStart, (state, action) => {
       const quoteData = action.payload
-      const { sellToken, buyToken, amount, chainId, kind } = quoteData
+      const { sellToken, buyToken, fromDecimals, toDecimals, amount, chainId, kind } = quoteData
       initializeState(state.quotes, action)
 
       // Reset quote params
@@ -75,6 +75,8 @@ export default createReducer(initialState, builder =>
       quotes[sellToken] = {
         sellToken,
         buyToken,
+        fromDecimals,
+        toDecimals,
         amount,
         chainId,
         kind,

--- a/src/custom/state/price/updater.ts
+++ b/src/custom/state/price/updater.ts
@@ -11,6 +11,7 @@ import { QuoteInformationObject } from './reducer'
 import { useIsUnsupportedTokenGp } from 'state/lists/hooks/hooksMod'
 import useDebounceWithForceUpdate from 'hooks/useDebounceWithForceUpdate'
 import useIsOnline from 'hooks/useIsOnline'
+import { DEFAULT_DECIMALS } from '@src/custom/constants'
 
 const DEBOUNCE_TIME = 350
 const REFETCH_CHECK_INTERVAL = 10000 // Every 10s
@@ -144,7 +145,9 @@ export default function FeesUpdater(): null {
     const amount = tryParseAmount(typedValue, (kind === 'sell' ? sellCurrency : buyCurrency) ?? undefined)
     if (!amount) return
 
-    const quoteParams = { buyToken, chainId, sellToken, kind, amount: amount.raw.toString() }
+    const fromDecimals = sellCurrency?.decimals ?? DEFAULT_DECIMALS
+    const toDecimals = buyCurrency?.decimals ?? DEFAULT_DECIMALS
+    const quoteParams = { chainId, sellToken, buyToken, fromDecimals, toDecimals, kind, amount: amount.raw.toString() }
 
     // Don't refetch if offline.
     //  Also, make sure we update the error state

--- a/src/custom/state/price/updater.ts
+++ b/src/custom/state/price/updater.ts
@@ -11,7 +11,7 @@ import { QuoteInformationObject } from './reducer'
 import { useIsUnsupportedTokenGp } from 'state/lists/hooks/hooksMod'
 import useDebounceWithForceUpdate from 'hooks/useDebounceWithForceUpdate'
 import useIsOnline from 'hooks/useIsOnline'
-import { DEFAULT_DECIMALS } from '@src/custom/constants'
+import { DEFAULT_DECIMALS } from 'custom/constants'
 
 const DEBOUNCE_TIME = 350
 const REFETCH_CHECK_INTERVAL = 10000 // Every 10s

--- a/src/custom/utils/format.ts
+++ b/src/custom/utils/format.ts
@@ -1,0 +1,7 @@
+import BigNumber from 'bignumber.js'
+
+const TEN = new BigNumber(10)
+
+export function formatAtoms(amount: string, decimals: number): string {
+  return new BigNumber(amount).div(TEN.pow(decimals)).toString(10)
+}

--- a/src/custom/utils/operator/index.ts
+++ b/src/custom/utils/operator/index.ts
@@ -130,11 +130,15 @@ export async function postSignedOrder(params: {
 export type FeeQuoteParams = Pick<OrderMetaData, 'sellToken' | 'buyToken' | 'kind'> & {
   amount: string
   chainId: ChainId
+  fromDecimals: number
+  toDecimals: number
 }
 
 export type PriceQuoteParams = Omit<FeeQuoteParams, 'sellToken' | 'buyToken'> & {
   baseToken: string
   quoteToken: string
+  fromDecimals: number
+  toDecimals: number
 }
 
 async function _getJson(chainId: ChainId, url: string): Promise<any> {

--- a/src/custom/utils/paraswap.ts
+++ b/src/custom/utils/paraswap.ts
@@ -54,7 +54,7 @@ function isGetRateSuccess(
 }
 
 export async function getPriceQuote(params: PriceQuoteParams): Promise<ParaSwapPriceQuote | null> {
-  const { baseToken: baseTokenAux, quoteToken: quoteTokenAux, amount, kind, chainId } = params
+  const { baseToken: baseTokenAux, quoteToken: quoteTokenAux, fromDecimals, toDecimals, amount, kind, chainId } = params
   const baseToken = toErc20Address(baseTokenAux, chainId)
   const quoteToken = toErc20Address(quoteTokenAux, chainId)
 
@@ -79,7 +79,7 @@ export async function getPriceQuote(params: PriceQuoteParams): Promise<ParaSwapP
   const options: RateOptions | undefined = undefined
 
   // Get price
-  const rateResult = await paraSwap.getRate(sellToken, buyToken, amount, swapSide, options)
+  const rateResult = await paraSwap.getRate(sellToken, buyToken, amount, swapSide, options, fromDecimals, toDecimals)
 
   if (isGetRateSuccess(rateResult)) {
     // Success getting the price


### PR DESCRIPTION
Paraswap price is failing for some tokens

## Context: 
https://gnosisinc.slack.com/archives/C0203Q9R4JJ/p1625039735002400

I just notice, we get an error with this endpoint:
https://apiv4.paraswap.io/v2/prices/?from=0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D&[…]083C756Cc2&amount=4668313438455293225856&side=SELL&network=1

However, if you specify the decimals, it works:
https://apiv4.paraswap.io/v2/prices/?from=0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D&[…]0000000000&fromDecimals=18&toDecimals=18&side=SELL&network=1

I was kind of assuming the decimals were optional if they are readable in the contract ... but is not the case!
https://etherscan.io/address/0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D#readContract


## Screenshot

![image](https://user-images.githubusercontent.com/2352112/123928627-5fc10200-d98e-11eb-938e-a4adb107f8fb.png)

## Test
To see the problem, use LQTY in in Staging. It will only return GP price and it will fail for Paraswap. Test:
- Add LQTY by address `0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D `
- Get an estimation
- Notice the error in the console, and the estimation is worse than Paraswap

TheIn this PR should work!
* Repeat

More tests. Maybe, try weird tokens? 
