### PR TITLE
Reduce tooltip 🔥 🔥 HELL🔥 🔥 

### DIFF
--- a/src/custom/components/Settings/SettingsMod.tsx
+++ b/src/custom/components/Settings/SettingsMod.tsx
@@ -186,7 +186,7 @@ export default function SettingsTab({ className, placeholderSlippage, SettingsBu
       </StyledMenuButton> */}
       {open && (
         <MenuFlyout>
-          <AutoColumn gap="md" style={{ padding: '1rem' }}>
+          <AutoColumn style={{ padding: '1rem' }}>
             <Text fontWeight={600} fontSize={14}>
               <Trans>Transaction Settings</Trans>
             </Text>

--- a/src/custom/components/Settings/SettingsMod.tsx
+++ b/src/custom/components/Settings/SettingsMod.tsx
@@ -200,6 +200,8 @@ export default function SettingsTab({ className, placeholderSlippage, SettingsBu
                   <Trans>Toggle Expert Mode</Trans>
                 </TYPE.black>
                 <QuestionHelper
+                  bgColor={theme.bg3}
+                  color={theme.text1}
                   text={
                     <Trans>Allow high price impact trades and skip the confirm screen. Use at your own risk.</Trans>
                   }

--- a/src/custom/components/Tooltip/TooltipMod.tsx
+++ b/src/custom/components/Tooltip/TooltipMod.tsx
@@ -7,6 +7,7 @@ const TooltipContainer = styled.div`
   padding: 0.6rem 1rem;
   font-weight: 400;
   word-break: break-word;
+  font-size: smaller;
 `
 
 export interface TooltipProps extends Omit<PopoverProps, 'content' | 'PopoverContainer' | 'Arrow'> {

--- a/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
+++ b/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
@@ -159,6 +159,8 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
             <Trans>MEV protected slippage</Trans>
           </TYPE.black>
           <QuestionHelper
+            bgColor={theme.bg3}
+            color={theme.text1}
             text={
               <Trans>
                 <p>Your slippage is MEV protected: all orders are submitted with tight spread (0.1%) on-chain.</p>
@@ -234,6 +236,8 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
             <Trans>Transaction deadline</Trans>
           </TYPE.black>
           <QuestionHelper
+            bgColor={theme.bg3}
+            color={theme.text1}
             text={t`Your swap expires and will not execute if it is pending for longer than the selected duration. ${INPUT_OUTPUT_EXPLANATION}`}
           />
         </RowFixed>

--- a/src/custom/components/swap/FeeInformationTooltip.tsx
+++ b/src/custom/components/swap/FeeInformationTooltip.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import TradeGp from 'state/swap/TradeGp'
 import QuestionHelper from 'components/QuestionHelper'
 import styled from 'styled-components'
@@ -76,6 +76,8 @@ export default function FeeInformationTooltip(props: FeeInformationTooltipProps)
   const theme = useTheme()
   const fiatValue = useUSDCValue(type === 'From' ? trade?.inputAmount : trade?.outputAmount)
 
+  const symbol = useMemo(() => trade?.[type === 'From' ? 'inputAmount' : 'outputAmount'].currency.symbol, [trade, type])
+
   if (!trade || !showHelper) return null
 
   return (
@@ -89,13 +91,15 @@ export default function FeeInformationTooltip(props: FeeInformationTooltipProps)
             <FeeInnerWrapper>
               <FeeTooltipLine>
                 <span>Before fee</span>
-                <span>{amountBeforeFees}</span>{' '}
+                <span>
+                  {amountBeforeFees} {symbol}
+                </span>{' '}
               </FeeTooltipLine>
               <FeeTooltipLine>
                 <span>Fee</span>
                 <span>
                   {type === 'From' ? '+' : '-'}
-                  {feeAmount}
+                  {feeAmount} {symbol}
                 </span>{' '}
               </FeeTooltipLine>
               <FeeTooltipLine>
@@ -105,7 +109,9 @@ export default function FeeInformationTooltip(props: FeeInformationTooltipProps)
               <Breakline />
               <FeeTooltipLine>
                 <strong>{type}</strong>
-                <strong>{amountAfterFees}</strong>{' '}
+                <strong>
+                  {amountAfterFees} {symbol}
+                </strong>{' '}
               </FeeTooltipLine>
             </FeeInnerWrapper>
           }

--- a/src/custom/components/swap/TradeSummary/TradeSummaryMod.tsx
+++ b/src/custom/components/swap/TradeSummary/TradeSummaryMod.tsx
@@ -74,7 +74,7 @@ export default function TradeSummary({
         </RowBetween>
       )}
 
-      <RowBetween height={24}>
+      {/* <RowBetween height={24}>
         <RowFixed>
           <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
             <Trans>{trade.tradeType === TradeType.EXACT_INPUT ? 'Receive' : 'From'} (incl. fee)</Trans>
@@ -84,7 +84,7 @@ export default function TradeSummary({
           {formatSmart(isExactIn ? trade.outputAmount : trade.inputAmountWithFee)}{' '}
           {(isExactIn ? trade.outputAmount : trade.inputAmount).currency.symbol}
         </TYPE.black>
-      </RowBetween>
+      </RowBetween> */}
 
       {/* 
       <RowBetween>
@@ -126,7 +126,11 @@ export default function TradeSummary({
       <RowBetween height={24}>
         <RowFixed>
           <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
-            {trade.tradeType === TradeType.EXACT_INPUT ? <Trans>Minimum received</Trans> : <Trans>Maximum sent</Trans>}
+            {trade.tradeType === TradeType.EXACT_INPUT ? (
+              <Trans>Minimum received (incl. fee)</Trans>
+            ) : (
+              <Trans>Maximum sent (incl. fee)</Trans>
+            )}
           </TYPE.black>
           {showHelpers && (
             <MouseoverTooltipContent

--- a/src/custom/components/swap/TradeSummary/TradeSummaryMod.tsx
+++ b/src/custom/components/swap/TradeSummary/TradeSummaryMod.tsx
@@ -15,6 +15,7 @@ import { MouseoverTooltipContent } from 'components/Tooltip'
 import { StyledInfo } from 'pages/Swap/SwapMod'
 import { formatSmart } from 'utils/format'
 import { TradeSummaryProps } from '.'
+import { INPUT_OUTPUT_EXPLANATION } from 'constants/index'
 
 // computes price breakdown for the trade
 export function computeTradePriceBreakdown(trade?: TradeGp | null): {
@@ -117,6 +118,22 @@ export default function TradeSummary({
           <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
             <Trans>Slippage tolerance</Trans>
           </TYPE.black>
+          <MouseoverTooltipContent
+            bgColor={theme.bg3}
+            color={theme.text1}
+            content={
+              <Trans>
+                <p>Your slippage is MEV protected: all orders are submitted with tight spread (0.1%) on-chain.</p>
+                <p>
+                  The slippage you pick here enables a resubmission of your order in case of unfavourable price
+                  movements.
+                </p>
+                <p>{INPUT_OUTPUT_EXPLANATION}</p>
+              </Trans>
+            }
+          >
+            <StyledInfo />
+          </MouseoverTooltipContent>
         </RowFixed>
         <TYPE.black textAlign="right" fontSize={12} color={theme.text1}>
           {allowedSlippage.toFixed(2)}%

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -82,7 +82,7 @@ const SwapModWrapper = styled(SwapMod)`
     }
 
     ${AutoColumn} {
-      grid-row-gap: 0px;
+      grid-row-gap: 8px;
     }
 
     .expertMode ${AutoColumn} {


### PR DESCRIPTION
1. remove redundant wording
2. make font smaller
3. add unit symbols

# Summary
Fixes tooltips as discussed here: https://gnosisinc.slack.com/archives/C025G521XQD/p1627384362005900

BUY ORDER
![image](https://user-images.githubusercontent.com/21335563/127180129-d20c070c-e707-434f-96b4-c2edf5f06ca3.png)

SELL ORDER
![image](https://user-images.githubusercontent.com/21335563/127180165-3cfe8682-e73e-4671-893e-b4f41ea89679.png)

CONFIRMATION PAGE (smaller font AND removed field)
![image](https://user-images.githubusercontent.com/21335563/127180221-f0f96a43-85fa-4462-a022-ceed14083a05.png)

CONFIRMATION PAGE - SLIPPAGE TOOLTIP
![image](https://user-images.githubusercontent.com/21335563/127184259-8c69c4cc-09e9-4184-a09a-8c738925aebf.png)

  # To Test

1. make buy order, look at tooltips
2. make sell order, look at tooltips
3. go into swap confirmation modal, look at tooltips