### PR TITLE
Update mergify rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,10 +1,10 @@
 pull_request_rules:
-  - name: Merge approved and green PRs without merge blocking PR labels
+  - name: Merge approved and green PRs when tagged with 'merge when green'
     conditions:
       - "#approved-reviews-by>=2"
-      - label!=["WIP", "Don't merge", "On hold"]
+      - label="merge when green"
       - check-success=Deploy
-      - base=develop
+      - check-success=Cypress
     actions:
       merge:
         method: squash


### PR DESCRIPTION
# Summary

Updating Mergify bot rules

- Behaviour inverted. Instead of always merging unless there's a tag,
  now it'll only merge when the label `merge when green` is set
- Can be used against any branch
- Also depends on `Cypress` succeeding

## Reasoning

More often than not, mergify is being triggered when we don't want it to.
This change makes it more explicit when it should act.

"Don't call us, we call you"

# Testing

Needs to merge it first then watch the rules in the next PR
 