### PR TITLE
[1057] Fix mobile swap confirmation styling

### DIFF
--- a/src/custom/components/AccountDetails/AccountDetailsMod.tsx
+++ b/src/custom/components/AccountDetails/AccountDetailsMod.tsx
@@ -103,6 +103,11 @@ export const LowerSection = styled.div`
   border-bottom-left-radius: 20px;
   border-bottom-right-radius: 20px;
 
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    border-radius: 0;
+    margin-bottom: 16px;
+  `}
+
   h5 {
     margin: 0;
     font-weight: 400;

--- a/src/custom/components/AccountDetails/Transaction.tsx
+++ b/src/custom/components/AccountDetails/Transaction.tsx
@@ -24,7 +24,7 @@ import { useCancelOrder } from 'hooks/useCancelOrder'
 import { LinkStyledButton } from 'theme'
 import { ButtonPrimary } from 'components/Button'
 import { MouseoverTooltip } from 'components/Tooltip'
-import { GpModal as Modal } from 'components/WalletModal'
+import { GpModal as Modal } from 'components/Modal'
 
 const PILL_COLOUR_MAP = {
   CONFIRMED: '#1b7b43',

--- a/src/custom/components/Modal/index.ts
+++ b/src/custom/components/Modal/index.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 import Modal from '@src/components/Modal'
+import { HeaderRow, ContentWrapper, CloseIcon, HoverText } from 'components/WalletModal/WalletModalMod'
 
 export * from '@src/components/Modal'
 export { default } from '@src/components/Modal'
@@ -8,21 +9,42 @@ export const GpModal = styled(Modal)`
   > [data-reach-dialog-content] {
     background-color: ${({ theme }) => theme.bg1};
 
-    .bottom-close-button {
-      display: none;
-      margin: auto auto 8px;
-
-      ${({ theme }) => theme.mediaWidth.upToExtraSmall`
-      display: flex;
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      max-height: 100%;
+      height: 100%;
+      width: 100vw;
+      border-radius: 0;
     `}
+
+    ${HeaderRow} {
+      ${({ theme }) => theme.mediaWidth.upToSmall`
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        padding: 16px;
+        background: ${({ theme }) => theme.bg1};
+        z-index: 20;
+      `}
     }
 
-    ${({ theme }) => theme.mediaWidth.upToExtraSmall`
-    max-height: 100vh;
-    height: 100vh;
-    max-width: 100vw;
-    width:  100vw;
-    border-radius: 0px;
-  `}
+    ${CloseIcon} {
+      ${({ theme }) => theme.mediaWidth.upToSmall`
+        z-index: 21;
+        position: fixed;
+      `}
+    }
+
+    ${HoverText} {
+      ${({ theme }) => theme.mediaWidth.upToSmall`
+        white-space: nowrap;
+      `}
+    }
+
+    ${ContentWrapper} {
+      ${({ theme }) => theme.mediaWidth.upToSmall`
+        margin: 62px auto 0;
+      `}
+    }
   }
 `

--- a/src/custom/components/Modal/index.ts
+++ b/src/custom/components/Modal/index.ts
@@ -1,0 +1,28 @@
+import styled from 'styled-components'
+import Modal from '@src/components/Modal'
+
+export * from '@src/components/Modal'
+export { default } from '@src/components/Modal'
+
+export const GpModal = styled(Modal)`
+  > [data-reach-dialog-content] {
+    background-color: ${({ theme }) => theme.bg1};
+
+    .bottom-close-button {
+      display: none;
+      margin: auto auto 0;
+
+      ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+      display: flex;
+    `}
+    }
+
+    ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    max-height: 100vh;
+    height: 100vh;
+    max-width: 100vw;
+    width:  100vw;
+    border-radius: 0px;
+  `}
+  }
+`

--- a/src/custom/components/Modal/index.ts
+++ b/src/custom/components/Modal/index.ts
@@ -10,7 +10,7 @@ export const GpModal = styled(Modal)`
 
     .bottom-close-button {
       display: none;
-      margin: auto auto 0;
+      margin: auto auto 8px;
 
       ${({ theme }) => theme.mediaWidth.upToExtraSmall`
       display: flex;

