### PR TITLE
[1070 waterfall] - Remove USD estimation from "Receive/From (incl. fee)" 

### DIFF
--- a/src/custom/components/swap/FeeInformationTooltip.tsx
+++ b/src/custom/components/swap/FeeInformationTooltip.tsx
@@ -15,6 +15,7 @@ interface FeeInformationTooltipProps {
   amountAfterFees?: string
   feeAmount?: string
   type: 'From' | 'To'
+  showFiat?: boolean
 }
 
 const WrappedQuestionHelper = styled(QuestionHelper)`
@@ -72,7 +73,7 @@ const FeeInnerWrapper = styled.div`
 `
 
 export default function FeeInformationTooltip(props: FeeInformationTooltipProps) {
-  const { trade, label, amountBeforeFees, amountAfterFees, feeAmount, type, showHelper } = props
+  const { trade, label, amountBeforeFees, amountAfterFees, feeAmount, type, showHelper, showFiat = false } = props
 
   const theme = useTheme()
   const fiatValue = useUSDCValue(type === 'From' ? trade?.inputAmount : trade?.outputAmount)
@@ -113,7 +114,7 @@ export default function FeeInformationTooltip(props: FeeInformationTooltipProps)
         />
       </span>
       <FeeAmountAndFiat>
-        {amountAfterFees} {fiatValue && <small>≈ ${formatSmart(fiatValue, FIAT_PRECISION)}</small>}
+        {amountAfterFees} {showFiat && fiatValue && <small>≈ ${formatSmart(fiatValue, FIAT_PRECISION)}</small>}
       </FeeAmountAndFiat>
     </FeeInformationTooltipWrapper>
   )


### PR DESCRIPTION
# Summary

Fixes one point in #1085 - removes USD estimation in Receive (incl.) field

as discussed on slack.

Swap page:
![image](https://user-images.githubusercontent.com/21335563/127328786-d9941927-8e5e-49d3-b8a9-ca27f0f70718.png)

Confirmation modal
![image](https://user-images.githubusercontent.com/21335563/127328820-abfd2991-82ec-44bc-a8e3-deff4e438469.png)


  # To Test

1. use the app normally and check inputs/confirmation modal