### PR TITLE
Fix search token

### DIFF
--- a/src/custom/components/CurrencyInputPanel/CurrencyInputPanelMod.tsx
+++ b/src/custom/components/CurrencyInputPanel/CurrencyInputPanelMod.tsx
@@ -4,7 +4,8 @@ import React, { useState, useCallback, ReactNode } from 'react'
 import styled from 'styled-components/macro'
 import { darken } from 'polished'
 import { useCurrencyBalance } from 'state/wallet/hooks'
-import CurrencySearchModalUni from '@src/components/SearchModal/CurrencySearchModal'
+// import CurrencySearchModal from '../SearchModal/CurrencySearchModal'
+import { CurrencySearchModal } from '.' // mod
 import CurrencyLogo from 'components/CurrencyLogo'
 import DoubleCurrencyLogo from 'components/DoubleLogo'
 // import { ButtonGray } from '../Button'
@@ -24,12 +25,6 @@ import { WithClassName } from 'types'
 import { formatSmart } from 'utils/format'
 import { SHORT_PRECISION } from 'constants/index'
 import { FeeInformationTooltipWrapper } from 'components/swap/FeeInformationTooltip'
-
-export const CurrencySearchModal = styled(CurrencySearchModalUni)`
-  > [data-reach-dialog-content] {
-    background-color: ${({ theme }) => theme.bg1};
-  }
-`
 
 export const InputPanel = styled.div<{ hideInput?: boolean }>`
   ${({ theme }) => theme.flexColumnNoWrap}

--- a/src/custom/components/CurrencyInputPanel/index.tsx
+++ b/src/custom/components/CurrencyInputPanel/index.tsx
@@ -14,11 +14,19 @@ import CurrencyInputPanelMod, {
   Container,
   StyledBalanceMax,
 } from './CurrencyInputPanelMod'
+import CurrencySearchModalUni from '@src/components/SearchModal/CurrencySearchModal'
 import { RowBetween } from 'components/Row'
 import { FeeInformationTooltipWrapper } from 'components/swap/FeeInformationTooltip'
 
 import { StyledLogo } from 'components/CurrencyLogo'
 import { LONG_LOAD_THRESHOLD } from 'constants/index'
+
+export const CurrencySearchModal = styled(CurrencySearchModalUni)`
+  > [data-reach-dialog-content] {
+    max-width: 520px;
+    background-color: ${({ theme }) => theme.bg1};
+  }
+`
 
 export const Wrapper = styled.div<{ selected: boolean; showLoader: boolean }>`
   // CSS Override

--- a/src/custom/components/SearchModal/CurrencyList/CurrencyListMod.tsx
+++ b/src/custom/components/SearchModal/CurrencyList/CurrencyListMod.tsx
@@ -14,7 +14,8 @@ import Column from 'components/Column'
 import { RowFixed, RowBetween } from 'components/Row'
 import CurrencyLogo from 'components/CurrencyLogo'
 import { MouseoverTooltip } from 'components/Tooltip'
-import { MenuItem } from 'components/SearchModal/styleds'
+// import { MenuItem } from 'components/SearchModal/styleds'
+import { MenuItem } from '.' // mod
 import Loader from 'components/Loader'
 import { isTokenOnList } from 'utils'
 import ImportRow from 'components/SearchModal/ImportRow'
@@ -51,7 +52,7 @@ export const Tag = styled.div`
   margin-right: 4px;
 `
 
-const FixedContentRow = styled.div`
+export const FixedContentRow = styled.div`
   padding: 4px 20px;
   height: 56px;
   display: grid;

--- a/src/custom/components/SearchModal/CurrencyList/index.tsx
+++ b/src/custom/components/SearchModal/CurrencyList/index.tsx
@@ -2,9 +2,8 @@ import React from 'react'
 import styled from 'styled-components'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import { LONG_PRECISION, UNSUPPORTED_TOKENS_FAQ_URL } from 'constants/index'
-import CurrencyListMod, { StyledBalanceText, Tag as TagMod, TagContainer } from './CurrencyListMod'
+import CurrencyListMod, { FixedContentRow, StyledBalanceText, Tag as TagMod, TagContainer } from './CurrencyListMod'
 import { StyledLogo } from 'components/CurrencyLogo'
