### PR TITLE
815 - Show loader when wallet disconnected

### DIFF
--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -535,7 +535,9 @@ export default function Swap({
               </ButtonPrimary>
             ) : !account ? (
               <ButtonLight buttonSize={ButtonSize.BIG} onClick={toggleWalletModal}>
-                Connect Wallet
+                <SwapButton showLoading={swapBlankState || isGettingNewQuote}>
+                  Connect Wallet
+                </SwapButton>
               </ButtonLight>
             ) : !isSupportedWallet ? (
               <ButtonError buttonSize={ButtonSize.BIG} id="swap-button" disabled={!isSupportedWallet}>


### PR DESCRIPTION
Closes #815 

Adds loading spinner to "Connect Wallet" button

## Testing
1. be disconnected
2. input amounts
3. observe loader