### PR TITLE
[V3] Fix tooltips

### DIFF
--- a/src/components/HoverInlineText/index.tsx
+++ b/src/components/HoverInlineText/index.tsx
@@ -1,4 +1,4 @@
-import Tooltip from 'components/Tooltip'
+import Tooltip from '@src/components/Tooltip'
 import React, { useState } from 'react'
 import styled from 'styled-components/macro'
 

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -40,7 +40,7 @@ import {
   renderTransactions,
 } from './AccountDetailsMod'
 import { ConnectedWalletInfo, useWalletInfo } from 'hooks/useWalletInfo'
-import { MouseoverTooltip } from 'components/Tooltip/TooltipMod'
+import { MouseoverTooltip } from 'components/Tooltip'
 
 const Wrapper = styled.div`
   color: ${({ theme }) => theme.text1};

--- a/src/custom/components/Popover/PopoverMod.tsx
+++ b/src/custom/components/Popover/PopoverMod.tsx
@@ -1,0 +1,136 @@
+import { Placement } from '@popperjs/core'
+import { transparentize } from 'polished'
+import React, { useCallback, useState } from 'react'
+import { usePopper } from 'react-popper'
+import styled, { DefaultTheme, StyledComponent } from 'styled-components/macro'
+import useInterval from 'hooks/useInterval'
+import Portal from '@reach/portal'
+import { PopoverContainerProps } from '.'
+
+export const PopoverContainer = styled.div<{ show: boolean }>`
+  z-index: 9999;
+  visibility: ${(props) => (props.show ? 'visible' : 'hidden')};
+  opacity: ${(props) => (props.show ? 1 : 0)};
+  transition: visibility 150ms linear, opacity 150ms linear;
+  background: ${({ theme }) => theme.bg1};
+  border: 1px solid ${({ theme }) => theme.bg3};
+  box-shadow: 0 4px 8px 0 ${({ theme }) => transparentize(0.9, theme.shadow1)};
+  color: ${({ theme }) => theme.text2};
+  border-radius: 8px;
+`
+
+const ReferenceElement = styled.div`
+  display: inline-block;
+`
+
+export const Arrow = styled.div`
+  width: 8px;
+  height: 8px;
+  z-index: 9998;
+
+  ::before {
+    position: absolute;
+    width: 8px;
+    height: 8px;
+    z-index: 9998;
+
+    content: '';
+    border: 1px solid ${({ theme }) => theme.bg3};
+    transform: rotate(45deg);
+    background: ${({ theme }) => theme.bg1};
+  }
+
+  &.arrow-top {
+    bottom: -5px;
+    ::before {
+      border-top: none;
+      border-left: none;
+    }
+  }
+
+  &.arrow-bottom {
+    top: -5px;
+    ::before {
+      border-bottom: none;
+      border-right: none;
+    }
+  }
+
+  &.arrow-left {
+    right: -5px;
+
+    ::before {
+      border-bottom: none;
+      border-left: none;
+    }
+  }
+
+  &.arrow-right {
+    left: -5px;
+    ::before {
+      border-right: none;
+      border-top: none;
+    }
+  }
+`
+
+export interface PopoverProps extends PopoverContainerProps {
+  content: React.ReactNode
+  // show: boolean
+  children: React.ReactNode
+  placement?: Placement
+  PopoverContainer: StyledComponent<'div', DefaultTheme, PopoverContainerProps, never> // gp mod
+  Arrow: StyledComponent<'div', DefaultTheme, Omit<PopoverContainerProps, 'color' | 'show'>, never> // gp mod
+}
+
+export default function Popover({
+  content,
+  show,
+  children,
+  placement = 'auto',
+  bgColor,
+  color,
+  PopoverContainer,
+  Arrow,
+}: PopoverProps) {
+  const [referenceElement, setReferenceElement] = useState<HTMLDivElement | null>(null)
+  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null)
+  const [arrowElement, setArrowElement] = useState<HTMLDivElement | null>(null)
+  const { styles, update, attributes } = usePopper(referenceElement, popperElement, {
+    placement,
+    strategy: 'fixed',
+    modifiers: [
+      { name: 'offset', options: { offset: [8, 8] } },
+      { name: 'arrow', options: { element: arrowElement } },
+    ],
+  })
+  const updateCallback = useCallback(() => {
+    update && update()
+  }, [update])
+  useInterval(updateCallback, show ? 100 : null)
+
+  return (
+    <>
+      <ReferenceElement ref={setReferenceElement as any}>{children}</ReferenceElement>
+      <Portal>
+        <PopoverContainer
+          show={show}
+          ref={setPopperElement as any}
+          style={styles.popper}
+          {...attributes.popper}
+          bgColor={bgColor}
+          color={color}
+        >
+          {content}
+          <Arrow
+            className={`arrow-${attributes.popper?.['data-popper-placement'] ?? ''}`}
+            ref={setArrowElement as any}
+            style={styles.arrow}
+            bgColor={bgColor}
+            {...attributes.arrow}
+          />
+        </PopoverContainer>
+      </Portal>
+    </>
+  )
+}

--- a/src/custom/components/Popover/index.tsx
+++ b/src/custom/components/Popover/index.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import PopoverMod, { Arrow as ArrowMod, PopoverContainer as PopoverContainerMod } from './PopoverMod'
+import styled from 'styled-components/macro'
+import { PopoverProps } from './PopoverMod'
+
+export * from './PopoverMod'
+
+export interface PopoverContainerProps {
+  show: boolean
+  bgColor?: string
+  color?: string
+}
+
+const PopoverContainer = styled(PopoverContainerMod)<PopoverContainerProps>`
+  background: ${({ theme, bgColor }) => bgColor || theme.bg2};
+  color: ${({ theme, color }) => color || theme.text2};
+`
+
+const Arrow = styled(ArrowMod)<Omit<PopoverContainerProps, 'color' | 'show'>>`
+  ::before {
+    background: ${({ theme, bgColor }) => bgColor || theme.bg2};
+  }
+`
+
+export default function Popover(props: Omit<PopoverProps, 'PopoverContainer' | 'Arrow'>) {
+  return <PopoverMod {...props} Arrow={Arrow} PopoverContainer={PopoverContainer} />
+}

--- a/src/custom/components/Tooltip/TooltipMod.tsx
+++ b/src/custom/components/Tooltip/TooltipMod.tsx
@@ -9,11 +9,11 @@ const TooltipContainer = styled.div`
   word-break: break-word;
 `
 
-interface TooltipProps extends Omit<PopoverProps, 'content'> {
+interface TooltipProps extends Omit<PopoverProps, 'content' | 'PopoverContainer' | 'Arrow'> {
   text: ReactNode
 }
 
-interface TooltipContentProps extends Omit<PopoverProps, 'content'> {
+interface TooltipContentProps extends Omit<PopoverProps, 'content' | 'PopoverContainer' | 'Arrow'> {
   content: ReactNode
 }
 

--- a/src/custom/components/Tooltip/index.tsx
+++ b/src/custom/components/Tooltip/index.tsx
@@ -1,2 +1,2 @@
 export * from '@src/components/Tooltip'
-export { default } from './TooltipMod'
+export { default, TooltipContent, MouseoverTooltip, MouseoverTooltipContent } from './TooltipMod'

--- a/src/custom/components/swap/AdvancedSwapDetails/AdvancedSwapDetailsMod.tsx
+++ b/src/custom/components/swap/AdvancedSwapDetails/AdvancedSwapDetailsMod.tsx
@@ -18,9 +18,10 @@ export interface AdvancedSwapDetailsProps {
   // trade?: V2Trade<Currency, Currency, TradeType> | V3Trade<Currency, Currency, TradeType>
   trade?: TradeGp
   allowedSlippage: Percent
+  showHelpers?: boolean
 }
 
-export function AdvancedSwapDetails({ trade, allowedSlippage }: AdvancedSwapDetailsProps) {
+export function AdvancedSwapDetails({ trade, allowedSlippage, showHelpers = true }: AdvancedSwapDetailsProps) {
   // const theme = useContext(ThemeContext)
 
   /* 
@@ -34,8 +35,11 @@ export function AdvancedSwapDetails({ trade, allowedSlippage }: AdvancedSwapDeta
   }, [trade]) 
   */
 
-  return !trade ? null : <TradeSummary trade={trade} allowedSlippage={allowedSlippage} /> /* 
-      <AutoColumn gap="8px">
+  if (!trade) return null
+
+  return <TradeSummary trade={trade} allowedSlippage={allowedSlippage} showHelpers={showHelpers} />
+  /* 
+    <AutoColumn gap="8px">
       <RowBetween>
         <RowFixed>
           <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
@@ -93,5 +97,5 @@ export function AdvancedSwapDetails({ trade, allowedSlippage }: AdvancedSwapDeta
         </TYPE.black>
       </RowBetween>
     </AutoColumn>
-      */
+  */
 }

--- a/src/custom/components/swap/SwapModalHeader/index.tsx
+++ b/src/custom/components/swap/SwapModalHeader/index.tsx
@@ -9,7 +9,7 @@ import { darken, transparentize } from 'polished'
 // MOD
 const LightCard = styled(LightCardUni)`
   background-color: ${({ theme }) => darken(0.06, theme.bg1)};
