### PR TITLE
[1010] Fix broken ether on xdai chain

### DIFF
--- a/src/custom/hooks/useSwapCallback.ts
+++ b/src/custom/hooks/useSwapCallback.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Currency, Ether as ETHER, Percent, TradeType, CurrencyAmount } from '@uniswap/sdk-core'
+import { Currency, /* Ether as ETHER, */ Percent, TradeType, CurrencyAmount } from '@uniswap/sdk-core'
 import { OrderKind } from '@gnosis.pm/gp-v2-contracts'
 
 import { INITIAL_ALLOWED_SLIPPAGE_PERCENT } from 'constants/index'
@@ -17,6 +17,7 @@ import { sendOrder } from 'utils/trade'
 import TradeGp from 'state/swap/TradeGp'
 import { useUserTransactionTTL } from '@src/state/user/hooks'
 import { BigNumber } from 'ethers'
+import { GpEther as ETHER } from 'constants/tokens'
 
 const MAX_VALID_TO_EPOCH = BigNumber.from('0xFFFFFFFF').toNumber() // Max uint32 (Feb 07 2106 07:28:15 GMT+0100)
 


### PR DESCRIPTION
# Summary

Fixes #1010

*App was whitescreening on XDAI when switching from WXDAI to XDAI because the wrong Ether sdk was being pulled in to useSwapCallback. Now uses the GpEther as it should*

![image](https://user-images.githubusercontent.com/21335563/126623052-97d572d9-b4fe-4725-b06a-bc9c9d97d3ee.png)

  # To Test

instructions inside #1010 