### PR TITLE
[921] ParaswapPool4 Exclusion from queries

### DIFF
--- a/src/custom/utils/paraswap.ts
+++ b/src/custom/utils/paraswap.ts
@@ -87,6 +87,7 @@ export async function getPriceQuote(params: PriceQuoteParams): Promise<ParaSwapP
   // https://developers.paraswap.network/api/get-rate-for-a-token-pair
   const options: RateOptions | undefined = {
     maxImpact: 100,
+    excludeDEXS: 'ParaSwapPool4',
   }
 
   // Get price


### PR DESCRIPTION
Closes #921 

Removes `ParaswapPool4` from all price queries