### PR TITLE
Move all price logic to the utils

### DIFF
--- a/cypress-custom/integration/fee.test.ts
+++ b/cypress-custom/integration/fee.test.ts
@@ -1,8 +1,7 @@
 import { SupportedChainId as ChainId } from '../../src/custom/constants/chains'
 import { WETH9 as WETH } from '@uniswap/sdk-core'
-import { FeeInformation } from '../../src/custom/state/fee/reducer'
 import { OrderKind } from '@gnosis.pm/gp-v2-contracts'
-import { FeeQuoteParams } from '../../src/custom/utils/operator'
+import { FeeQuoteParams, FeeInformation } from '../../src/custom/utils/price'
 import { parseUnits } from 'ethers/lib/utils'
 
 const DAI = '0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735'

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -1,4 +1,4 @@
-import { WithClassName } from '@src/custom/types'
+import { WithClassName } from 'types'
 import { Trans } from '@lingui/macro'
 import React from 'react'
 import styled from 'styled-components/macro'

--- a/src/custom/state/lists/actions/actionsMod.ts
+++ b/src/custom/state/lists/actions/actionsMod.ts
@@ -1,6 +1,7 @@
 import { ActionCreatorWithPayload, createAction } from '@reduxjs/toolkit'
 import { TokenList, Version } from '@uniswap/token-lists'
 import { SupportedChainId as ChainId } from 'constants/chains'
