### PR TITLE
Mobile responsive fixes for 1057

### DIFF
--- a/src/custom/components/Modal/index.ts
+++ b/src/custom/components/Modal/index.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 import Modal from '@src/components/Modal'
+import { HeaderRow, ContentWrapper, CloseIcon, HoverText } from 'components/WalletModal/WalletModalMod'
 
 export * from '@src/components/Modal'
 export { default } from '@src/components/Modal'
@@ -8,21 +9,42 @@ export const GpModal = styled(Modal)`
   > [data-reach-dialog-content] {
     background-color: ${({ theme }) => theme.bg1};
 
-    .bottom-close-button {
-      display: none;
-      margin: auto auto 8px;
-
-      ${({ theme }) => theme.mediaWidth.upToExtraSmall`
-      display: flex;
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      max-height: 100%;
+      height: 100%;
+      width: 100vw;
+      border-radius: 0;
     `}
+
+    ${HeaderRow} {
+      ${({ theme }) => theme.mediaWidth.upToSmall`
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        padding: 16px;
+        background: ${({ theme }) => theme.bg1};
+        z-index: 20;
+      `}
     }
 
-    ${({ theme }) => theme.mediaWidth.upToExtraSmall`
-    max-height: 100vh;
-    height: 100vh;
-    max-width: 100vw;
-    width:  100vw;
-    border-radius: 0px;
-  `}
+    ${CloseIcon} {
+      ${({ theme }) => theme.mediaWidth.upToSmall`
+        z-index: 21;
+        position: fixed;
+      `}
+    }
+
+    ${HoverText} {
+      ${({ theme }) => theme.mediaWidth.upToSmall`
+        white-space: nowrap;
+      `}
+    }
+
+    ${ContentWrapper} {
+      ${({ theme }) => theme.mediaWidth.upToSmall`
+        margin: 62px auto 0;
+      `}
+    }
   }
 `

