### PR TITLE
1120/consistent usd estimation display

### DIFF
--- a/src/custom/components/CurrencyInputPanel/FiatValue/FiatValueMod.tsx
+++ b/src/custom/components/CurrencyInputPanel/FiatValue/FiatValueMod.tsx
@@ -6,7 +6,7 @@ import { warningSeverity } from 'utils/prices'
 import HoverInlineText from 'components/HoverInlineText'
 import { Trans } from '@lingui/macro'
 
-import { FIAT_PRECISION } from 'constants/index' // mod
+import { FIAT_FORMAT_SMART_OPTIONS } from 'constants/index' // mod
 import { formatSmart } from 'utils/format'
 
 export function FiatValue({
@@ -34,7 +34,12 @@ export function FiatValue({
         <Trans>
           ≈ $
           <HoverInlineText
-            text={formatSmart(fiatValue, FIAT_PRECISION) /* fiatValue?.toSignificant(6, { groupSeparator: ',' }) */}
+            text={
+              formatSmart(
+                fiatValue,
+                ...FIAT_FORMAT_SMART_OPTIONS
+              ) /* fiatValue?.toSignificant(6, { groupSeparator: ',' }) */
+            }
           />
         </Trans>
       ) : (

--- a/src/custom/components/swap/FeeInformationTooltip.tsx
+++ b/src/custom/components/swap/FeeInformationTooltip.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import { useUSDCValue } from 'hooks/useUSDCPrice'
 import { formatSmart } from 'utils/format'
 import useTheme from 'hooks/useTheme'
-import { FIAT_PRECISION } from 'constants/index'
+import { FIAT_FORMAT_SMART_OPTIONS } from 'constants/index'
 
 interface FeeInformationTooltipProps {
   trade?: TradeGp
@@ -120,7 +120,8 @@ export default function FeeInformationTooltip(props: FeeInformationTooltipProps)
         />
       </span>
       <FeeAmountAndFiat>
-        {amountAfterFees} {showFiat && fiatValue && <small>≈ ${formatSmart(fiatValue, FIAT_PRECISION)}</small>}
+        {amountAfterFees}{' '}
+        {showFiat && fiatValue && <small>≈ ${formatSmart(fiatValue, ...FIAT_FORMAT_SMART_OPTIONS)}</small>}
       </FeeAmountAndFiat>
     </FeeInformationTooltipWrapper>
   )

--- a/src/custom/components/swap/TradePrice/TradePriceMod.tsx
+++ b/src/custom/components/swap/TradePrice/TradePriceMod.tsx
@@ -3,8 +3,8 @@ import { Price, Currency } from '@uniswap/sdk-core'
 import { useContext } from 'react'
 import { Text } from 'rebass'
 import styled, { ThemeContext } from 'styled-components'
-import { formatSmart, FormatSmartOptions } from 'utils/format' // mod
-import { DEFAULT_PRECISION } from 'constants/index' // mod
+import { formatSmart } from 'utils/format' // mod
+import { PRICE_FORMAT_OPTIONS } from 'constants/index' // mod
 import { LightGreyText } from 'pages/Swap'
 
 export interface TradePriceProps {
@@ -32,8 +32,6 @@ export const StyledPriceContainer = styled.button`
     width: fit-content;
   }
 `
-
-const PRICE_FORMAT_OPTIONS: [number, FormatSmartOptions] = [DEFAULT_PRECISION, { smallLimit: '0.00001' }]
 
 export default function TradePrice({ price, showInverted, fiatValue, setShowInverted }: TradePriceProps) {
   const theme = useContext(ThemeContext)

--- a/src/custom/components/swap/TradePrice/index.tsx
+++ b/src/custom/components/swap/TradePrice/index.tsx
@@ -3,7 +3,7 @@ import TradePriceMod, { TradePriceProps } from './TradePriceMod'
 import { useUSDCValue } from 'hooks/useUSDCPrice'
 import { formatSmart } from 'utils/format'
 import { tryParseAmount } from 'state/swap/hooks'
-import { FIAT_PRECISION, MAX_PRECISION } from 'constants/index'
+import { FIAT_FORMAT_SMART_OPTIONS, MAX_PRECISION } from 'constants/index'
 
 export * from './TradePriceMod'
 
@@ -18,7 +18,7 @@ export default function TradePrice(props: Omit<TradePriceProps, 'fiatValue'>) {
     [price, showInverted]
   )
   const amount = useUSDCValue(priceSide)
-  const fiatValueFormatted = formatSmart(amount, FIAT_PRECISION, { smallLimit: '0.01' })
+  const fiatValueFormatted = formatSmart(amount, ...FIAT_FORMAT_SMART_OPTIONS)
 
   return <TradePriceMod {...props} fiatValue={fiatValueFormatted} />
 }

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -24,6 +24,8 @@ export const PERCENTAGE_PRECISION = 2
 
 export const FIAT_FORMAT_SMART_OPTIONS: [number, FormatSmartOptions] = [FIAT_PRECISION, { smallLimit: '0.01' }]
 
+export const PRICE_FORMAT_OPTIONS: [number, FormatSmartOptions] = [DEFAULT_PRECISION, { smallLimit: '0.00001' }]
+
 export const LONG_LOAD_THRESHOLD = 2000
 
 export const APP_ID = Number(process.env.REACT_APP_ID)

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -5,6 +5,7 @@ import { WalletInfo, SUPPORTED_WALLETS as SUPPORTED_WALLETS_UNISWAP } from 'cons
 
 import JSBI from 'jsbi'
 import { SupportedChainId as ChainId } from 'constants/chains'
+import { FormatSmartOptions } from 'utils/format'
 
 // default allowed slippage, in bips
 export const INITIAL_ALLOWED_SLIPPAGE = 50
@@ -20,6 +21,8 @@ export const MAX_PRECISION = 18
 export const LONG_PRECISION = 10
 export const FIAT_PRECISION = 2
 export const PERCENTAGE_PRECISION = 2
+
+export const FIAT_FORMAT_SMART_OPTIONS: [number, FormatSmartOptions] = [FIAT_PRECISION, { smallLimit: '0.01' }]
 
 export const LONG_LOAD_THRESHOLD = 2000
 

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -237,8 +237,8 @@ function FeeGreaterMessage({ trade, fee, ...boxProps }: FeeGreaterMessageProp) {
         </MouseoverTooltipContent>
       </RowFixed>
       <TYPE.black fontSize={14} color={theme.text1}>
-        {formatSmart(realizedFee || fee, SHORT_PRECISION)} {(realizedFee || fee)?.currency.symbol}{' '}
-        {feeFiatValue && <LightGreyText>{feeFiatDisplay}</LightGreyText>}
+        {formatSmart(realizedFee || fee, SHORT_PRECISION, { smallLimit: '0.00001' })}{' '}
+        {(realizedFee || fee)?.currency.symbol} {feeFiatValue && <LightGreyText>{feeFiatDisplay}</LightGreyText>}
       </TYPE.black>
     </LowerSectionWrapper>
   )

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -220,7 +220,7 @@ function FeeGreaterMessage({ trade, fee, ...boxProps }: FeeGreaterMessageProp) {
   const feeFiatValue = useUSDCValue(feeAmount)
 
   const { realizedFee } = computeTradePriceBreakdown(trade)
-  const feeFiatDisplay = `(≈$${formatSmart(feeFiatValue, FIAT_PRECISION)})`
+  const feeFiatDisplay = `(≈$${formatSmart(feeFiatValue, FIAT_PRECISION, { smallLimit: '0.01' })})`
 
   return (
     <LowerSectionWrapper {...boxProps}>

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -23,7 +23,7 @@ import {
 import EthWethWrap, { Props as EthWethWrapProps } from 'components/swap/EthWethWrap'
 import { useReplaceSwapState, useSwapState } from 'state/swap/hooks'
 import { ArrowWrapperLoader, ArrowWrapperLoaderProps, Wrapper as ArrowWrapper } from 'components/ArrowWrapperLoader'
-import { FIAT_PRECISION, LONG_LOAD_THRESHOLD, SHORT_PRECISION } from 'constants/index'
+import { FIAT_FORMAT_SMART_OPTIONS, LONG_LOAD_THRESHOLD, SHORT_PRECISION } from 'constants/index'
 import { formatSmart } from 'utils/format'
 import { MouseoverTooltipContent } from 'components/Tooltip'
 import { StyledInfo } from 'pages/Swap/SwapMod'
@@ -220,7 +220,7 @@ function FeeGreaterMessage({ trade, fee, ...boxProps }: FeeGreaterMessageProp) {
   const feeFiatValue = useUSDCValue(feeAmount)
 
   const { realizedFee } = computeTradePriceBreakdown(trade)
-  const feeFiatDisplay = `(≈$${formatSmart(feeFiatValue, FIAT_PRECISION, { smallLimit: '0.01' })})`
+  const feeFiatDisplay = `(≈$${formatSmart(feeFiatValue, ...FIAT_FORMAT_SMART_OPTIONS)})`
 
   return (
     <LowerSectionWrapper {...boxProps}>

--- a/src/custom/utils/format.ts
+++ b/src/custom/utils/format.ts
@@ -19,8 +19,9 @@ export interface FormatSmartOptions {
 
 /**
  * formatSmart
- * @param amount
+ * @param value
  * @param decimalsToShow
+ * @param options
  * @returns string or undefined
  */
 export function formatSmart(


### PR DESCRIPTION
# Summary

Fixes #1120

Adjusting display of fiat amounts and fee amount

## Before
![screenshot_2021-07-29_15-11-41](https://user-images.githubusercontent.com/43217/127575171-1bda3621-3f47-4064-b468-2b6c9aff3f53.png)

## After
![screenshot_2021-07-29_15-38-54](https://user-images.githubusercontent.com/43217/127575184-6919994b-4910-4615-8e10-e7fc3f4d5508.png)
![screenshot_2021-07-29_15-16-25](https://user-images.githubusercontent.com/43217/127575188-b99eef60-f525-4842-a211-99a2ccc18e6f.png)


# To Test

1. On xDai, pick a wxDai and WETH
2. Insert a tiny wxDai amount (0.001)
- [ ] USD estimations should show `< 0.01`
- [ ] Fee amount should display `< 0.00001`

  # Background

*Optional: Give background information for changes you've made, that might be difficult to explain via comments*

