### PR TITLE
Non-Serialisable data sent to state (bug fix)

### DIFF
--- a/src/custom/state/orders/actions.ts
+++ b/src/custom/state/orders/actions.ts
@@ -1,8 +1,9 @@
 import { createAction } from '@reduxjs/toolkit'
 import { OrderID } from 'utils/operator'
 import { OrderCreation } from 'utils/signatures'
-import { SupportedChainId as ChainId } from 'constants/chains'
 import { Token } from '@uniswap/sdk-core'
+import { SupportedChainId as ChainId } from 'constants/chains'
+import { SerializedToken } from '@src/state/user/actions'
 export { OrderKind } from '@gnosis.pm/gp-v2-contracts'
 
 export enum OrderStatus {
@@ -13,7 +14,7 @@ export enum OrderStatus {
 }
 
 // used internally by dapp
-export interface Order extends Omit<OrderCreation, 'signingScheme'> {
+export interface BaseOrder extends Omit<OrderCreation, 'signingScheme'> {
   id: OrderID // it is special :), Unique identifier for the order: 56 bytes encoded as hex without 0x
   owner: string // address, without '0x' prefix
   status: OrderStatus
@@ -21,9 +22,17 @@ export interface Order extends Omit<OrderCreation, 'signingScheme'> {
   fulfilledTransactionHash?: string // hash of transaction when Order was fulfilled
   creationTime: string // Creation time of the order. Encoded as ISO 8601 UTC
   summary: string // for dapp use only, readable by user
+  isCancelling?: boolean // intermediate state while the order has been cancelled but order is still pending
+}
+
+export interface Order extends BaseOrder {
   inputToken: Token // for dapp use only, readable by user
   outputToken: Token // for dapp use only, readable by user
-  isCancelling?: boolean // intermediate state while the order has been cancelled but order is still pending
+}
+
+export interface SerializedOrder extends BaseOrder {
+  inputToken: SerializedToken // for dapp use only, readable by user
+  outputToken: SerializedToken // for dapp use only, readable by user
 }
 
 // gotten from querying /api/v1/orders
@@ -35,7 +44,7 @@ export interface OrderFromApi extends OrderCreation {
 export interface AddPendingOrderParams {
   id: OrderID
   chainId: ChainId
-  order: Order
+  order: SerializedOrder
 }
 
 export type ChangeOrderStatusParams = { id: OrderID; chainId: ChainId }

--- a/src/custom/state/orders/hooks.ts
+++ b/src/custom/state/orders/hooks.ts
@@ -96,8 +96,6 @@ export const useOrder = ({ id, chainId }: Partial<GetRemoveOrderParams>): Order 
     const orders = state.orders[chainId]
     const serialisedOrder = orders?.fulfilled[id] || orders?.pending[id] || orders?.expired[id] || orders?.cancelled[id]
 
-    if (!serialisedOrder) return undefined
-
     return _deserializeOrder(serialisedOrder)
   })
 }

--- a/src/custom/state/orders/hooks.ts
+++ b/src/custom/state/orders/hooks.ts
@@ -12,19 +12,25 @@ import {
   cancelOrder,
   requestOrderCancellation,
   updateLastCheckedBlock,
-  Order,
+  SerializedOrder,
   fulfillOrdersBatch,
   FulfillOrdersBatchParams,
   expireOrdersBatch,
   cancelOrdersBatch,
+  Order,
 } from './actions'
-import { OrdersState, PartialOrdersMap } from './reducer'
+import { OrderObject, OrdersState, PartialOrdersMap } from './reducer'
 import { isTruthy } from 'utils/misc'
 import { OrderID } from 'utils/operator'
 import { ContractDeploymentBlocks } from './consts'
+import { deserializeToken, serializeToken } from '@src/state/user/hooks'
+
+export interface AddUnserialisedPendingOrderParams extends GetRemoveOrderParams {
+  order: Order
+}
 
 interface AddPendingOrderParams extends GetRemoveOrderParams {
-  order: Order
+  order: SerializedOrder
 }
 
 interface FulfillOrderParams extends GetRemoveOrderParams {
@@ -53,7 +59,7 @@ interface UpdateLastCheckedBlockParams extends ClearOrdersParams {
   lastCheckedBlock: number
 }
 
-type AddOrderCallback = (addOrderParams: AddPendingOrderParams) => void
+type AddOrderCallback = (addOrderParams: AddUnserialisedPendingOrderParams) => void
 type RemoveOrderCallback = (removeOrderParams: GetRemoveOrderParams) => void
 type FulfillOrderCallback = (fulfillOrderParams: FulfillOrderParams) => void
 type FulfillOrdersBatchCallback = (fulfillOrdersBatchParams: FulfillOrdersBatchParams) => void
@@ -64,21 +70,35 @@ type CancelOrdersBatchCallback = (cancelOrdersBatchParams: CancelOrdersBatchPara
 type ClearOrdersCallback = (clearOrdersParams: ClearOrdersParams) => void
 type UpdateLastCheckedBlockCallback = (updateLastCheckedBlockParams: UpdateLastCheckedBlockParams) => void
 
-type GetOrderByIdCallback = (id: OrderID) => Order | undefined
+type GetOrderByIdCallback = (id: OrderID) => SerializedOrder | undefined
+
+function _deserializeOrder(orderObject: OrderObject | undefined) {
+  const serialisedOrder = orderObject?.order
+
+  let order: Order | undefined
+  if (serialisedOrder) {
+    const deserialisedInputToken = deserializeToken(serialisedOrder.inputToken)
+    const deserialisedOutputToken = deserializeToken(serialisedOrder.outputToken)
+    order = {
+      ...serialisedOrder,
+      inputToken: deserialisedInputToken,
+      outputToken: deserialisedOutputToken,
+    }
+  }
+
+  return order
+}
 
 export const useOrder = ({ id, chainId }: Partial<GetRemoveOrderParams>): Order | undefined => {
   return useSelector<AppState, Order | undefined>((state) => {
     if (!id || !chainId) return undefined
 
     const orders = state.orders[chainId]
+    const serialisedOrder = orders?.fulfilled[id] || orders?.pending[id] || orders?.expired[id] || orders?.cancelled[id]
 
-    if (!orders) return undefined
-    return (
-      orders?.fulfilled[id]?.order ||
-      orders?.pending[id]?.order ||
-      orders?.expired[id]?.order ||
-      orders?.cancelled[id]?.order
-    )
+    if (!serialisedOrder) return undefined
+
+    return _deserializeOrder(serialisedOrder)
   })
 }
 
@@ -97,12 +117,13 @@ export const useFindOrderById = ({ chainId }: GetOrdersParams): GetOrderByIdCall
     (id: OrderID) => {
       if (!chainId || !stateRef.current) return
 
-      return (
-        stateRef.current.fulfilled[id]?.order ||
-        stateRef.current.pending[id]?.order ||
-        stateRef.current.expired[id]?.order ||
-        stateRef.current.cancelled[id]?.order
-      )
+      const serialisedOrderObject =
+        stateRef.current.fulfilled[id] ||
+        stateRef.current.pending[id] ||
+        stateRef.current.expired[id] ||
+        stateRef.current.cancelled[id]
+
+      return _deserializeOrder(serialisedOrderObject)
     },
     [chainId]
   )
@@ -118,7 +139,7 @@ export const useOrders = ({ chainId }: GetOrdersParams): Order[] => {
       .concat(Object.values(state.pending))
       .concat(Object.values(state.expired))
       .concat(Object.values(state.cancelled || {}))
-      .map((orderObject) => orderObject?.order)
+      .map(_deserializeOrder)
       .filter(isTruthy)
     return allOrders
   }, [state])
@@ -147,9 +168,7 @@ export const usePendingOrders = ({ chainId }: GetOrdersParams): Order[] => {
   return useMemo(() => {
     if (!state) return []
 
-    return Object.values(state)
-      .map((orderObject) => orderObject?.order)
-      .filter(isTruthy)
+    return Object.values(state).map(_deserializeOrder).filter(isTruthy)
   }, [state])
 }
 
@@ -161,9 +180,7 @@ export const useFulfilledOrders = ({ chainId }: GetOrdersParams): Order[] => {
   return useMemo(() => {
     if (!state) return []
 
-    return Object.values(state)
-      .map((orderObject) => orderObject?.order)
-      .filter(isTruthy)
+    return Object.values(state).map(_deserializeOrder).filter(isTruthy)
   }, [state])
 }
 
@@ -175,9 +192,7 @@ export const useExpiredOrders = ({ chainId }: GetOrdersParams): Order[] => {
   return useMemo(() => {
     if (!state) return []
 
-    return Object.values(state)
-      .map((orderObject) => orderObject?.order)
-      .filter(isTruthy)
+    return Object.values(state).map(_deserializeOrder).filter(isTruthy)
   }, [state])
 }
 
@@ -189,15 +204,29 @@ export const useCancelledOrders = ({ chainId }: GetOrdersParams): Order[] => {
   return useMemo(() => {
     if (!state) return []
 
-    return Object.values(state)
-      .map((orderObject) => orderObject?.order)
-      .filter(isTruthy)
+    return Object.values(state).map(_deserializeOrder).filter(isTruthy)
   }, [state])
 }
 
 export const useAddPendingOrder = (): AddOrderCallback => {
   const dispatch = useDispatch<AppDispatch>()
-  return useCallback((addOrderParams: AddPendingOrderParams) => dispatch(addPendingOrder(addOrderParams)), [dispatch])
+  return useCallback(
+    (addOrderParams: AddUnserialisedPendingOrderParams) => {
+      const serialisedSellToken = serializeToken(addOrderParams.order.inputToken)
+      const serialisedBuyToken = serializeToken(addOrderParams.order.outputToken)
+      const order: SerializedOrder = {
+        ...addOrderParams.order,
+        inputToken: serialisedSellToken,
+        outputToken: serialisedBuyToken,
+      }
+      const params: AddPendingOrderParams = {
+        ...addOrderParams,
+        order,
+      }
+      return dispatch(addPendingOrder(params))
+    },
+    [dispatch]
+  )
 }
 
 // unused except in mock

--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -4,7 +4,6 @@ import { SupportedChainId as ChainId } from 'constants/chains'
 import {
   addPendingOrder,
   removeOrder,
-  Order,
   clearOrders,
   fulfillOrder,
   OrderStatus,
@@ -15,13 +14,14 @@ import {
   cancelOrder,
   cancelOrdersBatch,
   requestOrderCancellation,
+  SerializedOrder,
 } from './actions'
 import { ContractDeploymentBlocks } from './consts'
 import { Writable } from 'types'
 
 export interface OrderObject {
   id: OrderID
-  order: Order
+  order: SerializedOrder
 }
 
 // {order uuid => OrderObject} mapping

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -1,6 +1,7 @@
 import { CurrencyAmount, Currency, Token } from '@uniswap/sdk-core'
 import { isAddress, shortenAddress } from 'utils'
-import { AddPendingOrderParams, OrderStatus, OrderKind, ChangeOrderStatusParams } from 'state/orders/actions'
+import { OrderStatus, OrderKind, ChangeOrderStatusParams } from 'state/orders/actions'
+import { AddUnserialisedPendingOrderParams } from 'state/orders/hooks'
 
 import { signOrder, signOrderCancellation, UnsignedOrder } from 'utils/signatures'
 import { sendSignedOrderCancellation, sendSignedOrder, OrderID } from 'utils/operator'
@@ -22,7 +23,7 @@ export interface PostOrderParams {
   validTo: number
   recipient: string
   recipientAddressOrName: string | null
-  addPendingOrder: (order: AddPendingOrderParams) => void
+  addPendingOrder: (order: AddUnserialisedPendingOrderParams) => void
 }
 
 function _getSummary(params: PostOrderParams): string {

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -28,7 +28,7 @@ import {
 import { SupportedLocale } from 'constants/locales'
 import { useAppDispatch, useAppSelector } from '@src/state/hooks'
 
-function serializeToken(token: Token): SerializedToken {
+export function serializeToken(token: Token): SerializedToken {
   return {
     chainId: token.chainId,
     address: token.address,
@@ -38,7 +38,7 @@ function serializeToken(token: Token): SerializedToken {
   }
 }
 
-function deserializeToken(serializedToken: SerializedToken): Token {
+export function deserializeToken(serializedToken: SerializedToken): Token {
   return new Token(
     serializedToken.chainId,
     serializedToken.address,


### PR DESCRIPTION
"Unserialised token" being saved to state (Token class itself being sent to store) when it should be a serialised version.

![image](https://user-images.githubusercontent.com/21335563/125293182-1623d000-e31b-11eb-9f6b-448d2f75a5d2.png)

slack: https://gnosisinc.slack.com/archives/C025G521XQD/p1625870345026900

Either this change or we just remove the `serializableCheck` in `custom/state/index` middleware setup
![image](https://user-images.githubusercontent.com/21335563/125293460-58e5a800-e31b-11eb-865d-f9a4da3b0d69.png)
