### PR TITLE
[1006] Tooltips/Price display changes - Address comments

### DIFF
--- a/src/custom/components/Button/ButtonMod.tsx
+++ b/src/custom/components/Button/ButtonMod.tsx
@@ -19,7 +19,7 @@ const Base = styled(RebassButton)<
     buttonSize?: ButtonSize
   } & ButtonProps
 >`
-  padding: ${({ padding }) => (padding ? padding : '16x')};
+  padding: ${({ padding }) => (padding ? padding : '16px')};
   width: ${({ width }) => (width ? width : '100%')};
   ${({ theme, buttonSize = ButtonSize.DEFAULT }) => theme.buttonSizes[buttonSize]};
   font-weight: 500;

--- a/src/custom/components/CurrencyInputPanel/CurrencyInputPanelMod.tsx
+++ b/src/custom/components/CurrencyInputPanel/CurrencyInputPanelMod.tsx
@@ -148,12 +148,18 @@ export const StyledBalanceMax = styled.button`
     margin-right: 0.5rem;
   `};
 `
-const AuxInformationContainer = styled(Container)`
+export const AuxInformationContainer = styled(Container)<{
+  margin?: string
+  borderColor?: string
+  borderWidth?: string
+}>`
   &&&&& {
     background-color: ${({ theme }) => darken(0.0, theme.bg1 || theme.bg3)};
-    margin: 0 auto;
+    margin: ${({ margin = '0 auto' }) => margin};
     border-radius: 0 0 15px 15px;
     border-top: none;
+    ${({ borderColor }) => `border-color: ${borderColor};`}
+    border-width: ${({ borderWidth = '2px' }) => borderWidth};
   }
 
   > ${FeeInformationTooltipWrapper} {

--- a/src/custom/components/swap/AdvancedSwapDetails/AdvancedSwapDetailsMod.tsx
+++ b/src/custom/components/swap/AdvancedSwapDetails/AdvancedSwapDetailsMod.tsx
@@ -19,9 +19,15 @@ export interface AdvancedSwapDetailsProps {
   trade?: TradeGp
   allowedSlippage: Percent
   showHelpers?: boolean
+  showFee?: boolean
 }
 
-export function AdvancedSwapDetails({ trade, allowedSlippage, showHelpers = true }: AdvancedSwapDetailsProps) {
+export function AdvancedSwapDetails({
+  trade,
+  allowedSlippage,
+  showHelpers = true,
+  showFee = true,
+}: AdvancedSwapDetailsProps) {
   // const theme = useContext(ThemeContext)
 
   /* 
@@ -37,7 +43,7 @@ export function AdvancedSwapDetails({ trade, allowedSlippage, showHelpers = true
 
   if (!trade) return null
 
-  return <TradeSummary trade={trade} allowedSlippage={allowedSlippage} showHelpers={showHelpers} />
+  return <TradeSummary trade={trade} allowedSlippage={allowedSlippage} showHelpers={showHelpers} showFee={showFee} />
   /* 
     <AutoColumn gap="8px">
       <RowBetween>

--- a/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
+++ b/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
@@ -133,7 +133,7 @@ SwapModalHeaderProps) {
         </AutoColumn>
       </LightCard>
       {!!exactInLabel && (
-        <AuxInformationContainer margin="-4px auto" hideInput borderColor={transparentize(0.5, theme.bg0)}>
+        <AuxInformationContainer margin="-4px auto 4px" hideInput borderColor={transparentize(0.5, theme.bg0)}>
           <FeeInformationTooltip
             amountAfterFees={formatSmart(trade.inputAmountWithFee)}
             amountBeforeFees={formatSmart(trade.inputAmountWithoutFee)}
@@ -181,7 +181,7 @@ SwapModalHeaderProps) {
         </AutoColumn>
       </LightCard>
       {!!exactOutLabel && (
-        <AuxInformationContainer margin="-4px auto" hideInput borderColor={transparentize(0.5, theme.bg0)}>
+        <AuxInformationContainer margin="-4px auto 4px" hideInput borderColor={transparentize(0.5, theme.bg0)}>
           <FeeInformationTooltip
             amountAfterFees={formatSmart(trade.outputAmount)}
             amountBeforeFees={formatSmart(trade.outputAmountWithoutFee)}

--- a/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
+++ b/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
@@ -26,8 +26,11 @@ import TradeGp from 'state/swap/TradeGp'
 import { INPUT_OUTPUT_EXPLANATION } from 'constants/index'
 import { computeSlippageAdjustedAmounts } from 'utils/prices'
 import { Field } from 'state/swap/actions'
-import { LightCard } from 'components/Card'
 import { formatSmart } from 'utils/format'
+import { AuxInformationContainer } from 'components/CurrencyInputPanel/CurrencyInputPanelMod'
+import FeeInformationTooltip from '../FeeInformationTooltip'
+import { LightCardType } from '.'
+import { transparentize } from 'polished'
 
 export const ArrowWrapper = styled.div`
   padding: 4px;
@@ -55,7 +58,7 @@ export interface SwapModalHeaderProps {
   showAcceptChanges: boolean
   priceImpactWithoutFee?: Percent
   onAcceptChanges: () => void
-  LightCard: typeof LightCard
+  LightCard: LightCardType
 }
 
 export default function SwapModalHeader({
@@ -92,9 +95,17 @@ SwapModalHeaderProps) {
     [slippageAdjustedAmounts]
   )
 
+  const [exactInLabel, exactOutLabel] = useMemo(
+    () => [
+      trade?.tradeType === TradeType.EXACT_OUTPUT ? <Trans>From (incl. fee)</Trans> : null,
+      trade?.tradeType === TradeType.EXACT_INPUT ? <Trans>Receive (incl. fee)</Trans> : null,
+    ],
+    [trade]
+  )
+
   return (
     <AutoColumn gap={'4px'} style={{ marginTop: '1rem' }}>
-      <LightCard padding="0.75rem 1rem">
+      <LightCard flatBorder={!!exactInLabel} padding="0.75rem 1rem">
         <AutoColumn gap={'8px'}>
           <RowBetween>
             <TYPE.body color={theme.text3} fontWeight={500} fontSize={14}>
@@ -115,16 +126,33 @@ SwapModalHeaderProps) {
                 fontWeight={500}
                 color={showAcceptChanges && trade.tradeType === TradeType.EXACT_OUTPUT ? theme.primary1 : ''}
               >
-                {formatSmart(trade.inputAmount)}
+                {formatSmart(trade.inputAmountWithoutFee)}
               </TruncatedText>
             </RowFixed>
           </RowBetween>
         </AutoColumn>
       </LightCard>
+      {!!exactInLabel && (
+        <AuxInformationContainer margin="-4px auto" hideInput borderColor={transparentize(0.5, theme.bg0)}>
+          <FeeInformationTooltip
+            amountAfterFees={formatSmart(trade.inputAmountWithFee)}
+            amountBeforeFees={formatSmart(trade.inputAmountWithoutFee)}
+            feeAmount={formatSmart(trade.fee.feeAsCurrency)}
+            label={exactInLabel}
+            showHelper
+            trade={trade}
+            type="From"
+          />
+        </AuxInformationContainer>
+      )}
       <ArrowWrapper>
         <ArrowDown size="16" color={theme.text2} />
       </ArrowWrapper>
-      <LightCard padding="0.75rem 1rem" style={{ marginBottom: '0.25rem' }}>
+      <LightCard
+        flatBorder={!!exactOutLabel}
+        padding="0.75rem 1rem"
+        style={{ marginBottom: !!exactOutLabel ? '0' : '0.25rem' }}
+      >
         <AutoColumn gap={'8px'}>
           <RowBetween>
             <TYPE.body color={theme.text3} fontWeight={500} fontSize={14}>
@@ -146,12 +174,25 @@ SwapModalHeaderProps) {
             </RowFixed>
             <RowFixed gap={'0px'}>
               <TruncatedText fontSize={24} fontWeight={500}>
-                {formatSmart(trade.outputAmount)}
+                {formatSmart(trade.outputAmountWithoutFee)}
               </TruncatedText>
             </RowFixed>
           </RowBetween>
         </AutoColumn>
       </LightCard>
+      {!!exactOutLabel && (
+        <AuxInformationContainer margin="-4px auto" hideInput borderColor={transparentize(0.5, theme.bg0)}>
+          <FeeInformationTooltip
+            amountAfterFees={formatSmart(trade.outputAmount)}
+            amountBeforeFees={formatSmart(trade.outputAmountWithoutFee)}
+            feeAmount={formatSmart(trade.fee.feeAsCurrency)}
+            label={exactOutLabel}
+            showHelper
+            trade={trade}
+            type="To"
+          />
+        </AuxInformationContainer>
+      )}
       <RowBetween style={{ marginTop: '0.25rem', padding: '0 1rem' }}>
         <TYPE.body color={theme.text2} fontWeight={500} fontSize={14}>
           <Trans>Price</Trans>

--- a/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
+++ b/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
@@ -185,7 +185,7 @@ SwapModalHeaderProps) {
           <FeeInformationTooltip
             amountAfterFees={formatSmart(trade.outputAmount)}
             amountBeforeFees={formatSmart(trade.outputAmountWithoutFee)}
-            feeAmount={formatSmart(trade.fee.feeAsCurrency)}
+            feeAmount={formatSmart(trade.outputAmountWithoutFee?.subtract(trade.outputAmount))}
             label={exactOutLabel}
             showHelper
             trade={trade}

--- a/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
+++ b/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
@@ -87,8 +87,9 @@ SwapModalHeaderProps) {
 
   const [showInverted, setShowInverted] = useState<boolean>(false)
 
-  const fiatValueInput = useUSDCValue(trade.inputAmount)
-  const fiatValueOutput = useUSDCValue(trade.outputAmount)
+  // show fiatValue for unadjusted trade amounts!
+  const fiatValueInput = useUSDCValue(trade.inputAmountWithoutFee)
+  const fiatValueOutput = useUSDCValue(trade.outputAmountWithoutFee)
 
   const [slippageIn, slippageOut] = useMemo(
     () => [slippageAdjustedAmounts[Field.INPUT], slippageAdjustedAmounts[Field.OUTPUT]],

--- a/src/custom/components/swap/SwapModalHeader/index.tsx
+++ b/src/custom/components/swap/SwapModalHeader/index.tsx
@@ -7,10 +7,13 @@ import { LightCard as LightCardUni } from 'components/Card'
 import { darken, transparentize } from 'polished'
 
 // MOD
-const LightCard = styled(LightCardUni)`
+const LightCard = styled(LightCardUni)<{ flatBorder?: boolean }>`
   background-color: ${({ theme }) => darken(0.06, theme.bg1)};
   border: 2px solid ${({ theme }) => transparentize(0.5, theme.bg0)};
+  ${({ flatBorder = false }) => flatBorder && `border-radius: 20px 20px 0 0;`}
 `
+
+export type LightCardType = typeof LightCard
 
 const Wrapper = styled.div`
   svg {

--- a/src/custom/components/swap/TradeSummary/TradeSummaryMod.tsx
+++ b/src/custom/components/swap/TradeSummary/TradeSummaryMod.tsx
@@ -46,7 +46,6 @@ export default function TradeSummary({
 }) {
   const theme = useContext(ThemeContext)
   // const { priceImpactWithoutFee, realizedLPFee } = computeTradePriceBreakdown(trade)
-  const { /*priceImpactWithoutFee,*/ realizedFee } = React.useMemo(() => computeTradePriceBreakdown(trade), [trade])
   const isExactIn = trade.tradeType === TradeType.EXACT_INPUT
   const slippageAdjustedAmounts = computeSlippageAdjustedAmounts(trade, allowedSlippage)
 
@@ -57,10 +56,10 @@ export default function TradeSummary({
 
   return (
     <AutoColumn gap="2px">
-      <RowBetween>
+      {/* <RowBetween>
         <RowFixed>
           <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
-            {/* Liquidity Provider Fee */}
+            // Liquidity Provider Fee
             Fee
           </TYPE.black>
           {showHelpers && (
@@ -71,6 +70,17 @@ export default function TradeSummary({
         </RowFixed>
         <TYPE.black textAlign="right" fontSize={12} color={theme.text1}>
           {`${formatSmart(realizedFee) || '-'} ${realizedFee?.currency.symbol}`}
+        </TYPE.black>
+      </RowBetween> */}
+
+      <RowBetween height={24}>
+        <RowFixed>
+          <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
+            <Trans>{trade.tradeType === TradeType.EXACT_INPUT ? 'Receive' : 'From'} (incl. fee)</Trans>
+          </TYPE.black>
+        </RowFixed>
+        <TYPE.black textAlign="right" fontSize={12} color={theme.text1}>
+          {formatSmart(isExactIn ? trade.outputAmount : trade.inputAmountWithFee)}
         </TYPE.black>
       </RowBetween>
 
@@ -100,7 +110,18 @@ export default function TradeSummary({
         </RowBetween> 
         */}
 
-      <RowBetween>
+      <RowBetween height={24}>
+        <RowFixed>
+          <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
+            <Trans>Slippage tolerance</Trans>
+          </TYPE.black>
+        </RowFixed>
+        <TYPE.black textAlign="right" fontSize={12} color={theme.text1}>
+          {allowedSlippage.toFixed(2)}%
+        </TYPE.black>
+      </RowBetween>
+
+      <RowBetween height={24}>
         <RowFixed>
           <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
             {trade.tradeType === TradeType.EXACT_INPUT ? <Trans>Minimum received</Trans> : <Trans>Maximum sent</Trans>}
@@ -126,7 +147,7 @@ export default function TradeSummary({
         </TYPE.black>
       </RowBetween>
 
-      <RowBetween>
+      {/* <RowBetween>
         <RowFixed>
           <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
             <Trans>Slippage tolerance</Trans>
@@ -135,7 +156,7 @@ export default function TradeSummary({
         <TYPE.black textAlign="right" fontSize={12} color={theme.text1}>
           {allowedSlippage.toFixed(2)}%
         </TYPE.black>
-      </RowBetween>
+      </RowBetween> */}
     </AutoColumn>
   )
 }

--- a/src/custom/components/swap/TradeSummary/TradeSummaryMod.tsx
+++ b/src/custom/components/swap/TradeSummary/TradeSummaryMod.tsx
@@ -46,6 +46,7 @@ export default function TradeSummary({
 }) {
   const theme = useContext(ThemeContext)
   // const { priceImpactWithoutFee, realizedLPFee } = computeTradePriceBreakdown(trade)
+  const { /* priceImpactWithoutFee, */ realizedFee } = React.useMemo(() => computeTradePriceBreakdown(trade), [trade])
   const isExactIn = trade.tradeType === TradeType.EXACT_INPUT
   const slippageAdjustedAmounts = computeSlippageAdjustedAmounts(trade, allowedSlippage)
 
@@ -56,10 +57,10 @@ export default function TradeSummary({
 
   return (
     <AutoColumn gap="2px">
-      {/* <RowBetween>
+      <RowBetween height={24}>
         <RowFixed>
           <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
-            // Liquidity Provider Fee
+            {/* Liquidity Provider Fee */}
             Fee
           </TYPE.black>
           {showHelpers && (
@@ -71,7 +72,7 @@ export default function TradeSummary({
         <TYPE.black textAlign="right" fontSize={12} color={theme.text1}>
           {`${formatSmart(realizedFee) || '-'} ${realizedFee?.currency.symbol}`}
         </TYPE.black>
-      </RowBetween> */}
+      </RowBetween>
 
       <RowBetween height={24}>
         <RowFixed>
@@ -80,7 +81,8 @@ export default function TradeSummary({
           </TYPE.black>
         </RowFixed>
         <TYPE.black textAlign="right" fontSize={12} color={theme.text1}>
-          {formatSmart(isExactIn ? trade.outputAmount : trade.inputAmountWithFee)}
+          {formatSmart(isExactIn ? trade.outputAmount : trade.inputAmountWithFee)}{' '}
+          {(isExactIn ? trade.outputAmount : trade.inputAmount).currency.symbol}
         </TYPE.black>
       </RowBetween>
 

--- a/src/custom/components/swap/TradeSummary/TradeSummaryMod.tsx
+++ b/src/custom/components/swap/TradeSummary/TradeSummaryMod.tsx
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro'
 import React, { useContext, useMemo } from 'react'
 import { ThemeContext } from 'styled-components'
-import { CurrencyAmount, Currency, Percent, TradeType } from '@uniswap/sdk-core'
+import { CurrencyAmount, Currency, TradeType } from '@uniswap/sdk-core'
 
 import { Field } from 'state/swap/actions'
 import { TYPE } from 'theme'
@@ -14,6 +14,7 @@ import TradeGp from 'state/swap/TradeGp'
 import { MouseoverTooltipContent } from 'components/Tooltip'
 import { StyledInfo } from 'pages/Swap/SwapMod'
 import { formatSmart } from 'utils/format'
+import { TradeSummaryProps } from '.'
 
 // computes price breakdown for the trade
 export function computeTradePriceBreakdown(trade?: TradeGp | null): {
@@ -38,12 +39,9 @@ export const FEE_TOOLTIP_MSG =
 export default function TradeSummary({
   trade,
   allowedSlippage,
-  showHelpers = true,
-}: {
-  trade: TradeGp
-  allowedSlippage: Percent
-  showHelpers?: boolean
-}) {
+  showHelpers,
+  showFee,
+}: Omit<TradeSummaryProps, 'className'>) {
   const theme = useContext(ThemeContext)
   // const { priceImpactWithoutFee, realizedLPFee } = computeTradePriceBreakdown(trade)
   const { /* priceImpactWithoutFee, */ realizedFee } = React.useMemo(() => computeTradePriceBreakdown(trade), [trade])
@@ -57,22 +55,24 @@ export default function TradeSummary({
 
   return (
     <AutoColumn gap="2px">
-      <RowBetween height={24}>
-        <RowFixed>
-          <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
-            {/* Liquidity Provider Fee */}
-            Fee
+      {showFee && (
+        <RowBetween height={24}>
+          <RowFixed>
+            <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
+              {/* Liquidity Provider Fee */}
+              Fee
+            </TYPE.black>
+            {showHelpers && (
+              <MouseoverTooltipContent content={FEE_TOOLTIP_MSG} bgColor={theme.bg1} color={theme.text1}>
+                <StyledInfo />
+              </MouseoverTooltipContent>
+            )}
+          </RowFixed>
+          <TYPE.black textAlign="right" fontSize={12} color={theme.text1}>
+            {`${formatSmart(realizedFee) || '-'} ${realizedFee?.currency.symbol}`}
           </TYPE.black>
-          {showHelpers && (
-            <MouseoverTooltipContent content={FEE_TOOLTIP_MSG} bgColor={theme.bg1} color={theme.text1}>
-              <StyledInfo />
-            </MouseoverTooltipContent>
-          )}
-        </RowFixed>
-        <TYPE.black textAlign="right" fontSize={12} color={theme.text1}>
-          {`${formatSmart(realizedFee) || '-'} ${realizedFee?.currency.symbol}`}
-        </TYPE.black>
-      </RowBetween>
+        </RowBetween>
+      )}
 
       <RowBetween height={24}>
         <RowFixed>

--- a/src/custom/components/swap/TradeSummary/index.tsx
+++ b/src/custom/components/swap/TradeSummary/index.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 import styled from 'styled-components'
 import TradeSummaryMod from './TradeSummaryMod'
 import { RowFixed } from 'components/Row'
-import TradeGp from 'state/swap/TradeGp'
-import { Percent } from '@uniswap/sdk-core'
+import { WithClassName } from 'types'
+import { AdvancedSwapDetailsProps } from '../AdvancedSwapDetails'
 
 const Wrapper = styled.div`
   ${RowFixed} {
@@ -13,20 +13,12 @@ const Wrapper = styled.div`
   }
 `
 
-export default function TradeSummary({
-  className,
-  trade,
-  allowedSlippage,
-  showHelpers,
-}: {
-  trade: TradeGp
-  allowedSlippage: Percent
-  className?: string
-  showHelpers?: boolean
-}) {
+export type TradeSummaryProps = Required<AdvancedSwapDetailsProps> & WithClassName
+
+export default function TradeSummary({ className, trade, allowedSlippage, showHelpers, showFee }: TradeSummaryProps) {
   return (
     <Wrapper className={className}>
-      <TradeSummaryMod trade={trade} allowedSlippage={allowedSlippage} showHelpers={showHelpers} />
+      <TradeSummaryMod trade={trade} allowedSlippage={allowedSlippage} showHelpers={showHelpers} showFee={showFee} />
     </Wrapper>
   )
 }

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -650,7 +650,12 @@ export default function Swap({
                         />
                         <MouseoverTooltipContent
                           content={
-                            <AdvancedSwapDetails trade={trade} allowedSlippage={allowedSlippage} showHelpers={false} />
+                            <AdvancedSwapDetails
+                              trade={trade}
+                              allowedSlippage={allowedSlippage}
+                              showHelpers={false}
+                              showFee={false}
+                            />
                           }
                           bgColor={theme.bg1}
                           color={theme.text4}

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -744,9 +744,8 @@ export default function Swap({
                       approvalSubmitted ||
                       signatureState === UseERC20PermitState.SIGNED
                     }
-                    // TODO: check width with new v3 design
-                    // width="48%" // GP-WIDTH
                     width="100%"
+                    marginBottom={10}
                     altDisabledStyle={approvalState === ApprovalState.PENDING} // show solid button while waiting
                     confirmed={
                       approvalState === ApprovalState.APPROVED || signatureState === UseERC20PermitState.SIGNED


### PR DESCRIPTION
# Summary

Fixes #1006 

*Fixes issues/comments in #1006 regarding the price display changes/tooltips*

main swap page with tooltip open
![image](https://user-images.githubusercontent.com/21335563/126567613-288861c3-80f4-4372-9051-5eaf7320408f.png)

confirmation modal
![image](https://user-images.githubusercontent.com/21335563/126567647-530c3c55-e90f-4bd7-926b-2e201b0e5010.png)

  # To Test

1. setup a trade
- [ ] look at the displayed prices/amounts in the primary inputs and make sure that they are PRE-FEES
- [ ] look at the amount below the dependent fields to make sure they are POST-FEES (e.g Receive (incl. fees) field)
2. Hit swap
- [ ] make sure the amounts are shown the same in the confirmation modals
- [ ] make sure the auxiliary data showing amounts WITH fees are shown properly
3. check the tooltips on all pages that the calculations are correct

