### PR TITLE
Handle price impact error

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "@gnosis.pm/gp-v2-contracts": "^0.0.1-alpha.20",
     "@uniswap/default-token-list": "^2.0.0",
     "@web3-react/walletconnect-connector": "^6.2.0",
-    "paraswap": "^4.15.0",
+    "paraswap": "^4.18.0",
     "react-appzi": "^1.0.4",
     "react-router-hash-link": "^2.4.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13240,10 +13240,10 @@ param-case@^3.0.3:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
-paraswap@^4.15.0:
-  version "4.15.0"
-  resolved "https://registry.yarnpkg.com/paraswap/-/paraswap-4.15.0.tgz#b7110a91a1489ca9ec0ec2c393de8cf7a3b6797d"
-  integrity sha512-2T3iiwQgoX6E+m32X8RaGlXeeK9OvITmi0tllNuvkZRbWB556F7RSc5tvBMf+nJYg97aw9Q7Pq4s+OaKG/uPhA==
+paraswap@^4.18.0:
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/paraswap/-/paraswap-4.18.0.tgz#d032d1a6ad7869f192a69283126d10c48d78b1e8"
+  integrity sha512-509oTtd1B1/RO49dW6U5t/9UvhAGNp4Vq7xXEFR4t1mCYDgahbtSbvJNWllqy34jGT0eKFrqLMyXnr2hPi4B7Q==
   dependencies:
     "@0x/utils" "^4.5.2"
     async "^3.1.0"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2352112/124129584-37183580-da7e-11eb-9349-be07495558ae.png)

Closes #835 #825

You can see in the picture how we receive now more tokens in these situations than current production version. 

Related to https://github.com/gnosis/cowswap/pull/839, which will make the error to go away, so it's not a 400 anymore. 
Anyways, I think for resiliance is good to also do this error handling on top of https://github.com/gnosis/cowswap/pull/839.
Bot PRs independently solve the issue, but is good to have both