### PR TITLE
Fix issue with small prices

### DIFF
--- a/src/custom/components/swap/TradePrice/index.tsx
+++ b/src/custom/components/swap/TradePrice/index.tsx
@@ -3,7 +3,7 @@ import TradePriceMod, { TradePriceProps } from './TradePriceMod'
 import { useUSDCValue } from 'hooks/useUSDCPrice'
 import { formatSmart } from 'utils/format'
 import { tryParseAmount } from 'state/swap/hooks'
-import { FIAT_PRECISION } from 'constants/index'
+import { FIAT_PRECISION, MAX_PRECISION } from 'constants/index'
 
 export * from './TradePriceMod'
 
@@ -13,8 +13,8 @@ export default function TradePrice(props: Omit<TradePriceProps, 'fiatValue'>) {
   const priceSide = useMemo(
     () =>
       !showInverted
-        ? tryParseAmount(price.invert().toFixed(18), price.baseCurrency)
-        : tryParseAmount(price.toFixed(18), price.quoteCurrency),
+        ? tryParseAmount(price.invert().toFixed(MAX_PRECISION), price.baseCurrency)
+        : tryParseAmount(price.toFixed(MAX_PRECISION), price.quoteCurrency),
     [price, showInverted]
   )
   const amount = useUSDCValue(priceSide)

--- a/src/custom/components/swap/TradePrice/index.tsx
+++ b/src/custom/components/swap/TradePrice/index.tsx
@@ -18,7 +18,7 @@ export default function TradePrice(props: Omit<TradePriceProps, 'fiatValue'>) {
     [price, showInverted]
   )
   const amount = useUSDCValue(priceSide)
-  const fiatValueFormatted = formatSmart(amount, FIAT_PRECISION)
+  const fiatValueFormatted = formatSmart(amount, FIAT_PRECISION, { smallLimit: '0.01' })
 
   return <TradePriceMod {...props} fiatValue={fiatValueFormatted} />
 }

--- a/src/custom/components/swap/TradePrice/index.tsx
+++ b/src/custom/components/swap/TradePrice/index.tsx
@@ -13,8 +13,8 @@ export default function TradePrice(props: Omit<TradePriceProps, 'fiatValue'>) {
   const priceSide = useMemo(
     () =>
       !showInverted
-        ? tryParseAmount(price.invert().toFixed(), price.baseCurrency)
-        : tryParseAmount(price.toFixed(), price.quoteCurrency),
+        ? tryParseAmount(price.invert().toFixed(18), price.baseCurrency)
+        : tryParseAmount(price.toFixed(18), price.quoteCurrency),
     [price, showInverted]
   )
   const amount = useUSDCValue(priceSide)

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -16,6 +16,7 @@ export const DEFAULT_DECIMALS = 18
 export const DEFAULT_PRECISION = 6
 export const SHORT_PRECISION = 4
 export const SHORTEST_PRECISION = 3
+export const MAX_PRECISION = 18
 export const LONG_PRECISION = 10
 export const FIAT_PRECISION = 2
 export const PERCENTAGE_PRECISION = 2


### PR DESCRIPTION
# Summary

Making sure relative prices <0.0001 get a USD estimation as well.
Also when USD value < 0.01, show just that, `< 0.01`

## Before (#1070)
![screenshot_2021-07-28_12-27-29](https://user-images.githubusercontent.com/43217/127383783-09f891c6-eae0-4f4b-ae63-37d030ccc87b.png)

## After
![screenshot_2021-07-28_12-27-08](https://user-images.githubusercontent.com/43217/127383803-4d1bf731-63b4-4d69-8db1-b261c6b25dad.png)


  # To Test

1. Fill in WETH-AMP pair (or any pair where there's a huge price difference, greater than 10k)
2. Make sure there's a USD estimation for the amounts for given pair
3. Observe the price
- [ ] Regular price display has a USD estimation
3. Invert the price display
- [ ] Inverted price display has a USD estimation


  # Background

*Optional: Give background information for changes you've made, that might be difficult to explain via comments*

