### PR TITLE
[Bug fix] useDebounce error w/force-update and switching input fields

### DIFF
--- a/src/custom/state/price/updater.ts
+++ b/src/custom/state/price/updater.ts
@@ -7,11 +7,11 @@ import useIsWindowVisible from 'hooks/useIsWindowVisible'
 import { Field } from 'state/swap/actions'
 import { useCurrency } from 'hooks/Tokens'
 import { useAllQuotes, useIsQuoteLoading, useSetQuoteError } from './hooks'
+import useDebounce from 'hooks/useDebounce'
 import { useRefetchQuoteCallback } from 'hooks/useRefetchPriceCallback'
 import { FeeQuoteParams, UnsupportedToken } from 'utils/operator'
 import { QuoteInformationObject } from './reducer'
 import { useIsUnsupportedTokenGp } from 'state/lists/hooks/hooksMod'
-import useDebounceWithForceUpdate from 'hooks/useDebounceWithForceUpdate'
 import useIsOnline from 'hooks/useIsOnline'
 import { DEFAULT_DECIMALS } from 'custom/constants'
 
@@ -50,7 +50,7 @@ function quoteUsingSameParameters(currentParams: FeeQuoteParams, quoteInfo: Quot
     amount: currentAmount,
     sellToken: currentSellToken,
     buyToken: currentBuyToken,
-    kind: currentKind
+    kind: currentKind,
   } = currentParams
   const { amount, buyToken, sellToken, kind } = quoteInfo
 
@@ -108,17 +108,12 @@ export default function FeesUpdater(): null {
     INPUT: { currencyId: sellToken },
     OUTPUT: { currencyId: buyToken },
     independentField,
-    typedValue: rawTypedValue
+    typedValue: rawTypedValue,
   } = useSwapState()
-
-  // pass independent field as a reference to use against
-  // any changes to determine if user has switched input fields
-  // useful to force debounce value to refresh
-  const forceUpdateRef = independentField
 
   // Debounce the typed value to not refetch the fee too often
   // Fee API calculation/call
-  const typedValue = useDebounceWithForceUpdate(rawTypedValue, DEBOUNCE_TIME, forceUpdateRef)
+  const typedValue = useDebounce(rawTypedValue, DEBOUNCE_TIME)
 
   const sellCurrency = useCurrency(sellToken)
   const buyCurrency = useCurrency(buyToken)
@@ -186,8 +181,8 @@ export default function FeesUpdater(): null {
           quoteParams,
           fetchFee: true, // TODO: Review this, because probably now doesn't make any sense to not query the feee in some situations. Actually the endpoint will change to one that returns fee and quote together
           previousFee: quoteInfo?.fee,
-          isPriceRefresh
-        }).catch(error => console.error('Error re-fetching the quote', error))
+          isPriceRefresh,
+        }).catch((error) => console.error('Error re-fetching the quote', error))
       }
     }
 
@@ -215,7 +210,7 @@ export default function FeesUpdater(): null {
     refetchQuote,
     isUnsupportedTokenGp,
     isLoading,
-    setQuoteError
+    setQuoteError,
   ])
 
   return null

--- a/src/custom/utils/async.ts
+++ b/src/custom/utils/async.ts
@@ -72,19 +72,18 @@ export function createImperativePromise<T>(promiseArg?: Promise<T> | null | unde
 
 type ArgumentsType<T> = T extends (...args: infer A) => any ? A : never
 type AsyncFunction<T> = (...args: any[]) => Promise<T>
-type AnyFunctionCancelable<T> = (...args: any[]) => Promise<CancelableResult<T>>
 
 // see https://stackoverflow.com/a/54825370/82609
-export function onlyResolvesLast<R>(asyncFunction: AsyncFunction<R>): AnyFunctionCancelable<R> {
+export function onlyResolvesLast<R>(
+  asyncFunction: AsyncFunction<R>
+): (...args: ArgumentsType<AsyncFunction<R>>) => Promise<CancelableResult<R>> {
   let cancelPrevious: CancelCallback | null = null
 
-  const wrappedFunction = (...args: ArgumentsType<AsyncFunction<R>>) => {
+  return (...args: ArgumentsType<AsyncFunction<R>>) => {
     cancelPrevious && cancelPrevious()
     const initialPromise = asyncFunction(...args)
     const { promise, cancel } = createImperativePromise(initialPromise)
     cancelPrevious = cancel
     return promise
   }
-
-  return wrappedFunction as any // TODO fix TS
 }


### PR DESCRIPTION
## Fix

Previously we needed to force update our debounce hook to stop flashing of incorrect price calculation. However now that we have proper error handling and async loading UX implemented this is properly hidden away and the use of the forceUpdater is no longer required.

`useDebounceWithForceUpdate` was flawed anyways and giving us race condition issues with amounts replacing others. In this case typing `100` was sometimes being overwritten by `1` after switching input fields and confusing the hook.

This fixes that.

## Testing
1. Sell: OWL
2.  Buy: USDC
3.  Input as SELL: 100 OWL > notice correct price
4. Input as BUY : 100 USDC > notice correct price (< -- trying this in prod will give the error)