### PR TITLE
[984] Fix fee colour and tooltip bg colour

### DIFF
--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -15,13 +15,14 @@ import { InputContainer } from 'components/AddressInputPanel'
 import { GreyCard } from 'components/Card'
 import { StyledBalanceMaxMini } from 'components/swap/styleds'
 import Card from 'components/Card'
-import QuestionHelper from 'components/QuestionHelper'
 import { ButtonError, ButtonPrimary } from 'components/Button'
 import EthWethWrap, { Props as EthWethWrapProps } from 'components/swap/EthWethWrap'
 import { useReplaceSwapState, useSwapState } from 'state/swap/hooks'
 import { ArrowWrapperLoader, ArrowWrapperLoaderProps, Wrapper as ArrowWrapper } from 'components/ArrowWrapperLoader'
 import { LONG_LOAD_THRESHOLD, SHORT_PRECISION } from 'constants/index'
 import { formatSmart } from 'utils/format'
+import { MouseoverTooltipContent } from 'components/Tooltip'
+import { StyledInfo } from 'pages/Swap/SwapMod'
 
 interface FeeGreaterMessageProp {
   fee: CurrencyAmount<Currency>
@@ -117,10 +118,16 @@ function FeeGreaterMessage({ fee }: FeeGreaterMessageProp) {
   return (
     <RowBetween>
       <RowFixed>
-        <TYPE.black fontSize={14} fontWeight={400} color={theme.text2}>
+        <TYPE.black fontSize={14} fontWeight={400} color={theme.text1}>
           Fee
         </TYPE.black>
-        <QuestionHelper text="GP Swap has 0 gas fees. A portion of the sell amount in each trade goes to the GP Protocol." />
+        <MouseoverTooltipContent
+          bgColor={theme.bg1}
+          color={theme.text1}
+          content="GP Swap has 0 gas fees. A portion of the sell amount in each trade goes to the GP Protocol."
+        >
+          <StyledInfo />
+        </MouseoverTooltipContent>
       </RowFixed>
       <TYPE.black fontSize={14} color={theme.text1}>
         {formatSmart(fee, SHORT_PRECISION)} {fee.currency.symbol}


### PR DESCRIPTION
# Summary

Fixes #984 

*Fixes the shitty colour for darkmode when fee > input*

![image](https://user-images.githubusercontent.com/21335563/126613885-605da77d-22f1-4b13-bd30-451ee788b468.png)

  # To Test

1. pick weth
2. enter a tiny amount 0.00000001
3. observe fee show up with hover info thing
4. observe it works and looks great, A+ stuff


