### PR TITLE
Fix small issue return type

### DIFF
--- a/src/custom/utils/paraswap.ts
+++ b/src/custom/utils/paraswap.ts
@@ -58,7 +58,7 @@ function getPriceQuoteFromError(error: APIError): ParaSwapPriceQuote | null {
     // If the price impact is too big, it still give you the estimation
     return error.data.priceRoute
   } else {
-    throw error
+    return null
   }
 }
 


### PR DESCRIPTION
It was meant to return null. It was still being handle as an error, it was still handled but it's more correct that the getter returns null or the extracted price quote