### PR TITLE
Handling exceptions on getBestQuote

### DIFF
--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -177,12 +177,6 @@ export async function getBestQuote({ quoteParams, fetchFee, previousFee }: Quote
       ? getFeeQuote({ chainId, sellToken, buyToken, fromDecimals, toDecimals, amount, kind })
       : Promise.resolve(previousFee)
 
-  // Log fee for debugging
-  feePromise.then((fee) => {
-    console.log(`Fee: ${formatAtoms(fee.amount, fromDecimals)} (in atoms ${fee.amount})`)
-    return fee
-  })
-
   // Get a new price quote
   let exchangeAmount
   let feeExceedsPrice = false

--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -89,7 +89,10 @@ function _filterWinningPrice(params: FilterWinningPriceParams) {
   return { token, amount }
 }
 
-export type QuoteResult = [PromiseSettledResult<PriceInformation>, PromiseSettledResult<FeeInformation>]
+export type QuoteResult = [
+  PromiseSettledResult<PriceInformation | undefined>,
+  PromiseSettledResult<FeeInformation | undefined>
+]
 
 /**
  *  Return all price estimations from all price sources
@@ -175,28 +178,33 @@ export async function getBestQuote({ quoteParams, fetchFee, previousFee }: Quote
   const feePromise =
     fetchFee || !previousFee
       ? getFeeQuote({ chainId, sellToken, buyToken, fromDecimals, toDecimals, amount, kind })
+          .then((fee) => {
+            console.log(`Fee: ${formatAtoms(fee.amount, fromDecimals)} (in atoms ${fee.amount})`)
+            return fee
+          })
+          .catch((e) => {
+            console.log(`Failed to fetch fee`, e)
+            return undefined
+          })
       : Promise.resolve(previousFee)
-
-  // Log fee for debugging
-  feePromise.then((fee) => {
-    console.log(`Fee: ${formatAtoms(fee.amount, fromDecimals)} (in atoms ${fee.amount})`)
-    return fee
-  })
 
   // Get a new price quote
   let exchangeAmount
   let feeExceedsPrice = false
   if (kind === 'sell') {
-    // Sell orders need to deduct the fee from the swapped amount
-    // we need to check for 0/negative exchangeAmount should fee >= amount
-    const { amount: fee } = await feePromise
-    const result = BigNumber.from(amount).sub(fee)
-    console.log(`Sell amount before fee: ${formatAtoms(amount, fromDecimals)}  (in atoms ${amount})`)
-    console.log(`Sell amount after fee: ${formatAtoms(result.toString(), fromDecimals)}  (in atoms ${result})`)
+    const feeObj = await feePromise
+    if (feeObj) {
+      // Sell orders need to deduct the fee from the swapped amount
+      // we need to check for 0/negative exchangeAmount should fee >= amount
+      const { amount: fee } = feeObj
+      const result = BigNumber.from(amount).sub(fee)
+      console.log(`Sell amount before fee: ${formatAtoms(amount, fromDecimals)}  (in atoms ${amount})`)
+      console.log(`Sell amount after fee: ${formatAtoms(result.toString(), fromDecimals)}  (in atoms ${result})`)
 
-    feeExceedsPrice = result.lte('0')
+      feeExceedsPrice = result.lte('0')
 
-    exchangeAmount = !feeExceedsPrice ? result.toString() : null
+      exchangeAmount = !feeExceedsPrice ? result.toString() : null
+    }
   } else {
     // For buy orders, we swap the whole amount, then we add the fee on top
     exchangeAmount = amount
@@ -205,7 +213,12 @@ export async function getBestQuote({ quoteParams, fetchFee, previousFee }: Quote
   // Get price for price estimation
   const pricePromise =
     !feeExceedsPrice && exchangeAmount
-      ? getBestPrice({ chainId, baseToken, quoteToken, fromDecimals, toDecimals, amount: exchangeAmount, kind })
+      ? getBestPrice({ chainId, baseToken, quoteToken, fromDecimals, toDecimals, amount: exchangeAmount, kind }).catch(
+          (e) => {
+            console.log(`Failed to get price`, e)
+            return undefined
+          }
+        )
       : // fee exceeds our price, is invalid
         Promise.reject(FEE_EXCEEDS_FROM_ERROR)
 


### PR DESCRIPTION
# Summary

Handling exceptions on `getBestQuote`.

When either fee or price throws, return undefined for the respective promise.

![screenshot_2021-07-09_12-58-35](https://user-images.githubusercontent.com/43217/125134914-ff803d80-e0bc-11eb-8304-60d25a218057.png)