+export { SupportedChainId as ChainId } from 'constants/chains'
 
 export interface WithChainId {
   chainId?: ChainId

--- a/src/custom/state/price/actions.ts
+++ b/src/custom/state/price/actions.ts
@@ -1,5 +1,5 @@
 import { createAction } from '@reduxjs/toolkit'
-import { FeeQuoteParams } from 'utils/operator'
+import { FeeQuoteParams } from 'utils/price'
 import { SupportedChainId as ChainId } from 'constants/chains'
 import { QuoteInformationObject } from './reducer'
 

--- a/src/custom/state/price/reducer.ts
+++ b/src/custom/state/price/reducer.ts
@@ -3,23 +3,13 @@ import { SupportedChainId as ChainId } from 'constants/chains'
 import { updateQuote, setQuoteError, getNewQuote, refreshQuote, QuoteError } from './actions'
 import { Writable } from 'custom/types'
 import { PrefillStateRequired } from '../orders/reducer'
-import { FeeQuoteParams } from 'utils/operator'
+import { FeeInformation, FeeQuoteParams, PriceInformation } from 'utils/price'
 
 // API Doc: https://protocol-rinkeby.dev.gnosisdev.com/api
 
 export const EMPTY_FEE = {
   feeAsCurrency: undefined,
   amount: '0',
-}
-
-export interface FeeInformation {
-  expirationDate: string
-  amount: string
-}
-
-export interface PriceInformation {
-  token: string
-  amount: string | null
 }
 
 export interface QuoteInformationObject extends FeeQuoteParams {

--- a/src/custom/state/price/updater.ts
+++ b/src/custom/state/price/updater.ts
@@ -1,17 +1,22 @@
 import { useEffect } from 'react'
-import { useActiveWeb3React } from 'hooks/web3'
+
+import { DEFAULT_DECIMALS } from 'custom/constants'
+
+import { UnsupportedToken } from 'utils/operator'
+import { FeeQuoteParams } from 'utils/price'
+
 import { useSwapState, tryParseAmount } from 'state/swap/hooks'
-import useIsWindowVisible from 'hooks/useIsWindowVisible'
 import { Field } from 'state/swap/actions'
+import { useIsUnsupportedTokenGp } from 'state/lists/hooks/hooksMod'
+
+import useIsWindowVisible from 'hooks/useIsWindowVisible'
 import { useCurrency } from 'hooks/Tokens'
 import { useAllQuotes, useIsQuoteLoading, useSetQuoteError } from './hooks'
-import { useRefetchQuoteCallback } from 'hooks/useRefetchPriceCallback'
-import { FeeQuoteParams, UnsupportedToken } from 'utils/operator'
-import { QuoteInformationObject } from './reducer'
-import { useIsUnsupportedTokenGp } from 'state/lists/hooks/hooksMod'
 import useDebounceWithForceUpdate from 'hooks/useDebounceWithForceUpdate'
+import { useRefetchQuoteCallback } from 'hooks/useRefetchPriceCallback'
+import { useActiveWeb3React } from 'hooks/web3'
 import useIsOnline from 'hooks/useIsOnline'
-import { DEFAULT_DECIMALS } from 'custom/constants'
+import { QuoteInformationObject } from './reducer'
 
 const DEBOUNCE_TIME = 350
 const REFETCH_CHECK_INTERVAL = 10000 // Every 10s

--- a/src/custom/state/swap/TradeGp.ts
+++ b/src/custom/state/swap/TradeGp.ts
@@ -1,7 +1,7 @@
-import { CanonicalMarketParams, getCanonicalMarket } from '@src/custom/utils/misc'
+import { CanonicalMarketParams, getCanonicalMarket } from 'utils/misc'
+import { FeeInformation, PriceInformation } from 'utils/price'
 import { CurrencyAmount, Currency, TradeType, Price, Percent, Fraction } from '@uniswap/sdk-core'
 import { Trade } from '@uniswap/v2-sdk'
-import { FeeInformation, PriceInformation } from '../price/reducer'
 
 export type FeeForTrade = { feeAsCurrency: CurrencyAmount<Currency> } & Pick<FeeInformation, 'amount'>
 

--- a/src/custom/state/swap/trade.test.ts
+++ b/src/custom/state/swap/trade.test.ts
@@ -1,6 +1,6 @@
 import JSBI from 'jsbi'
 import { parseUnits } from '@ethersproject/units'
-import { DEFAULT_PRECISION, INITIAL_ALLOWED_SLIPPAGE, LONG_PRECISION } from '@src/custom/constants'
+import { DEFAULT_PRECISION, INITIAL_ALLOWED_SLIPPAGE, LONG_PRECISION } from 'constants/index'
 import { CurrencyAmount, Fraction, Percent, Token, Price, Currency, TradeType } from '@uniswap/sdk-core'
 import { stringToCurrency } from './extension'
 import { SupportedChainId as ChainId } from 'constants/chains'

--- a/src/custom/utils/paraswap.ts
+++ b/src/custom/utils/paraswap.ts
@@ -1,11 +1,10 @@
 import { OrderKind } from '@gnosis.pm/gp-v2-contracts'
 import { ParaSwap, SwapSide, NetworkID } from 'paraswap'
 import { toErc20Address } from 'utils/tokens'
-import { PriceQuoteParams } from 'utils/operator'
 import { OptimalRatesWithPartnerFees, APIError, RateOptions } from 'paraswap/build/types'
 import { SupportedChainId as ChainId } from 'constants/chains'
-import { PriceInformation } from 'state/price/reducer'
-import { getTokensFromMarket } from './misc'
+import { getTokensFromMarket } from 'utils/misc'
+import { PriceInformation, PriceQuoteParams } from 'utils/price'
 
 type ParaSwapPriceQuote = OptimalRatesWithPartnerFees
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13352,9 +13352,9 @@ ndjson@^1.5.0:
     split2 "^2.1.0"
     through2 "^2.0.3"
 
-"neat-frame@git+https://github.com/agentofuser/neat-frame.git#wrap-ansi-options":
+"neat-frame@https://github.com/agentofuser/neat-frame#wrap-ansi-options":
   version "1.0.2"
-  resolved "git+https://github.com/agentofuser/neat-frame.git#b244ca11078bd35f63b2d7cb22d5e4b5c12ae2aa"
+  resolved "https://github.com/agentofuser/neat-frame#b244ca11078bd35f63b2d7cb22d5e4b5c12ae2aa"
   dependencies:
     inspect-with-kind "^1.0.5"
     merge-options "^1.0.1"


### PR DESCRIPTION
This is a proposal continuing the direction of #879 

This PR creates a new 'util/price` which has all the logic for fetching new prices from the different price feeds.

For this reason, It will depend on the `utils/paraswap` and `utils/operator` (which we should rename to `utils/gp` or similar)
This way, we can easily use the price logics anywhere, and we can test them easier. They are not related to any hook or react, just fetch price logics.

I also moved some type definitions to this util, since they are pretty general types for price fetching. So now the different price feed utils can use them.

Some functions where renamed to make them easier to understand.

## Takeaway
Now `util/prices` has some reusable exported functions:
* `getAllPrices`: Return all prices from all feeds
* `getBestPrice`: Return only the best price
* `getBestQuote`: Return the best quote (price + fee)

Refetch hook logic is now smaller