--- a/src/custom/components/TransactionConfirmationModal/TransactionConfirmationModalMod.tsx
+++ b/src/custom/components/TransactionConfirmationModal/TransactionConfirmationModalMod.tsx
@@ -191,7 +191,6 @@ export function ConfirmationModalContent({
   onDismiss: () => void
   topContent: () => ReactNode
   bottomContent?: () => ReactNode | undefined
-  CloseModalLink: () => ReactNode // mod
 } */ return (
     <Wrapper>
       <Section>

--- a/src/custom/components/TransactionConfirmationModal/TransactionConfirmationModalMod.tsx
+++ b/src/custom/components/TransactionConfirmationModal/TransactionConfirmationModalMod.tsx
@@ -29,7 +29,7 @@ import { Trans } from '@lingui/macro'
 // import { getEtherscanLink, getExplorerLabel } from 'utils'
 import { GpModal } from 'components/Modal'
 import { lighten } from 'polished'
-import { ConfirmationModalContentProps, TransactionSubmittedContent } from './index' // mod
+import { ConfirmationModalContentProps, TransactionSubmittedContent, GPModalHeader } from '.' // mod
 
 const Wrapper = styled.div`
   width: 100%;
@@ -185,7 +185,6 @@ export function ConfirmationModalContent({
   bottomContent,
   onDismiss,
   topContent,
-  CloseModalLink,
 }: ConfirmationModalContentProps) {
   /* {
   title: ReactNode
@@ -196,16 +195,17 @@ export function ConfirmationModalContent({
 } */ return (
     <Wrapper>
       <Section>
-        <RowBetween>
+        {/* <RowBetween> */}
+        <GPModalHeader>
           <Text fontWeight={500} fontSize={16}>
             {title}
           </Text>
           <CloseIcon onClick={onDismiss} />
-        </RowBetween>
+        </GPModalHeader>
+        {/* </RowBetween> */}
         {topContent()}
       </Section>
       {bottomContent && <BottomSection gap="12px">{bottomContent()}</BottomSection>}
-      <CloseModalLink closeModalCb={onDismiss} />
     </Wrapper>
   )
 }

--- a/src/custom/components/TransactionConfirmationModal/index.tsx
+++ b/src/custom/components/TransactionConfirmationModal/index.tsx
@@ -5,7 +5,7 @@ import React, { ReactNode, useContext } from 'react'
 import styled, { ThemeContext } from 'styled-components'
 import { CloseIcon } from 'theme'
 import { ExternalLink } from 'theme'
-import { RowFixed } from 'components/Row'
+import { RowBetween, RowFixed } from 'components/Row'
 import MetaMaskLogo from 'assets/images/metamask.png'
 import { getEtherscanLink, getExplorerLabel } from 'utils'
 import { Text } from 'rebass'
@@ -37,6 +37,18 @@ const CloseLink = styled.span`
   color: ${({ theme }) => theme.primary1};
   cursor: pointer;
   margin: 8px auto;
+`
+
+export const GPModalHeader = styled(RowBetween)`
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 16px;
+    background: ${({ theme }) => theme.bg1};
+    z-index: 20;
+  `}
 `
 
 const InternalLink = styled(Link)``
@@ -178,7 +190,6 @@ export interface ConfirmationModalContentProps {
   onDismiss: () => void
   topContent: () => ReactNode
   bottomContent?: () => ReactNode | undefined
-  CloseModalLink: (props: CloseModalProps) => JSX.Element // mod
 }
 
 interface CloseModalProps {
@@ -190,24 +201,30 @@ const CloseModalWrapper = styled.div`
   flex-flow: row nowrap;
   align-items: center;
   justify-content: center;
-  gap: 4px;
   color: ${({ theme }) => theme.text3};
-  font-size: smaller;
+  font-size: 13px;
   cursor: pointer;
+  position: fixed;
+  bottom: 0;
+  height: 56px;
+  width: 100%;
+  background: ${({ theme }) => theme.bg3};
+  margin: 0 auto;
+  left: 0;
+  right: 0;
 
-  > span:nth-of-type(2) {
-    text-decoration: underline;
-    margin-left: 3px;
+  > span {
+    margin: 0 0 0 3px;
   }
 `
 
 export const CloseModalLink = ({ closeModalCb }: CloseModalProps) => (
   <CloseModalWrapper className="bottom-close-button" onClick={closeModalCb}>
-    <ArrowLeft size={16} />
+    <ArrowLeft size={18} />
     <span>Close modal and go back</span>
   </CloseModalWrapper>
 )
 
 export function ConfirmationModalContent(props: Omit<ConfirmationModalContentProps, 'CloseModalLink'>) {
-  return <ConfirmationModalContentMod {...props} CloseModalLink={CloseModalLink} />
+  return <ConfirmationModalContentMod {...props} />
 }

--- a/src/custom/components/TransactionConfirmationModal/index.tsx
+++ b/src/custom/components/TransactionConfirmationModal/index.tsx
@@ -9,7 +9,7 @@ import { RowBetween, RowFixed } from 'components/Row'
 import MetaMaskLogo from 'assets/images/metamask.png'
 import { getEtherscanLink, getExplorerLabel } from 'utils'
 import { Text } from 'rebass'
-import { ArrowLeft, ArrowUpCircle, CheckCircle } from 'react-feather'
+import { ArrowUpCircle, CheckCircle } from 'react-feather'
 import useAddTokenToMetamask from 'hooks/useAddTokenToMetamask'
 import GameIcon from 'assets/cow-swap/game.gif'
 import { Link } from 'react-router-dom'
@@ -192,39 +192,6 @@ export interface ConfirmationModalContentProps {
   bottomContent?: () => ReactNode | undefined
 }
 
-interface CloseModalProps {
-  closeModalCb: () => void
-}
-
-const CloseModalWrapper = styled.div`
-  display: flex;
-  flex-flow: row nowrap;
-  align-items: center;
-  justify-content: center;
-  color: ${({ theme }) => theme.text3};
-  font-size: 13px;
-  cursor: pointer;
-  position: fixed;
-  bottom: 0;
-  height: 56px;
-  width: 100%;
-  background: ${({ theme }) => theme.bg3};
-  margin: 0 auto;
-  left: 0;
-  right: 0;
-
-  > span {
-    margin: 0 0 0 3px;
-  }
-`
-
-export const CloseModalLink = ({ closeModalCb }: CloseModalProps) => (
-  <CloseModalWrapper className="bottom-close-button" onClick={closeModalCb}>
-    <ArrowLeft size={18} />
-    <span>Close modal and go back</span>
-  </CloseModalWrapper>
-)
-
-export function ConfirmationModalContent(props: Omit<ConfirmationModalContentProps, 'CloseModalLink'>) {
+export function ConfirmationModalContent(props: ConfirmationModalContentProps) {
   return <ConfirmationModalContentMod {...props} />
 }

--- a/src/custom/components/WalletModal/WalletModalMod.tsx
+++ b/src/custom/components/WalletModal/WalletModalMod.tsx
@@ -25,9 +25,8 @@ import ModalMod from '@src/components/Modal'
 import Option from 'components/WalletModal/Option'
 import PendingView from 'components/WalletModal/PendingView'
 import { LightCard } from 'components/Card'
-import { CloseModalLink } from 'components/TransactionConfirmationModal' // mod
 
-const CloseIcon = styled.div`
+export const CloseIcon = styled.div`
   position: absolute;
   right: 1rem;
   top: 14px;
@@ -49,15 +48,9 @@ const Wrapper = styled.div`
   padding: 0;
   width: 100%;
   overflow-y: auto; /* MOD */
-
-  > .bottom-close-button {
-    &&&&& {
-      margin-bottom: 16px;
-    }
-  }
 `
 
-const HeaderRow = styled.div`
+export const HeaderRow = styled.div`
   ${({ theme }) => theme.flexRowNoWrap};
   padding: 1rem 1rem;
   font-weight: 500;
@@ -67,7 +60,7 @@ const HeaderRow = styled.div`
   `};
 `
 
-const ContentWrapper = styled.div`
+export const ContentWrapper = styled.div`
   /* background-color: ${({ theme }) => theme.bg0}; */
   background-color: ${({ theme }) => theme.bg1};
   padding: 0 1rem 1rem 1rem;
@@ -106,7 +99,7 @@ const OptionGrid = styled.div`
   `};
 `
 
-const HoverText = styled.div`
+export const HoverText = styled.div`
   text-decoration: none;
   color: ${({ theme }) => theme.text1};
   display: flex;
@@ -400,10 +393,7 @@ export default function WalletModal({
 
   return (
     <Modal isOpen={walletModalOpen} onDismiss={toggleWalletModal} minHeight={false} maxHeight={90}>
-      <Wrapper>
-        {getModalContent()}
-        <CloseModalLink closeModalCb={toggleWalletModal} /> {/* MOD */}
-      </Wrapper>
+      <Wrapper>{getModalContent()}</Wrapper>
     </Modal>
   )
 }

--- a/src/custom/components/swap/SwapModalHeader/index.tsx
+++ b/src/custom/components/swap/SwapModalHeader/index.tsx
@@ -16,6 +16,10 @@ const LightCard = styled(LightCardUni)<{ flatBorder?: boolean }>`
 export type LightCardType = typeof LightCard
 
 const Wrapper = styled.div`
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    margin: 32px auto 0;
+  `};
+
   svg {
     stroke: ${({ theme }) => theme.text1};
   }


### PR DESCRIPTION
# Summary

In response to issues/feedback reported on https://github.com/gnosis/cowswap/pull/1063
In my opinion I think the '<- Close modal and go back'
<img width="235" alt="Screen Shot 2021-07-27 at 18 09 48" src="https://user-images.githubusercontent.com/31534717/127189011-890c0cbd-4a2e-4b0b-8d53-925c718e952c.png">
can be made redundant by having a fixed header. This simplifies the approach, reduces noise and there's less interference with the content.

https://user-images.githubusercontent.com/31534717/127188882-5415fbe8-035a-4df5-a7aa-457a8217d235.mov 

https://user-images.githubusercontent.com/31534717/127188914-54a19cda-dbc9-4658-94eb-279809bb4a06.mov

# Issue spotted:
- The modal library we use, has a sort of 'janky' 'slide down to close' behavior, which interferes at times, with our fixed header approach. Here you can see how it manipulates the `transform: translateY`
<img width="1191" alt="Screen Shot 2021-07-27 at 16 55 12" src="https://user-images.githubusercontent.com/31534717/127189246-b575aaa8-3a66-40de-b3b2-4c973a332801.png">

As for a solution to this, I'd be curious if we can disable this while keeping the library. But haven't dig into that (yet).


# To Test
1. Mobile > Get to the swap confirmation modal > Scroll down > Header should remain fixed > click X to close
2. Mobile > Get to the Wallet modal > Header should remain fixed > click X to close
3. In both cases, the initial view should have sufficient top margin to separate Fixed header <-> Content.
