### PR TITLE
1104/fix issue with small usd amounts again

### DIFF
--- a/src/custom/components/swap/TradePrice/index.tsx
+++ b/src/custom/components/swap/TradePrice/index.tsx
@@ -3,7 +3,7 @@ import TradePriceMod, { TradePriceProps } from './TradePriceMod'
 import { useUSDCValue } from 'hooks/useUSDCPrice'
 import { formatSmart } from 'utils/format'
 import { tryParseAmount } from 'state/swap/hooks'
-import { FIAT_FORMAT_SMART_OPTIONS, MAX_PRECISION } from 'constants/index'
+import { FIAT_FORMAT_SMART_OPTIONS } from 'constants/index'
 
 export * from './TradePriceMod'
 
@@ -13,8 +13,8 @@ export default function TradePrice(props: Omit<TradePriceProps, 'fiatValue'>) {
   const priceSide = useMemo(
     () =>
       !showInverted
-        ? tryParseAmount(price.invert().toFixed(MAX_PRECISION), price.baseCurrency)
-        : tryParseAmount(price.toFixed(MAX_PRECISION), price.quoteCurrency),
+        ? tryParseAmount(price.invert().toFixed(price.baseCurrency.decimals), price.baseCurrency)
+        : tryParseAmount(price.toFixed(price.quoteCurrency.decimals), price.quoteCurrency),
     [price, showInverted]
   )
   const amount = useUSDCValue(priceSide)

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -17,7 +17,6 @@ export const DEFAULT_DECIMALS = 18
 export const DEFAULT_PRECISION = 6
 export const SHORT_PRECISION = 4
 export const SHORTEST_PRECISION = 3
-export const MAX_PRECISION = 18
 export const LONG_PRECISION = 10
 export const FIAT_PRECISION = 2
 export const PERCENTAGE_PRECISION = 2

--- a/src/custom/hooks/useUSDCPrice/index.ts
+++ b/src/custom/hooks/useUSDCPrice/index.ts
@@ -85,7 +85,7 @@ export default function useUSDCPrice(currency?: Currency) {
 
 /**
  * Returns the price in USDC of the input currency from price APIs
- * @param currency currency to compute the USDC price of
+ * @param currencyAmount currency to compute the USDC price of
  */
 export function useUSDCValue(currencyAmount?: CurrencyAmount<Currency>) {
   const { price, error } = useUSDCPrice(currencyAmount?.currency)


### PR DESCRIPTION
# Summary

Fixes #1104 

Fixing usd estimation for prices (once again :crossed_fingers: )

![screenshot_2021-07-29_14-46-06](https://user-images.githubusercontent.com/43217/127570020-9bccac36-9aaf-456b-b9e4-4d33d6e7e0ad.png)

  # To Test

1. Pick a pair with large enough price difference
- [ ] USD estimation should be displayed on the price, even if small

  # Background