-  border: 2px solid ${({ theme }) => transparentize(0.7, theme.bg0)};
+  border: 2px solid ${({ theme }) => transparentize(0.5, theme.bg0)};
 `
 
 const Wrapper = styled.div`

--- a/src/custom/components/swap/SwapModalHeader/index.tsx
+++ b/src/custom/components/swap/SwapModalHeader/index.tsx
@@ -4,12 +4,12 @@ import SwapModalHeaderMod, { SwapModalHeaderProps } from './SwapModalHeaderMod'
 import { AutoColumn } from 'components/Column'
 import styled from 'styled-components'
 import { LightCard as LightCardUni } from 'components/Card'
-import { darken } from 'polished'
+import { darken, transparentize } from 'polished'
 
 // MOD
 const LightCard = styled(LightCardUni)`
   background-color: ${({ theme }) => darken(0.06, theme.bg1)};
-  border: 2px solid ${({ theme }) => theme.bg0};
+  border: 2px solid ${({ theme }) => transparentize(0.7, theme.bg0)};
 `
 
 const Wrapper = styled.div`

--- a/src/custom/components/swap/TradeSummary/TradeSummaryMod.tsx
+++ b/src/custom/components/swap/TradeSummary/TradeSummaryMod.tsx
@@ -9,10 +9,11 @@ import { computeSlippageAdjustedAmounts } from 'utils/prices'
 import { getMinimumReceivedTooltip } from 'utils/tooltips'
 
 import { AutoColumn } from 'components/Column'
-import QuestionHelper from 'components/QuestionHelper'
 import { RowBetween, RowFixed } from 'components/Row'
 import TradeGp from 'state/swap/TradeGp'
 import { DEFAULT_PRECISION } from 'constants/index'
+import { MouseoverTooltipContent } from 'components/Tooltip'
+import { StyledInfo } from 'pages/Swap/SwapMod'
 
 // computes price breakdown for the trade
 export function computeTradePriceBreakdown(trade?: TradeGp | null): {
@@ -34,7 +35,15 @@ export function computeTradePriceBreakdown(trade?: TradeGp | null): {
 export const FEE_TOOLTIP_MSG =
   'On CowSwap you sign your order (hence no gas costs!). The fees are covering your gas costs already.'
 
-export default function TradeSummary({ trade, allowedSlippage }: { trade: TradeGp; allowedSlippage: Percent }) {
+export default function TradeSummary({
+  trade,
+  allowedSlippage,
+  showHelpers = true,
+}: {
+  trade: TradeGp
+  allowedSlippage: Percent
+  showHelpers?: boolean
+}) {
   const theme = useContext(ThemeContext)
   // const { priceImpactWithoutFee, realizedLPFee } = computeTradePriceBreakdown(trade)
   const { /*priceImpactWithoutFee,*/ realizedFee } = React.useMemo(() => computeTradePriceBreakdown(trade), [trade])
@@ -42,21 +51,26 @@ export default function TradeSummary({ trade, allowedSlippage }: { trade: TradeG
   const slippageAdjustedAmounts = computeSlippageAdjustedAmounts(trade, allowedSlippage)
 
   return (
-    <AutoColumn gap="8px">
+    <AutoColumn gap="2px">
       <RowBetween>
         <RowFixed>
           <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
             {/* Liquidity Provider Fee */}
             Fee
           </TYPE.black>
-          <QuestionHelper text={FEE_TOOLTIP_MSG} />
+          {showHelpers && (
+            <MouseoverTooltipContent content={FEE_TOOLTIP_MSG} bgColor={theme.bg1} color={theme.text1}>
+              <StyledInfo />
+            </MouseoverTooltipContent>
+          )}
         </RowFixed>
         <TYPE.black textAlign="right" fontSize={12} color={theme.text1}>
           {realizedFee ? `${realizedFee.toSignificant(DEFAULT_PRECISION)} ${realizedFee.currency.symbol}` : '-'}
         </TYPE.black>
       </RowBetween>
 
-      {/* <RowBetween>
+      {/* 
+      <RowBetween>
           <RowFixed>
             <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
               <Trans>Route</Trans>
@@ -65,9 +79,11 @@ export default function TradeSummary({ trade, allowedSlippage }: { trade: TradeG
           <TYPE.black textAlign="right" fontSize={12} color={theme.text1}>
             <SwapRoute trade={trade} />
           </TYPE.black>
-        </RowBetween> */}
+        </RowBetween> 
+        */}
 
-      {/* <RowBetween>
+      {/* 
+      <RowBetween>
           <RowFixed>
             <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
               <Trans>Price Impact</Trans>
@@ -76,14 +92,23 @@ export default function TradeSummary({ trade, allowedSlippage }: { trade: TradeG
           <TYPE.black textAlign="right" fontSize={12} color={theme.text1}>
             <FormattedPriceImpact priceImpact={priceImpact} />
           </TYPE.black>
-        </RowBetween> */}
+        </RowBetween> 
+        */}
 
       <RowBetween>
         <RowFixed>
           <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
             {trade.tradeType === TradeType.EXACT_INPUT ? <Trans>Minimum received</Trans> : <Trans>Maximum sent</Trans>}
           </TYPE.black>
-          <QuestionHelper text={getMinimumReceivedTooltip(allowedSlippage, isExactIn)} />
+          {showHelpers && (
+            <MouseoverTooltipContent
+              content={getMinimumReceivedTooltip(allowedSlippage, isExactIn)}
+              bgColor={theme.bg1}
+              color={theme.text1}
+            >
+              <StyledInfo />
+            </MouseoverTooltipContent>
+          )}
         </RowFixed>
 
         <TYPE.black textAlign="right" fontSize={12} color={theme.text1}>

--- a/src/custom/components/swap/TradeSummary/index.tsx
+++ b/src/custom/components/swap/TradeSummary/index.tsx
@@ -8,15 +8,25 @@ import { Percent } from '@uniswap/sdk-core'
 const Wrapper = styled.div`
   ${RowFixed} {
     > div {
-      color: ${({ theme }) => theme.text1};
+      color: ${({ theme }) => theme.text4};
     }
   }
 `
 
-export default function TradeSummary({ trade, allowedSlippage }: { trade: TradeGp; allowedSlippage: Percent }) {
+export default function TradeSummary({
+  className,
+  trade,
+  allowedSlippage,
+  showHelpers,
+}: {
+  trade: TradeGp
+  allowedSlippage: Percent
+  className?: string
+  showHelpers?: boolean
+}) {
   return (
-    <Wrapper>
-      <TradeSummaryMod trade={trade} allowedSlippage={allowedSlippage} />
+    <Wrapper className={className}>
+      <TradeSummaryMod trade={trade} allowedSlippage={allowedSlippage} showHelpers={showHelpers} />
     </Wrapper>
   )
 }

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -2,16 +2,16 @@ import { Trans } from '@lingui/macro'
 import { Currency, CurrencyAmount, Token, TradeType } from '@uniswap/sdk-core'
 // import { Trade as V2Trade } from '@uniswap/v2-sdk'
 // import { Trade as V3Trade } from '@uniswap/v3-sdk'
-// import { AdvancedSwapDetails } from 'components/swap/AdvancedSwapDetails'
+import { AdvancedSwapDetails } from 'components/swap/AdvancedSwapDetails'
 import UnsupportedCurrencyFooter from 'components/swap/UnsupportedCurrencyFooter'
-import { MouseoverTooltip /* , MouseoverTooltipContent */ } from 'components/Tooltip'
+import { MouseoverTooltip, MouseoverTooltipContent } from 'components/Tooltip'
 // import JSBI from 'jsbi'
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react'
-import { ArrowDown, /*, ArrowLeft */ CheckCircle, HelpCircle /*, Info */ } from 'react-feather'
+import { ArrowDown, /*, ArrowLeft */ CheckCircle, HelpCircle, Info } from 'react-feather'
 import ReactGA from 'react-ga'
 // import { Link, RouteComponentProps } from 'react-router-dom'
 import { Text } from 'rebass'
-import { /* styled, */ ThemeContext } from 'styled-components'
+import styled, { ThemeContext } from 'styled-components'
 import AddressInputPanel from 'components/AddressInputPanel'
 import { ButtonConfirmed, ButtonError, /* ButtonGray, */ ButtonLight, ButtonPrimary } from 'components/Button'
 import Card, { GreyCard } from 'components/Card'
@@ -73,8 +73,7 @@ import { SwapProps } from '.'
 import TradeGp from 'state/swap/TradeGp'
 import AdvancedSwapDetailsDropdown from 'components/swap/AdvancedSwapDetailsDropdown'
 
-/* 
-const StyledInfo = styled(Info)`
+export const StyledInfo = styled(Info)`
   opacity: 0.4;
   color: ${({ theme }) => theme.text1};
   height: 16px;
@@ -82,8 +81,7 @@ const StyledInfo = styled(Info)`
   :hover {
     opacity: 0.8;
   }
