### PR TITLE
barn.cowswap.exchange

### DIFF
--- a/.env
+++ b/.env
@@ -20,7 +20,7 @@ REACT_APP_DOMAIN_REGEX_DEV="^(:?cowswap\.dev|localhost:\d{2,5}|pr\d+--gpswapui\.
 REACT_APP_DOMAIN_REGEX_STAGING="^cowswap\.staging"
 REACT_APP_DOMAIN_REGEX_PROD="^cowswap\.exchange$"
 REACT_APP_DOMAIN_REGEX_ENS="^cowswap\.eth"
-REACT_APP_DOMAIN_REGEX_PRESTAGING="^cowswap\.prestaging"
+REACT_APP_DOMAIN_REGEX_PRESTAGING="^barn\.cowswap\.exchange"
 
 # Analytics
 #REACT_APP_GOOGLE_ANALYTICS_ID_DEV="UA-190948266-3"

--- a/.env
+++ b/.env
@@ -20,6 +20,7 @@ REACT_APP_DOMAIN_REGEX_DEV="^(:?cowswap\.dev|localhost:\d{2,5}|pr\d+--gpswapui\.
 REACT_APP_DOMAIN_REGEX_STAGING="^cowswap\.staging"
 REACT_APP_DOMAIN_REGEX_PROD="^cowswap\.exchange$"
 REACT_APP_DOMAIN_REGEX_ENS="^cowswap\.eth"
+REACT_APP_DOMAIN_REGEX_PRESTAGING="^cowswap\.prestaging"
 
 # Analytics
 #REACT_APP_GOOGLE_ANALYTICS_ID_DEV="UA-190948266-3"

--- a/.env.production
+++ b/.env.production
@@ -20,7 +20,7 @@ REACT_APP_DOMAIN_REGEX_DEV="^(:?cowswap\.dev|localhost:\d{2,5}|pr\d+--gpswapui\.
 REACT_APP_DOMAIN_REGEX_STAGING="^cowswap\.staging"
 REACT_APP_DOMAIN_REGEX_PROD="^cowswap\.exchange$"
 REACT_APP_DOMAIN_REGEX_ENS="^cowswap\.eth"
-REACT_APP_DOMAIN_REGEX_PRESTAGING="^cowswap\.prestaging"
+REACT_APP_DOMAIN_REGEX_PRESTAGING="^barn\.cowswap\.exchange"
 
 # Analytics
 #REACT_APP_GOOGLE_ANALYTICS_ID_DEV="UA-190948266-3"

--- a/.env.production
+++ b/.env.production
@@ -20,6 +20,7 @@ REACT_APP_DOMAIN_REGEX_DEV="^(:?cowswap\.dev|localhost:\d{2,5}|pr\d+--gpswapui\.
 REACT_APP_DOMAIN_REGEX_STAGING="^cowswap\.staging"
 REACT_APP_DOMAIN_REGEX_PROD="^cowswap\.exchange$"
 REACT_APP_DOMAIN_REGEX_ENS="^cowswap\.eth"
+REACT_APP_DOMAIN_REGEX_PRESTAGING="^cowswap\.prestaging"
 
 # Analytics
 #REACT_APP_GOOGLE_ANALYTICS_ID_DEV="UA-190948266-3"

