### PR TITLE
Fix reverse logic amount beforee fees

### DIFF
--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -375,7 +375,7 @@ export default function Swap({
   const swapBlankState = !swapInputError && !trade
   let amountBeforeFees: string | undefined
   if (trade) {
-    if (trade.tradeType === TradeType.EXACT_INPUT && trade.inputAmountWithFee.greaterThan(trade.fee.amount)) {
+    if (trade.tradeType === TradeType.EXACT_INPUT && trade.inputAmountWithFee.lessThan(trade.fee.amount)) {
       amountBeforeFees = '0'
     } else {
       amountBeforeFees = trade.inputAmountWithFee.subtract(trade.fee.feeAsCurrency).toSignificant(DEFAULT_PRECISION)
@@ -540,9 +540,7 @@ export default function Swap({
               </ButtonPrimary>
             ) : !account ? (
               <ButtonLight buttonSize={ButtonSize.BIG} onClick={toggleWalletModal}>
-                <SwapButton showLoading={swapBlankState || isGettingNewQuote}>
-                  Connect Wallet
-                </SwapButton>
+                <SwapButton showLoading={swapBlankState || isGettingNewQuote}>Connect Wallet</SwapButton>
               </ButtonLight>
             ) : !isSupportedWallet ? (
               <ButtonError buttonSize={ButtonSize.BIG} id="swap-button" disabled={!isSupportedWallet}>


### PR DESCRIPTION
The logic was reversed!


I managed to reproduce with:
- Select WETH-DAI
- input 0.01, wait until it says that the fee excedes the amount
- change it to 0.02 --> it should break in production, but not in this PR