--- a/src/custom/components/TransactionConfirmationModal/TransactionConfirmationModalMod.tsx
+++ b/src/custom/components/TransactionConfirmationModal/TransactionConfirmationModalMod.tsx
@@ -29,7 +29,7 @@ import { Trans } from '@lingui/macro'
 // import { getEtherscanLink, getExplorerLabel } from 'utils'
 import { GpModal } from 'components/Modal'
 import { lighten } from 'polished'
-import { ConfirmationModalContentProps, TransactionSubmittedContent } from './index' // mod
+import { ConfirmationModalContentProps, TransactionSubmittedContent, GPModalHeader } from '.' // mod
 
 const Wrapper = styled.div`
   width: 100%;
@@ -185,27 +185,26 @@ export function ConfirmationModalContent({
   bottomContent,
   onDismiss,
   topContent,
-  CloseModalLink,
 }: ConfirmationModalContentProps) {
   /* {
   title: ReactNode
   onDismiss: () => void
   topContent: () => ReactNode
   bottomContent?: () => ReactNode | undefined
-  CloseModalLink: () => ReactNode // mod
 } */ return (
     <Wrapper>
       <Section>
-        <RowBetween>
+        {/* <RowBetween> */}
+        <GPModalHeader>
           <Text fontWeight={500} fontSize={16}>
             {title}
           </Text>
           <CloseIcon onClick={onDismiss} />
-        </RowBetween>
+        </GPModalHeader>
+        {/* </RowBetween> */}
         {topContent()}
       </Section>
       {bottomContent && <BottomSection gap="12px">{bottomContent()}</BottomSection>}
-      <CloseModalLink closeModalCb={onDismiss} />
     </Wrapper>
   )
 }

--- a/src/custom/components/TransactionConfirmationModal/TransactionConfirmationModalMod.tsx
+++ b/src/custom/components/TransactionConfirmationModal/TransactionConfirmationModalMod.tsx
@@ -36,6 +36,7 @@ const Wrapper = styled.div`
   padding: 1rem;
   display: flex; /* MOD */
   flex-flow: column nowrap; /* MOD */
+  overflow-y: auto; /* MOD */
 `
 const Section = styled(AutoColumn)<{ inline?: boolean }>`
   padding: ${({ inline }) => (inline ? '0' : '0')};
@@ -44,6 +45,9 @@ const Section = styled(AutoColumn)<{ inline?: boolean }>`
 const BottomSection = styled(Section)`
   border-bottom-left-radius: 20px;
   border-bottom-right-radius: 20px;
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    margin-bottom: 16px;
+  `}
 `
 
 const ConfirmedIcon = styled(ColumnCenter)<{ inline?: boolean }>`

--- a/src/custom/components/TransactionConfirmationModal/TransactionConfirmationModalMod.tsx
+++ b/src/custom/components/TransactionConfirmationModal/TransactionConfirmationModalMod.tsx
@@ -27,13 +27,15 @@ import { useActiveWeb3React } from 'hooks/web3'
 import { Trans } from '@lingui/macro'
 // MOD
 // import { getEtherscanLink, getExplorerLabel } from 'utils'
-import { GpModal } from 'components/WalletModal'
+import { GpModal } from 'components/Modal'
 import { lighten } from 'polished'
-import { TransactionSubmittedContent } from './index'
+import { ConfirmationModalContentProps, TransactionSubmittedContent } from './index' // mod
 
 const Wrapper = styled.div`
   width: 100%;
   padding: 1rem;
+  display: flex; /* MOD */
+  flex-flow: column nowrap; /* MOD */
 `
 const Section = styled(AutoColumn)<{ inline?: boolean }>`
   padding: ${({ inline }) => (inline ? '0' : '0')};