-` 
-*/
+`
 
 export default function Swap({
   history,
@@ -630,17 +628,28 @@ export default function Swap({
               </Row>
               */
               <Card padding={showWrap ? '.25rem 1rem 0 1rem' : '0px'} borderRadius={'20px'}>
-                <AutoColumn gap="8px" style={{ padding: '0 16px' }}>
+                <AutoColumn gap="8px" style={{ padding: '0 8px' }}>
                   {trade && (
                     <RowBetween align="center">
                       <Text fontWeight={500} fontSize={14} color={theme.text2}>
                         <Trans>Price</Trans>
                       </Text>
-                      <TradePrice
-                        price={trade.executionPrice}
-                        showInverted={showInverted}
-                        setShowInverted={setShowInverted}
-                      />
+                      <div style={{ display: 'flex', gap: 5 }}>
+                        <TradePrice
+                          price={trade.executionPrice}
+                          showInverted={showInverted}
+                          setShowInverted={setShowInverted}
+                        />
+                        <MouseoverTooltipContent
+                          content={
+                            <AdvancedSwapDetails trade={trade} allowedSlippage={allowedSlippage} showHelpers={false} />
+                          }
+                          bgColor={theme.bg1}
+                          color={theme.text4}
+                        >
+                          <StyledInfo />
+                        </MouseoverTooltipContent>
+                      </div>
                     </RowBetween>
                   )}
                   {!allowedSlippage.equalTo(INITIAL_ALLOWED_SLIPPAGE_PERCENT) && (

--- a/src/custom/theme/cowSwapTheme.tsx
+++ b/src/custom/theme/cowSwapTheme.tsx
@@ -38,7 +38,7 @@ export function colors(darkMode: boolean): Colors {
     text1: darkMode ? '#c5daef' : '#000000',
     text2: darkMode ? '#021E34' : '#000000',
     text3: darkMode ? 'rgba(197, 218, 239, 0.4)' : '#000000',
-    text4: darkMode ? 'rgba(197, 218, 239, 0.4)' : '#000000b8',
+    text4: darkMode ? 'rgba(197, 218, 239, 0.7)' : '#000000b8',
 
     // ****** backgrounds / greys ******
     bg1: darkMode ? '#163861' : '#D5E9F0',


### PR DESCRIPTION
Fixed tooltips as they were broken - uses cleaner icon, adds props to allow changing tooltip bg colour and text colour, also more inline with v3 changes

Tooltips:
![image](https://user-images.githubusercontent.com/21335563/124516454-96a57680-ddd9-11eb-8269-895837041923.png)

confirmation icon change
![image](https://user-images.githubusercontent.com/21335563/124516478-a1f8a200-ddd9-11eb-9224-13cea70d2937.png)

confirmation tooltip expanded
![image](https://user-images.githubusercontent.com/21335563/124516505-b3da4500-ddd9-11eb-9afa-db57965d4dc2.png)