-import { MenuItem } from 'components/SearchModal/styleds'
 import { MouseoverTooltip } from 'components/Tooltip'
 import { RowFixed } from 'components/Row'
 import { LightGreyCard } from 'components/Card'
@@ -12,6 +11,8 @@ import { HashLink } from 'react-router-hash-link'
 import { t } from '@lingui/macro'
 import { TagInfo, WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
 import { formatSmart } from 'utils/format'
+import Column from 'components/Column'
+import { MenuItem as MenuItemMod } from '@src/components/SearchModal/styleds'
 
 const UNSUPPORTED_TOKEN_TAG = [
   {
@@ -37,10 +38,18 @@ const TagLink = styled(Tag)`
 `
 
 const Wrapper = styled.div`
-  ${MenuItem} {
-    &:hover {
-      background-color: ${({ theme }) => theme.bg4};
+  ${Column} {
+    display: flex;
+    flex-flow: column wrap;
+    word-break: break-word;
+    text-overflow: ellipsis;
+    > div {
+      flex: 0;
     }
+  }
+
+  ${FixedContentRow} {
+    background: red;
   }
 
   ${StyledLogo} {
@@ -57,6 +66,12 @@ const Wrapper = styled.div`
 
   ${LightGreyCard} ${RowFixed} > div {
     color: ${({ theme }) => theme.text2};
+  }
+`
+
+export const MenuItem = styled(MenuItemMod)`
+  &:hover {
+    background-color: ${({ theme, disabled }) => !disabled && theme.bg4};
   }
 `
 

--- a/src/custom/components/SearchModal/CurrencyList/index.tsx
+++ b/src/custom/components/SearchModal/CurrencyList/index.tsx
@@ -64,8 +64,12 @@ const Wrapper = styled.div`
     color: ${({ theme }) => theme.text1};
   }
 
+  ${LightGreyCard} {
+    background: ${({ theme }) => theme.bg4};
+  }
+
   ${LightGreyCard} ${RowFixed} > div {
-    color: ${({ theme }) => theme.text2};
+    color: ${({ theme }) => theme.text1};
   }
 `
 

--- a/src/custom/components/SearchModal/CurrencyList/index.tsx
+++ b/src/custom/components/SearchModal/CurrencyList/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import { LONG_PRECISION, UNSUPPORTED_TOKENS_FAQ_URL } from 'constants/index'
-import CurrencyListMod, { FixedContentRow, StyledBalanceText, Tag as TagMod, TagContainer } from './CurrencyListMod'
+import CurrencyListMod, { StyledBalanceText, Tag as TagMod, TagContainer } from './CurrencyListMod'
 import { StyledLogo } from 'components/CurrencyLogo'
 import { MouseoverTooltip } from 'components/Tooltip'
 import { RowFixed } from 'components/Row'
@@ -39,17 +39,17 @@ const TagLink = styled(Tag)`
 
 const Wrapper = styled.div`
   ${Column} {
-    display: flex;
-    flex-flow: column wrap;
-    word-break: break-word;
-    text-overflow: ellipsis;
     > div {
-      flex: 0;
-    }
-  }
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      max-width: 220px;
+      width: 100%;
 
-  ${FixedContentRow} {
-    background: red;
+      ${({ theme }) => theme.mediaWidth.upToSmall`
+        max-width: 140px;
+      `};
+    }
   }
 
   ${StyledLogo} {


### PR DESCRIPTION
# Summary

Addresses #1021 

- Makes the token search modal a bit wider (desktop)
- Introduces text ellipsis (CSS) with a max-width for the text container (to support text-overflow: ellipsis) 
- Mobile responsive

<img width="400" alt="Screen Shot 2021-07-23 at 13 16 47" src="https://user-images.githubusercontent.com/31534717/126774868-41edd41a-3b0a-4321-aafc-5e53a97ad053.png"><img width="400" alt="Screen Shot 2021-07-23 at 13 15 57" src="https://user-images.githubusercontent.com/31534717/126774878-8475197e-b7f7-4fdc-bb49-648fd3b04ad4.png"><img width="400" alt="Screen Shot 2021-07-23 at 13 15 36" src="https://user-images.githubusercontent.com/31534717/126774881-9f3b5fd9-2550-414f-ba44-8cb37725683e.png">


  