@@ -179,13 +181,15 @@ export function ConfirmationModalContent({
   bottomContent,
   onDismiss,
   topContent,
-}: {
+  CloseModalLink,
+}: ConfirmationModalContentProps) {
+  /* {
   title: ReactNode
   onDismiss: () => void
   topContent: () => ReactNode
   bottomContent?: () => ReactNode | undefined
-}) {
-  return (
+  CloseModalLink: () => ReactNode // mod
+} */ return (
     <Wrapper>
       <Section>
         <RowBetween>
@@ -197,6 +201,7 @@ export function ConfirmationModalContent({
         {topContent()}
       </Section>
       {bottomContent && <BottomSection gap="12px">{bottomContent()}</BottomSection>}
+      <CloseModalLink closeModalCb={onDismiss} />
     </Wrapper>
   )
 }

--- a/src/custom/components/TransactionConfirmationModal/index.tsx
+++ b/src/custom/components/TransactionConfirmationModal/index.tsx
@@ -5,11 +5,11 @@ import React, { ReactNode, useContext } from 'react'
 import styled, { ThemeContext } from 'styled-components'
 import { CloseIcon } from 'theme'
 import { ExternalLink } from 'theme'
-import { RowFixed } from 'components/Row'
+import { RowBetween, RowFixed } from 'components/Row'
 import MetaMaskLogo from 'assets/images/metamask.png'
 import { getEtherscanLink, getExplorerLabel } from 'utils'
 import { Text } from 'rebass'
-import { ArrowLeft, ArrowUpCircle, CheckCircle } from 'react-feather'
+import { ArrowUpCircle, CheckCircle } from 'react-feather'
 import useAddTokenToMetamask from 'hooks/useAddTokenToMetamask'
 import GameIcon from 'assets/cow-swap/game.gif'
 import { Link } from 'react-router-dom'
@@ -37,6 +37,18 @@ const CloseLink = styled.span`
   color: ${({ theme }) => theme.primary1};
   cursor: pointer;
   margin: 8px auto;
+`
+
+export const GPModalHeader = styled(RowBetween)`
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 16px;
+    background: ${({ theme }) => theme.bg1};
+    z-index: 20;
+  `}
 `
 
 const InternalLink = styled(Link)``
@@ -178,36 +190,8 @@ export interface ConfirmationModalContentProps {
   onDismiss: () => void
   topContent: () => ReactNode
   bottomContent?: () => ReactNode | undefined
-  CloseModalLink: (props: CloseModalProps) => JSX.Element // mod
 }
 
-interface CloseModalProps {
-  closeModalCb: () => void
-}
-
-const CloseModalWrapper = styled.div`
-  display: flex;
-  flex-flow: row nowrap;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  color: ${({ theme }) => theme.text3};
-  font-size: smaller;
-  cursor: pointer;
-
-  > span:nth-of-type(2) {
-    text-decoration: underline;
-    margin-left: 3px;
-  }
-`
-
-export const CloseModalLink = ({ closeModalCb }: CloseModalProps) => (
-  <CloseModalWrapper className="bottom-close-button" onClick={closeModalCb}>
-    <ArrowLeft size={16} />
-    <span>Close modal and go back</span>
-  </CloseModalWrapper>
-)
-
-export function ConfirmationModalContent(props: Omit<ConfirmationModalContentProps, 'CloseModalLink'>) {
-  return <ConfirmationModalContentMod {...props} CloseModalLink={CloseModalLink} />
+export function ConfirmationModalContent(props: ConfirmationModalContentProps) {
+  return <ConfirmationModalContentMod {...props} />
 }

--- a/src/custom/components/TransactionConfirmationModal/index.tsx
+++ b/src/custom/components/TransactionConfirmationModal/index.tsx
@@ -1,7 +1,7 @@
 import { Currency } from '@uniswap/sdk-core'
 import { useActiveWeb3React } from 'hooks/web3'
 import { SupportedChainId as ChainId } from 'constants/chains'
-import React, { useContext } from 'react'
+import React, { ReactNode, useContext } from 'react'
 import styled, { ThemeContext } from 'styled-components'
 import { CloseIcon } from 'theme'
 import { ExternalLink } from 'theme'
@@ -9,10 +9,11 @@ import { RowFixed } from 'components/Row'
 import MetaMaskLogo from 'assets/images/metamask.png'
 import { getEtherscanLink, getExplorerLabel } from 'utils'
 import { Text } from 'rebass'
-import { ArrowUpCircle, CheckCircle } from 'react-feather'
+import { ArrowLeft, ArrowUpCircle, CheckCircle } from 'react-feather'
 import useAddTokenToMetamask from 'hooks/useAddTokenToMetamask'
 import GameIcon from 'assets/cow-swap/game.gif'
 import { Link } from 'react-router-dom'
+import { ConfirmationModalContent as ConfirmationModalContentMod } from './TransactionConfirmationModalMod'
 
 const Wrapper = styled.div`
   width: 100%;
@@ -103,6 +104,9 @@ const CheckCircleCustom = styled(CheckCircle)`
   margin: 0 10px 0 0;
 `
 
+export * from './TransactionConfirmationModalMod'
+export { default } from './TransactionConfirmationModalMod'
+
 export function TransactionSubmittedContent({
   onDismiss,
   chainId,
@@ -169,5 +173,41 @@ export function TransactionSubmittedContent({
   )
 }
 
-export * from './TransactionConfirmationModalMod'
-export { default } from './TransactionConfirmationModalMod'
+export interface ConfirmationModalContentProps {
+  title: ReactNode
+  onDismiss: () => void
+  topContent: () => ReactNode
+  bottomContent?: () => ReactNode | undefined
+  CloseModalLink: (props: CloseModalProps) => JSX.Element // mod
+}
+
+interface CloseModalProps {
+  closeModalCb: () => void
+}
+
+const CloseModalWrapper = styled.div`
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  color: ${({ theme }) => theme.text3};
+  font-size: smaller;
+  cursor: pointer;
+
+  > span:nth-of-type(2) {
+    text-decoration: underline;
+    margin-left: 3px;
+  }
+`
+
+const CloseModalLink = ({ closeModalCb }: CloseModalProps) => (
+  <CloseModalWrapper className="bottom-close-button" onClick={closeModalCb}>
+    <ArrowLeft size={16} />
+    <span>Close modal and go back</span>
+  </CloseModalWrapper>
+)
+
+export function ConfirmationModalContent(props: Omit<ConfirmationModalContentProps, 'CloseModalLink'>) {
+  return <ConfirmationModalContentMod {...props} CloseModalLink={CloseModalLink} />
+}

--- a/src/custom/components/TransactionConfirmationModal/index.tsx
+++ b/src/custom/components/TransactionConfirmationModal/index.tsx
@@ -201,7 +201,7 @@ const CloseModalWrapper = styled.div`
   }
 `
 
-const CloseModalLink = ({ closeModalCb }: CloseModalProps) => (
+export const CloseModalLink = ({ closeModalCb }: CloseModalProps) => (
   <CloseModalWrapper className="bottom-close-button" onClick={closeModalCb}>
     <ArrowLeft size={16} />
     <span>Close modal and go back</span>

--- a/src/custom/components/WalletModal/WalletModalMod.tsx
+++ b/src/custom/components/WalletModal/WalletModalMod.tsx
@@ -49,6 +49,12 @@ const Wrapper = styled.div`
   padding: 0;
   width: 100%;
   overflow-y: auto; /* MOD */
+
+  > .bottom-close-button {
+    &&&&& {
+      margin-bottom: 16px;
+    }
+  }
 `
 
 const HeaderRow = styled.div`

--- a/src/custom/components/WalletModal/WalletModalMod.tsx
+++ b/src/custom/components/WalletModal/WalletModalMod.tsx
@@ -25,9 +25,8 @@ import ModalMod from '@src/components/Modal'
 import Option from 'components/WalletModal/Option'
 import PendingView from 'components/WalletModal/PendingView'
 import { LightCard } from 'components/Card'
-import { CloseModalLink } from 'components/TransactionConfirmationModal' // mod
 
-const CloseIcon = styled.div`
+export const CloseIcon = styled.div`
   position: absolute;
   right: 1rem;
   top: 14px;
@@ -49,15 +48,9 @@ const Wrapper = styled.div`
   padding: 0;
   width: 100%;
   overflow-y: auto; /* MOD */
-
-  > .bottom-close-button {
-    &&&&& {
-      margin-bottom: 16px;
-    }
-  }
 `
 
-const HeaderRow = styled.div`
+export const HeaderRow = styled.div`
   ${({ theme }) => theme.flexRowNoWrap};
   padding: 1rem 1rem;
   font-weight: 500;
@@ -67,7 +60,7 @@ const HeaderRow = styled.div`
   `};
 `
 
-const ContentWrapper = styled.div`
+export const ContentWrapper = styled.div`
   /* background-color: ${({ theme }) => theme.bg0}; */
   background-color: ${({ theme }) => theme.bg1};
   padding: 0 1rem 1rem 1rem;
@@ -106,7 +99,7 @@ const OptionGrid = styled.div`
   `};
 `
 
-const HoverText = styled.div`
+export const HoverText = styled.div`
   text-decoration: none;
   color: ${({ theme }) => theme.text1};
   display: flex;
@@ -400,10 +393,7 @@ export default function WalletModal({
 
   return (
     <Modal isOpen={walletModalOpen} onDismiss={toggleWalletModal} minHeight={false} maxHeight={90}>
-      <Wrapper>
-        {getModalContent()}
-        <CloseModalLink closeModalCb={toggleWalletModal} /> {/* MOD */}
-      </Wrapper>
+      <Wrapper>{getModalContent()}</Wrapper>
     </Modal>
   )
 }

--- a/src/custom/components/WalletModal/WalletModalMod.tsx
+++ b/src/custom/components/WalletModal/WalletModalMod.tsx
@@ -21,10 +21,11 @@ import {
 import AccountDetails from 'components/AccountDetails'
 import { Trans } from '@lingui/macro'
 
-import ModalMod from 'components/Modal'
+import ModalMod from '@src/components/Modal'
 import Option from 'components/WalletModal/Option'
 import PendingView from 'components/WalletModal/PendingView'
 import { LightCard } from 'components/Card'
+import { CloseModalLink } from 'components/TransactionConfirmationModal' // mod
 
 const CloseIcon = styled.div`
   position: absolute;
@@ -47,6 +48,7 @@ const Wrapper = styled.div`
   margin: 0;
   padding: 0;
   width: 100%;
+  overflow-y: auto; /* MOD */
 `
 
 const HeaderRow = styled.div`
@@ -392,7 +394,10 @@ export default function WalletModal({
 
   return (
     <Modal isOpen={walletModalOpen} onDismiss={toggleWalletModal} minHeight={false} maxHeight={90}>
-      <Wrapper>{getModalContent()}</Wrapper>
+      <Wrapper>
+        {getModalContent()}
+        <CloseModalLink closeModalCb={toggleWalletModal} /> {/* MOD */}
+      </Wrapper>
     </Modal>
   )
 }

--- a/src/custom/components/WalletModal/index.tsx
+++ b/src/custom/components/WalletModal/index.tsx
@@ -1,17 +1,11 @@
 import React from 'react'
-import Modal from '@src/components/Modal'
+import { GpModal } from 'components/Modal' // mod
 import styled from 'styled-components'
 import WalletModalMod, { WalletModalProps } from './WalletModalMod'
 import { ExternalLink } from 'theme'
 import { Trans } from '@lingui/macro'
 
 export * from '@src/components/WalletModal'
-
-export const GpModal = styled(Modal)`
-  > [data-reach-dialog-content] {
-    background-color: ${({ theme }) => theme.bg1};
-  }
-`
 
 const TermsWrapper = styled.div`
   color: ${({ theme }) => theme.text1};

--- a/src/custom/components/swap/SwapModalHeader/index.tsx
+++ b/src/custom/components/swap/SwapModalHeader/index.tsx
@@ -16,6 +16,10 @@ const LightCard = styled(LightCardUni)<{ flatBorder?: boolean }>`
 export type LightCardType = typeof LightCard
 
 const Wrapper = styled.div`
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    margin: 32px auto 0;
+  `};
+
   svg {
     stroke: ${({ theme }) => theme.text1};
   }


### PR DESCRIPTION
# Summary

Fixes #1057

Fixes issue described in #1057 - the issue of too much data and no overflow catch creating clipping. This reimagines this w/o overflow and scrolling and instead fullscreens mobile + provides an easy mobile friendly go back/cancel button.

Notice bottom (mobile only) close link, mobile friendly
![image](https://user-images.githubusercontent.com/21335563/127022968-e07798d4-117f-4e8c-9d2f-83618bb28827.png)


  # To Test

1. either be on mobile and get to swap conf screen
2. or use smaller screen on desktop and test 
