### PR TITLE
Add missing weth xdai

### DIFF
--- a/src/custom/components/CurrencyInputPanel/FiatValue/FiatValueMod.tsx
+++ b/src/custom/components/CurrencyInputPanel/FiatValue/FiatValueMod.tsx
@@ -6,7 +6,7 @@ import { warningSeverity } from 'utils/prices'
 import HoverInlineText from 'components/HoverInlineText'
 import { Trans } from '@lingui/macro'
 
-import { FIAT_FORMAT_SMART_OPTIONS } from 'constants/index' // mod
+import { FIAT_PRECISION } from 'constants/index' // mod
 import { formatSmart } from 'utils/format'
 
 export function FiatValue({
@@ -34,12 +34,7 @@ export function FiatValue({
         <Trans>
           ≈ $
           <HoverInlineText
-            text={
-              formatSmart(
-                fiatValue,
-                ...FIAT_FORMAT_SMART_OPTIONS
-              ) /* fiatValue?.toSignificant(6, { groupSeparator: ',' }) */
-            }
+            text={formatSmart(fiatValue, FIAT_PRECISION) /* fiatValue?.toSignificant(6, { groupSeparator: ',' }) */}
           />
         </Trans>
       ) : (

--- a/src/custom/components/CurrencyLogo/CurrencyLogoMod.tsx
+++ b/src/custom/components/CurrencyLogo/CurrencyLogoMod.tsx
@@ -40,7 +40,6 @@ export default function CurrencyLogo({
   const srcs: string[] = useMemo(() => {
     if (!currency || currency.isNative) return []
     const imageOverride = ADDRESS_IMAGE_OVERRIDE[currency.address]
-    console.log('imageOverride', imageOverride)
 
     if (currency.isToken) {
       const defaultUrls = imageOverride ? [imageOverride] : [getTokenLogoURL(currency.address)]

--- a/src/custom/components/swap/FeeInformationTooltip.tsx
+++ b/src/custom/components/swap/FeeInformationTooltip.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import { useUSDCValue } from 'hooks/useUSDCPrice'
 import { formatSmart } from 'utils/format'
 import useTheme from 'hooks/useTheme'
-import { FIAT_FORMAT_SMART_OPTIONS } from 'constants/index'
+import { FIAT_PRECISION } from 'constants/index'
 
 interface FeeInformationTooltipProps {
   trade?: TradeGp
@@ -120,8 +120,7 @@ export default function FeeInformationTooltip(props: FeeInformationTooltipProps)
         />
       </span>
       <FeeAmountAndFiat>
-        {amountAfterFees}{' '}
-        {showFiat && fiatValue && <small>≈ ${formatSmart(fiatValue, ...FIAT_FORMAT_SMART_OPTIONS)}</small>}
+        {amountAfterFees} {showFiat && fiatValue && <small>≈ ${formatSmart(fiatValue, FIAT_PRECISION)}</small>}
       </FeeAmountAndFiat>
     </FeeInformationTooltipWrapper>
   )

--- a/src/custom/components/swap/TradePrice/TradePriceMod.tsx
+++ b/src/custom/components/swap/TradePrice/TradePriceMod.tsx
@@ -3,8 +3,8 @@ import { Price, Currency } from '@uniswap/sdk-core'
 import { useContext } from 'react'
 import { Text } from 'rebass'
 import styled, { ThemeContext } from 'styled-components'
-import { formatSmart } from 'utils/format' // mod
-import { PRICE_FORMAT_OPTIONS } from 'constants/index' // mod
+import { formatSmart, FormatSmartOptions } from 'utils/format' // mod
+import { DEFAULT_PRECISION } from 'constants/index' // mod
 import { LightGreyText } from 'pages/Swap'
 
 export interface TradePriceProps {
@@ -32,6 +32,8 @@ export const StyledPriceContainer = styled.button`
     width: fit-content;
   }
 `
+
+const PRICE_FORMAT_OPTIONS: [number, FormatSmartOptions] = [DEFAULT_PRECISION, { smallLimit: '0.00001' }]
 
 export default function TradePrice({ price, showInverted, fiatValue, setShowInverted }: TradePriceProps) {
   const theme = useContext(ThemeContext)

--- a/src/custom/components/swap/TradePrice/index.tsx
+++ b/src/custom/components/swap/TradePrice/index.tsx
@@ -3,7 +3,7 @@ import TradePriceMod, { TradePriceProps } from './TradePriceMod'
 import { useUSDCValue } from 'hooks/useUSDCPrice'
 import { formatSmart } from 'utils/format'
 import { tryParseAmount } from 'state/swap/hooks'
-import { FIAT_FORMAT_SMART_OPTIONS } from 'constants/index'
+import { FIAT_PRECISION } from 'constants/index'
 
 export * from './TradePriceMod'
 
@@ -18,7 +18,7 @@ export default function TradePrice(props: Omit<TradePriceProps, 'fiatValue'>) {
     [price, showInverted]
   )
   const amount = useUSDCValue(priceSide)
-  const fiatValueFormatted = formatSmart(amount, ...FIAT_FORMAT_SMART_OPTIONS)
+  const fiatValueFormatted = formatSmart(amount, FIAT_PRECISION, { smallLimit: '0.01' })
 
   return <TradePriceMod {...props} fiatValue={fiatValueFormatted} />
 }

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -5,7 +5,6 @@ import { WalletInfo, SUPPORTED_WALLETS as SUPPORTED_WALLETS_UNISWAP } from 'cons
 
 import JSBI from 'jsbi'
 import { SupportedChainId as ChainId } from 'constants/chains'
-import { FormatSmartOptions } from 'utils/format'
 
 // default allowed slippage, in bips
 export const INITIAL_ALLOWED_SLIPPAGE = 50
@@ -20,10 +19,6 @@ export const SHORTEST_PRECISION = 3
 export const LONG_PRECISION = 10
 export const FIAT_PRECISION = 2
 export const PERCENTAGE_PRECISION = 2
-
-export const FIAT_FORMAT_SMART_OPTIONS: [number, FormatSmartOptions] = [FIAT_PRECISION, { smallLimit: '0.01' }]
-
-export const PRICE_FORMAT_OPTIONS: [number, FormatSmartOptions] = [DEFAULT_PRECISION, { smallLimit: '0.00001' }]
 
 export const LONG_LOAD_THRESHOLD = 2000
 

--- a/src/custom/constants/routing/routingMod.ts
+++ b/src/custom/constants/routing/routingMod.ts
@@ -1,5 +1,5 @@
 // a list of tokens by chain
-import { USDC_XDAI, USDT_XDAI, WBTC_XDAI, WETH_XDAI } from 'utils/xdai/constants'
+import { USDC_XDAI, /*USDT_XDAI,*/ WBTC_XDAI, WETH_XDAI } from 'utils/xdai/constants'
 import { DAI_RINKEBY, USDC_RINKEBY, USDT_RINKEBY } from 'utils/rinkeby/constants'
 import { Currency /* , Token */ } from '@uniswap/sdk-core'
 // import { SupportedChainId } from 'constants/chains'

--- a/src/custom/constants/routing/routingMod.ts
+++ b/src/custom/constants/routing/routingMod.ts
@@ -101,7 +101,7 @@ export const COMMON_BASES: ChainCurrencyList = {
   [4]: [/* ExtendedEther.onChain(4),  */ DAI_RINKEBY, USDC_RINKEBY, USDT_RINKEBY, WETH9_EXTENDED[4]],
   [5]: [/* ExtendedEther.onChain(5),  */ WETH9_EXTENDED[5]],
   [42]: [/* ExtendedEther.onChain(42), */ WETH9_EXTENDED[42]],
-  [100]: [/* ExtendedEther.onChain(42), */ USDC_XDAI, USDT_XDAI, WBTC_XDAI, WETH9_EXTENDED[100], WETH_XDAI], // mod
+  [100]: [/* ExtendedEther.onChain(42), */ USDC_XDAI, /*USDT_XDAI,*/ WBTC_XDAI, WETH9_EXTENDED[100], WETH_XDAI], // mod
   // [SupportedChainId.ARBITRUM_KOVAN]: [
   //   ExtendedEther.onChain(SupportedChainId.ARBITRUM_KOVAN),
   //   WETH9_EXTENDED[SupportedChainId.ARBITRUM_KOVAN],

--- a/src/custom/constants/routing/routingMod.ts
+++ b/src/custom/constants/routing/routingMod.ts
@@ -1,5 +1,5 @@
 // a list of tokens by chain
-import { USDC_XDAI, USDT_XDAI, WBTC_XDAI } from 'utils/xdai/constants'
+import { USDC_XDAI, USDT_XDAI, WBTC_XDAI, WETH_XDAI } from 'utils/xdai/constants'
 import { DAI_RINKEBY, USDC_RINKEBY, USDT_RINKEBY } from 'utils/rinkeby/constants'
 import { Currency /* , Token */ } from '@uniswap/sdk-core'
 // import { SupportedChainId } from 'constants/chains'
@@ -101,7 +101,7 @@ export const COMMON_BASES: ChainCurrencyList = {
   [4]: [/* ExtendedEther.onChain(4),  */ DAI_RINKEBY, USDC_RINKEBY, USDT_RINKEBY, WETH9_EXTENDED[4]],
   [5]: [/* ExtendedEther.onChain(5),  */ WETH9_EXTENDED[5]],
   [42]: [/* ExtendedEther.onChain(42), */ WETH9_EXTENDED[42]],
-  [100]: [/* ExtendedEther.onChain(42), */ USDC_XDAI, USDT_XDAI, WBTC_XDAI, WETH9_EXTENDED[100]], // mod
+  [100]: [/* ExtendedEther.onChain(42), */ USDC_XDAI, USDT_XDAI, WBTC_XDAI, WETH9_EXTENDED[100], WETH_XDAI], // mod
   // [SupportedChainId.ARBITRUM_KOVAN]: [
   //   ExtendedEther.onChain(SupportedChainId.ARBITRUM_KOVAN),
   //   WETH9_EXTENDED[SupportedChainId.ARBITRUM_KOVAN],

--- a/src/custom/constants/tokens/index.ts
+++ b/src/custom/constants/tokens/index.ts
@@ -22,9 +22,9 @@ export const ADDRESS_IMAGE_OVERRIDE = {
 
   // xDai
   [USDC_XDAI.address]: getTrustImage(USDC.address),
-  [USDT_XDAI.address]: getTrustImage(USDT.address),
+  // [USDT_XDAI.address]: getTrustImage(USDT.address),
   [WBTC_XDAI.address]: getTrustImage(WBTC.address),
   [WXDAI.address]:
     'https://raw.githubusercontent.com/1Hive/default-token-list/master/src/assets/xdai/0xe91d153e0b41518a2ce8dd3d7944fa863463a97d/logo.png',
-  [WETH_XDAI.address]: WETH_ADDRESS_MAINNET,
+  [WETH_XDAI.address]: getTrustImage(WETH_ADDRESS_MAINNET),
 }

--- a/src/custom/constants/tokens/index.ts
+++ b/src/custom/constants/tokens/index.ts
@@ -2,7 +2,7 @@ import { ChainId } from '@uniswap/sdk'
 import { WETH9 } from '@uniswap/sdk-core'
 import { DAI_RINKEBY, USDC_RINKEBY, USDT_RINKEBY, WBTC_RINKEBY } from 'utils/rinkeby/constants'
 import { DAI, USDC, USDT, WBTC } from 'constants/tokens'
-import { USDC_XDAI, USDT_XDAI, WBTC_XDAI, WETH_XDAI, WXDAI } from 'utils/xdai/constants'
+import { USDC_XDAI, /*USDT_XDAI,*/ WBTC_XDAI, WETH_XDAI, WXDAI } from 'utils/xdai/constants'
 
 export * from './tokensMod'
 

--- a/src/custom/constants/tokens/index.ts
+++ b/src/custom/constants/tokens/index.ts
@@ -2,7 +2,7 @@ import { ChainId } from '@uniswap/sdk'
 import { WETH9 } from '@uniswap/sdk-core'
 import { DAI_RINKEBY, USDC_RINKEBY, USDT_RINKEBY, WBTC_RINKEBY } from 'utils/rinkeby/constants'
 import { DAI, USDC, USDT, WBTC } from 'constants/tokens'
-import { USDC_XDAI, USDT_XDAI, WBTC_XDAI, WXDAI } from 'utils/xdai/constants'
+import { USDC_XDAI, USDT_XDAI, WBTC_XDAI, WETH_XDAI, WXDAI } from 'utils/xdai/constants'
 
 export * from './tokensMod'
 
@@ -10,13 +10,15 @@ function getTrustImage(mainnetAddress: string): string {
   return `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/${mainnetAddress}/logo.png`
 }
 
+const WETH_ADDRESS_MAINNET = WETH9[ChainId.MAINNET].address
+
 export const ADDRESS_IMAGE_OVERRIDE = {
   // Rinkeby
   [DAI_RINKEBY.address]: getTrustImage(DAI.address),
   [USDC_RINKEBY.address]: getTrustImage(USDC.address),
   [USDT_RINKEBY.address]: getTrustImage(USDT.address),
   [WBTC_RINKEBY.address]: getTrustImage(WBTC.address),
-  [WETH9[ChainId.RINKEBY].address]: getTrustImage(WETH9[ChainId.MAINNET].address),
+  [WETH9[ChainId.RINKEBY].address]: getTrustImage(WETH_ADDRESS_MAINNET),
 
   // xDai
   [USDC_XDAI.address]: getTrustImage(USDC.address),
@@ -24,4 +26,5 @@ export const ADDRESS_IMAGE_OVERRIDE = {
   [WBTC_XDAI.address]: getTrustImage(WBTC.address),
   [WXDAI.address]:
     'https://raw.githubusercontent.com/1Hive/default-token-list/master/src/assets/xdai/0xe91d153e0b41518a2ce8dd3d7944fa863463a97d/logo.png',
+  [WETH_XDAI.address]: WETH_ADDRESS_MAINNET,
 }

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -23,7 +23,7 @@ import {
 import EthWethWrap, { Props as EthWethWrapProps } from 'components/swap/EthWethWrap'
 import { useReplaceSwapState, useSwapState } from 'state/swap/hooks'
 import { ArrowWrapperLoader, ArrowWrapperLoaderProps, Wrapper as ArrowWrapper } from 'components/ArrowWrapperLoader'
-import { FIAT_FORMAT_SMART_OPTIONS, LONG_LOAD_THRESHOLD, SHORT_PRECISION } from 'constants/index'
+import { FIAT_PRECISION, LONG_LOAD_THRESHOLD, SHORT_PRECISION } from 'constants/index'
 import { formatSmart } from 'utils/format'
 import { MouseoverTooltipContent } from 'components/Tooltip'
 import { StyledInfo } from 'pages/Swap/SwapMod'
@@ -218,7 +218,7 @@ function FeeGreaterMessage({ trade, fee, ...boxProps }: FeeGreaterMessageProp) {
   const feeFiatValue = useUSDCValue(feeAmount)
 
   const { realizedFee } = computeTradePriceBreakdown(trade)
-  const feeFiatDisplay = `(≈$${formatSmart(feeFiatValue, ...FIAT_FORMAT_SMART_OPTIONS)})`
+  const feeFiatDisplay = `(≈$${formatSmart(feeFiatValue, FIAT_PRECISION)})`
 
   return (
     <LowerSectionWrapper {...boxProps}>
@@ -235,8 +235,8 @@ function FeeGreaterMessage({ trade, fee, ...boxProps }: FeeGreaterMessageProp) {
         </MouseoverTooltipContent>
       </RowFixed>
       <TYPE.black fontSize={14} color={theme.text1}>
-        {formatSmart(realizedFee || fee, SHORT_PRECISION, { smallLimit: '0.00001' })}{' '}
-        {(realizedFee || fee)?.currency.symbol} {feeFiatValue && <LightGreyText>{feeFiatDisplay}</LightGreyText>}
+        {formatSmart(realizedFee || fee, SHORT_PRECISION)} {(realizedFee || fee)?.currency.symbol}{' '}
+        {feeFiatValue && <LightGreyText>{feeFiatDisplay}</LightGreyText>}
       </TYPE.black>
     </LowerSectionWrapper>
   )

--- a/src/custom/utils/format.ts
+++ b/src/custom/utils/format.ts
@@ -19,9 +19,8 @@ export interface FormatSmartOptions {
 
 /**
  * formatSmart
- * @param value
+ * @param amount
  * @param decimalsToShow
- * @param options
  * @returns string or undefined
  */
 export function formatSmart(

--- a/src/custom/utils/xdai/constants.ts
+++ b/src/custom/utils/xdai/constants.ts
@@ -12,6 +12,13 @@ export const USDT_XDAI = new Token(ChainId.XDAI, '0x4ECaBa5870353805a9F068101A40
 export const USDC_XDAI = new Token(ChainId.XDAI, '0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83', 6, 'USDC', 'USD Coin')
 export const SUSD_XDAI = new Token(ChainId.XDAI, '0xB1950Fb2C9C0CbC8553578c67dB52Aa110A93393', 18, 'sUSD', 'Synth sUSD')
 export const WBTC_XDAI = new Token(ChainId.XDAI, '0x8e5bbbb09ed1ebde8674cda39a0c169401db4252', 8, 'WBTC', 'Wrapped BTC')
+export const WETH_XDAI = new Token(
+  ChainId.XDAI,
+  '0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1',
+  8,
+  'WETH',
+  'Wrapped Ether on xDAI'
+)
 
 export const GNO_XDAI = new Token(ChainId.XDAI, '0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb', 18, 'GNO', 'Gnosis Token')
 export const STAKE_XDAI = new Token(ChainId.XDAI, '0xb7D311E2Eb55F2f68a9440da38e7989210b9A05e', 18, 'STAKE', 'STAKE')


### PR DESCRIPTION
# Summary

xDAI uses wrapped xDAI by default, but offering WETH in the bases might be more interesting than USDT imo, since allows you to buy/sell WETH in this network at a low cost, and we already offer USDC stable coin in the bases.

We could add the 5 tokens, for now I decided against, so it doesn't take too much space. What do you think? 


![image](https://user-images.githubusercontent.com/2352112/127648319-c7d80c0e-f8d3-47d7-8563-b7e2668c034d.png)
