### PR TITLE
Remove start from names (#820)

### DIFF
--- a/src/custom/hooks/useIsOnline.ts
+++ b/src/custom/hooks/useIsOnline.ts
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useState } from 'react'
 
+const IS_SUPPORTED = navigator.onLine !== undefined
+
 export function isOnline() {
-  return window.navigator.onLine
+  return window.navigator.onLine || !IS_SUPPORTED
 }
 
 /**

--- a/src/custom/hooks/useRefetchPriceCallback.ts
+++ b/src/custom/hooks/useRefetchPriceCallback.ts
@@ -232,13 +232,13 @@ function _handleQuoteError({ quoteData, error, addUnsupportedToken }: HandleQuot
 export function useRefetchQuoteCallback() {
   const isUnsupportedTokenGp = useIsUnsupportedTokenGp()
   // dispatchers
-  const { getNewQuoteStart, refreshQuoteStart, updateQuote, setQuoteError } = useQuoteDispatchers()
+  const { getNewQuote, refreshQuote, updateQuote, setQuoteError } = useQuoteDispatchers()
   const addUnsupportedToken = useAddGpUnsupportedToken()
   const removeGpUnsupportedToken = useRemoveGpUnsupportedToken()
 
   registerOnWindow({
-    getNewQuoteStart,
-    refreshQuoteStart,
+    getNewQuote,
+    refreshQuote,
     updateQuote,
     setQuoteError,
     addUnsupportedToken,
@@ -255,10 +255,10 @@ export function useRefetchQuoteCallback() {
         // Start action: Either new quote or refreshing quote
         if (isPriceRefresh) {
           // Refresh the quote
-          refreshQuoteStart({ sellToken, chainId })
+          refreshQuote({ sellToken, chainId })
         } else {
           // Get new quote
-          getNewQuoteStart(quoteParams)
+          getNewQuote(quoteParams)
         }
 
         // Get the quote
@@ -327,8 +327,8 @@ export function useRefetchQuoteCallback() {
       removeGpUnsupportedToken,
       setQuoteError,
       addUnsupportedToken,
-      getNewQuoteStart,
-      refreshQuoteStart
+      getNewQuote,
+      refreshQuote
     ]
   )
 }

--- a/src/custom/state/price/actions.ts
+++ b/src/custom/state/price/actions.ts
@@ -10,8 +10,8 @@ export interface ClearQuoteParams {
   chainId: ChainId
 }
 
-export type GetQuoteStartParams = FeeQuoteParams
-export type RefreshQuoteParams = Pick<GetQuoteStartParams, 'sellToken' | 'chainId'>
+export type GetQuoteParams = FeeQuoteParams
+export type RefreshQuoteParams = Pick<GetQuoteParams, 'sellToken' | 'chainId'>
 
 export type QuoteError =
   | 'fetch-quote-error'
@@ -22,7 +22,7 @@ export type QuoteError =
 
 export type SetQuoteErrorParams = UpdateQuoteParams & { error?: QuoteError }
 
-export const getNewQuoteStart = createAction<GetQuoteStartParams>('price/getNewQuoteStart')
-export const refreshQuoteStart = createAction<RefreshQuoteParams>('price/refreshQuoteStart')
+export const getNewQuote = createAction<GetQuoteParams>('price/getNewQuote')
+export const refreshQuote = createAction<RefreshQuoteParams>('price/refreshQuote')
 export const updateQuote = createAction<UpdateQuoteParams>('price/updateQuote')
 export const setQuoteError = createAction<SetQuoteErrorParams>('price/setQuoteError')

--- a/src/custom/state/price/hooks.ts
+++ b/src/custom/state/price/hooks.ts
@@ -8,17 +8,17 @@ import {
   updateQuote,
   UpdateQuoteParams,
   ClearQuoteParams,
-  getNewQuoteStart,
-  GetQuoteStartParams,
-  refreshQuoteStart,
+  getNewQuote,
+  GetQuoteParams,
+  refreshQuote,
   SetQuoteErrorParams,
   setQuoteError,
   RefreshQuoteParams
 } from './actions'
 import { QuoteInformationObject, QuotesMap } from './reducer'
 
-type GetNewQuoteStartCallback = (params: GetQuoteStartParams) => void
-type RefreshQuoteStartCallback = (params: RefreshQuoteParams) => void
+type GetNewQuoteCallback = (params: GetQuoteParams) => void
+type RefreshQuoteCallback = (params: RefreshQuoteParams) => void
 type AddPriceCallback = (params: UpdateQuoteParams) => void
 type SetQuoteErrorCallback = (params: SetQuoteErrorParams) => void
 
@@ -75,14 +75,14 @@ export function useIsQuoteRefreshing() {
   return isRefreshingQuote
 }
 
-export const useGetNewQuoteStart = (): GetNewQuoteStartCallback => {
+export const useGetNewQuote = (): GetNewQuoteCallback => {
   const dispatch = useDispatch<AppDispatch>()
-  return useCallback((params: GetQuoteStartParams) => dispatch(getNewQuoteStart(params)), [dispatch])
+  return useCallback((params: GetQuoteParams) => dispatch(getNewQuote(params)), [dispatch])
 }
 
-export const useRefreshQuoteStart = (): RefreshQuoteStartCallback => {
+export const useRefreshQuote = (): RefreshQuoteCallback => {
   const dispatch = useDispatch<AppDispatch>()
-  return useCallback((params: RefreshQuoteParams) => dispatch(refreshQuoteStart(params)), [dispatch])
+  return useCallback((params: RefreshQuoteParams) => dispatch(refreshQuote(params)), [dispatch])
 }
 
 export const useUpdateQuote = (): AddPriceCallback => {
@@ -96,16 +96,16 @@ export const useSetQuoteError = (): SetQuoteErrorCallback => {
 }
 
 interface QuoteDispatchers {
-  getNewQuoteStart: GetNewQuoteStartCallback
-  refreshQuoteStart: RefreshQuoteStartCallback
+  getNewQuote: GetNewQuoteCallback
+  refreshQuote: RefreshQuoteCallback
   updateQuote: AddPriceCallback
   setQuoteError: SetQuoteErrorCallback
 }
 
 export const useQuoteDispatchers = (): QuoteDispatchers => {
   return {
-    getNewQuoteStart: useGetNewQuoteStart(),
-    refreshQuoteStart: useRefreshQuoteStart(),
+    getNewQuote: useGetNewQuote(),
+    refreshQuote: useRefreshQuote(),
     updateQuote: useUpdateQuote(),
     setQuoteError: useSetQuoteError()
   }

--- a/src/custom/state/price/reducer.ts
+++ b/src/custom/state/price/reducer.ts
@@ -1,6 +1,6 @@
 import { createReducer, PayloadAction } from '@reduxjs/toolkit'
 import { ChainId } from '@uniswap/sdk'
-import { updateQuote, setQuoteError, getNewQuoteStart, refreshQuoteStart, QuoteError } from './actions'
+import { updateQuote, setQuoteError, getNewQuote, refreshQuote, QuoteError } from './actions'
 import { Writable } from 'custom/types'
 import { PrefillStateRequired } from '../orders/reducer'
 import { FeeQuoteParams } from 'utils/operator'
@@ -65,7 +65,7 @@ export default createReducer(initialState, builder =>
     /**
      * Gets a new quote
      */
-    .addCase(getNewQuoteStart, (state, action) => {
+    .addCase(getNewQuote, (state, action) => {
       const quoteData = action.payload
       const { sellToken, buyToken, amount, chainId, kind } = quoteData
       initializeState(state.quotes, action)
@@ -91,7 +91,7 @@ export default createReducer(initialState, builder =>
     /**
      * Refresh quote
      */
-    .addCase(refreshQuoteStart, (state, action) => {
+    .addCase(refreshQuote, (state, action) => {
       const quoteData = action.payload
       const { sellToken, chainId } = quoteData
       initializeState(state.quotes, action)


### PR DESCRIPTION
#820  and #846 were never included in the release. The 0.15 had some PRs that were not included in the version.

This PR bring these changes to release/0.16

It's already approved. Merging directly without squashing...

* Remove start from names
* Fallback for browsers that doesn't suppoty navigator.online