### PR TITLE
978/disable gasless token allowances

### DIFF
--- a/src/custom/hooks/useERC20Permit/useERC20PermitMod.ts
+++ b/src/custom/hooks/useERC20Permit/useERC20PermitMod.ts
@@ -1,5 +1,5 @@
 // import JSBI from 'jsbi'
-import { Percent /* CurrencyAmount, Currency, TradeType, Token */ } from '@uniswap/sdk-core'
+import { Percent, CurrencyAmount, Currency /*, TradeType, Token */ } from '@uniswap/sdk-core'
 // import { Trade as V2Trade } from '@uniswap/v2-sdk'
 // import { Trade as V3Trade } from '@uniswap/v3-sdk'
 // import { splitSignature } from 'ethers/lib/utils'
@@ -12,7 +12,7 @@ import { useActiveWeb3React } from 'hooks/web3'
 // import useIsArgentWallet from 'hooks/useIsArgentWallet'
 // import useTransactionDeadline from 'hooks/useTransactionDeadline'
 
-import { useERC20Permit } from '@src/hooks/useERC20Permit'
+import { PermitInfo, SignatureData, UseERC20PermitState } from '@src/hooks/useERC20Permit'
 import TradeGp from 'state/swap/TradeGp'
 import { GP_ALLOWANCE_MANAGER_CONTRACT_ADDRESS } from 'custom/constants'
 
@@ -120,15 +120,24 @@ export * from '@src/hooks/useERC20Permit'
 //   { name: 'allowed', type: 'bool' },
 // ]
 
-// export function useERC20Permit(
-//   currencyAmount: CurrencyAmount<Currency> | null | undefined,
-//   spender: string | null | undefined,
-//   overridePermitInfo: PermitInfo | undefined | null
-// ): {
-//   signatureData: SignatureData | null
-//   state: UseERC20PermitState
-//   gatherPermitSignature: null | (() => Promise<void>)
-// } {
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export function useERC20Permit(
+  currencyAmount: CurrencyAmount<Currency> | null | undefined,
+  spender: string | null | undefined,
+  overridePermitInfo: PermitInfo | undefined | null
+): {
+  signatureData: SignatureData | null
+  state: UseERC20PermitState
+  gatherPermitSignature: null | (() => Promise<void>)
+} {
+  // Mod: make useERC20Permit a noop. Permissable ERC20 currently not supported by our contracts
+  return {
+    signatureData: null,
+    state: UseERC20PermitState.NOT_APPLICABLE,
+    gatherPermitSignature: null,
+  }
+}
+/* eslint-enable @typescript-eslint/no-unused-vars */
 //   const { account, chainId, library } = useActiveWeb3React()
 //   const transactionDeadline = useTransactionDeadline()
 //   const tokenAddress = currencyAmount?.currency?.isToken ? currencyAmount.currency.address : undefined

--- a/src/hooks/useERC20Permit.ts
+++ b/src/hooks/useERC20Permit.ts
@@ -20,7 +20,7 @@ enum PermitType {
 // 20 minutes to submit after signing
 const PERMIT_VALIDITY_BUFFER = 20 * 60
 
-interface PermitInfo {
+export interface PermitInfo {
   type: PermitType
   name: string
   // version is optional, and if omitted, will not be included in the domain


### PR DESCRIPTION
# Summary

Fixes #978 

Disabling permissable tokens.

Our contracts have no support for it yet.
Disabling it for now

  # To Test

1. With an account that either has never approved UNI or you have yourself revoked the allowance (see [etherscan](https://etherscan.io/tokenapprovalchecker) or https://app.unrekt.net/
2. Get some UNI in your account (transfer from another account, swap it from WETH, etc...)
3. Sell UNI for any other token
- [ ] `Approve uni` button should be visible
![screenshot_2021-07-22_10-49-13](https://user-images.githubusercontent.com/43217/126685198-596d1437-6ad7-4945-b570-eb8b9ce4a5e1.png)
4. Click on approve UNI
- [ ] You should get a prompt on your wallet to execute and **approval transaction** (not **sign** it)
5. Send the tx
6. After tx is mined, Swap
- [ ] Swap should be placed and executed successfully

7. Repeat the process with a token that's no permissable, for example GNO
- [ ] Should be allowed to allow and place orders the same way

**Note:** These steps can be performed on any network, as UNI is available on all of them. For a list of which token is permissable on each network, see https://github.com/gnosis/cowswap/blob/d0caeb0d562b5263c09fb2be5ad617e7e1169a27/src/hooks/useERC20Permit.ts#L31-L55