--- a/src/custom/utils/analytics.ts
+++ b/src/custom/utils/analytics.ts
@@ -1,7 +1,7 @@
-import { isDev, isStaging, isProd, isEns } from './environments'
+import { isDev, isStaging, isProd, isEns, isPreStaging } from './environments'
 
 function getAnalyticsId(): string | undefined {
-  if (isDev) {
+  if (isDev || isPreStaging) {
     return process.env.REACT_APP_GOOGLE_ANALYTICS_ID_DEV || 'UA-190948266-3'
   } else if (isStaging) {
     return process.env.REACT_APP_GOOGLE_ANALYTICS_ID_STAGING || 'UA-190948266-4'

--- a/src/custom/utils/environments.ts
+++ b/src/custom/utils/environments.ts
@@ -5,15 +5,21 @@ export function checkEnvironment(host: string) {
   const domainStagingRegex = getRegex(process.env.REACT_APP_DOMAIN_REGEX_STAGING)
   const domainProdRegex = getRegex(process.env.REACT_APP_DOMAIN_REGEX_PROD)
   const domainEnsRegex = getRegex(process.env.REACT_APP_DOMAIN_REGEX_ENS)
+  const domainPreStagingRegex = getRegex(process.env.REACT_APP_DOMAIN_REGEX_PRESTAGING)
 
   return {
+    // Project environments
     isDev: domainDevRegex?.test(host) || false,
     isStaging: domainStagingRegex?.test(host) || false,
     isProd: domainProdRegex?.test(host) || false,
     isEns: domainEnsRegex?.test(host) || false,
+
+    // Environment used for Backend workflow
+    //  Latest stable version pointing to the DEV api
+    isPreStaging: domainPreStagingRegex?.test(host) || false,
   }
 }
 
-const { isDev, isStaging, isProd, isEns } = checkEnvironment(window.location.host)
+const { isDev, isStaging, isProd, isEns, isPreStaging } = checkEnvironment(window.location.host)
 
-export { isDev, isStaging, isProd, isEns }
+export { isDev, isStaging, isProd, isEns, isPreStaging }

--- a/src/custom/utils/explorer.ts
+++ b/src/custom/utils/explorer.ts
@@ -1,10 +1,10 @@
 import { SupportedChainId as ChainId } from 'constants/chains'
 import { OrderID } from 'utils/operator'
-import { isDev, isStaging } from './environments'
+import { isDev, isStaging, isPreStaging } from './environments'
 
 function _getExplorerUrlByEnvironment() {
   let baseUrl: string | undefined
-  if (isDev) {
+  if (isDev || isPreStaging) {
     baseUrl = process.env.REACT_APP_EXPLORER_URL_DEV || 'https://protocol-explorer.dev.gnosisdev.com'
   } else if (isStaging) {
     baseUrl = process.env.REACT_APP_EXPLORER_URL_STAGING || 'https://protocol-explorer.staging.gnosisdev.com'

--- a/src/custom/utils/operator/index.ts
+++ b/src/custom/utils/operator/index.ts
@@ -3,7 +3,7 @@ import { OrderKind } from '@gnosis.pm/gp-v2-contracts'
 import { getSigningSchemeApiValue, OrderCreation, OrderCancellation } from 'utils/signatures'
 import { APP_ID } from 'constants/index'
 import { registerOnWindow } from '../misc'
-import { isDev } from '../environments'
+import { isDev, isPreStaging } from '../environments'
 import OperatorError, { ApiErrorCodeDetails, ApiErrorCodes, ApiErrorObject } from 'utils/operator/errors/OperatorError'
 import QuoteError, {
   GpQuoteErrorCodes,
@@ -15,7 +15,7 @@ import { toErc20Address } from 'utils/tokens'
 import { FeeInformation, FeeQuoteParams, PriceInformation, PriceQuoteParams } from '../price'
 
 function getOperatorUrl(): Partial<Record<ChainId, string>> {
-  if (isDev) {
+  if (isDev || isPreStaging) {
     return {
       [ChainId.MAINNET]:
         process.env.REACT_APP_API_URL_STAGING_MAINNET || 'https://protocol-mainnet.dev.gnosisdev.com/api',


### PR DESCRIPTION
# Summary

The idea of this PR is to create an alias of our staging environemnt, accesible using https://cowswap.prestaging.gnosisdev.com 

This would be an evironment used within the backend workflow to access the `stable version` (our `master` branch) version, but pointing to the DEV API


@giacomolicari do you think we can create an alias to the staging web? so these two return the same:
* https://cowswap.prestaging.gnosisdev.com
* https://cowswap.staging.gnosisdev.com


# Background
* We only need DEV/STAGIN/PRODUCTION
* Our DEV and branches points to DEV API
* Everything else (ENS, staging, PRO) points to PRODUCTION API
* For the backend, it makes sense, as part of their deployment process, to be able to use their DEV backend with the stable web