### PR TITLE
Update wrong word in COW FAQ

### DIFF
--- a/src/custom/pages/Faq/index.tsx
+++ b/src/custom/pages/Faq/index.tsx
@@ -229,7 +229,7 @@ export default function Faq() {
             This means, on CowSwap, when two traders each hold an asset the other wants, a trade can be settled directly
             between them without an external market maker or liquidity provider. This leads to better prices for the
             individual traders (because traditionally market makers add a fee — referred to as spread — for their
-            surface)
+            service)
           </p>
 
           <p>


### PR DESCRIPTION
In the line 253, for the question: To what does the term Coincidence of Wants  (CoWs) refer? We have "This leads to better prices for the individual traders (because traditionally market makers add a fee — referred to as spread — for their surface)". This PR changes the word surface for the correct word, "service"