### PR TITLE
Turning wallect connect disconnect back on and adding Translation tags

### DIFF
--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -8,6 +8,7 @@ import { getExplorerLabel, shortenAddress } from 'utils'
 import { AutoRow } from 'components/Row'
 import Copy, { CopyIcon } from 'components/AccountDetails/Copy'
 import styled from 'styled-components'
+import { Trans } from '@lingui/macro'
 
 import { SUPPORTED_WALLETS } from 'constants/index'
 import { getEtherscanLink } from 'utils'
@@ -176,23 +177,23 @@ export default function AccountDetails({
               <AccountGroupingRow>
                 {formatConnectorName(connector, walletInfo)}
                 <div>
-                  {/* connector !== injected && connector !== walletlink && (
+                  {connector !== injected && connector !== walletlink && (
                     <WalletAction
                       style={{ fontSize: '.825rem', fontWeight: 400, marginRight: '8px' }}
                       onClick={() => {
                         ;(connector as any).close()
                       }}
                     >
-                      Disconnect
+                      <Trans>Disconnect</Trans>
                     </WalletAction>
-                  ) */}
+                  )}
                   <WalletAction
                     style={{ fontSize: '.825rem', fontWeight: 400 }}
                     onClick={() => {
                       openOptions()
                     }}
                   >
-                    Change
+                    <Trans>Change</Trans>
                   </WalletAction>
                 </div>
               </AccountGroupingRow>


### PR DESCRIPTION
# Summary

Fixes #906 

Now WallectConnect wallets can be disconnected again \o/

Examples of:
- Trust wallet
![screenshot_2021-07-20_17-30-59](https://user-images.githubusercontent.com/43217/126412812-a3258a56-03c8-4db0-b8dd-e517658bdf79.png)
- imToken
![screenshot_2021-07-20_17-29-51](https://user-images.githubusercontent.com/43217/126412817-f7579eb1-7346-494a-a5a8-99949c7136ee.png)
- Argent (unsupported)
![screenshot_2021-07-20_17-29-05](https://user-images.githubusercontent.com/43217/126412818-7ec1a163-babf-4c40-ad3e-3bc473783a5c.png)

And one that's screwing up the UI because their server is offline or something
- TokenPocket 
![screenshot_2021-07-20_17-41-34](https://user-images.githubusercontent.com/43217/126412894-e1276735-c223-4728-864b-db011e0d86be.png)

Spent awhile debugging, but the issue is on their side.

For next steps, we should use an image fallback when the wallet provided icon fails to load.

# Testing

1. Connect a WalletConnect wallet
2. Open the account details
- [ ] There should be a button: `Disconnect`
3. Click on `Disconnect`
- [ ] Wallet should be disconnected

