### PR TITLE
Slippage in expert mode

### DIFF
--- a/src/custom/components/swap/TradeSummary/TradeSummaryMod.tsx
+++ b/src/custom/components/swap/TradeSummary/TradeSummaryMod.tsx
@@ -5,8 +5,6 @@ import { CurrencyAmount, Currency, TradeType } from '@uniswap/sdk-core'
 
 // import { Field } from 'state/swap/actions'
 import { TYPE } from 'theme'
-// import { computeSlippageAdjustedAmounts } from 'utils/prices'
-// import { getMinimumReceivedTooltip } from 'utils/tooltips'
 
 import { AutoColumn } from 'components/Column'
 import { RowBetween, RowFixed } from 'components/Row'
@@ -43,9 +41,7 @@ export default function TradeSummary({
   showFee,
 }: Omit<TradeSummaryProps, 'className'>) {
   const theme = useContext(ThemeContext)
-  // const { priceImpactWithoutFee, realizedLPFee } = computeTradePriceBreakdown(trade)
-  const { /* priceImpactWithoutFee, */ realizedFee } = React.useMemo(() => computeTradePriceBreakdown(trade), [trade])
-  // const isExactIn = trade.tradeType === TradeType.EXACT_INPUT
+  const { realizedFee } = React.useMemo(() => computeTradePriceBreakdown(trade), [trade])
 
   return (
     <AutoColumn gap="2px">
@@ -53,7 +49,6 @@ export default function TradeSummary({
         <RowBetween height={24}>
           <RowFixed>
             <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
-              {/* Liquidity Provider Fee */}
               Fees (incl. gas costs)
             </TYPE.black>
             {showHelpers && (
@@ -68,44 +63,6 @@ export default function TradeSummary({
         </RowBetween>
       )}
 
-      {/* <RowBetween height={24}>
-        <RowFixed>
-          <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
-            <Trans>{trade.tradeType === TradeType.EXACT_INPUT ? 'Receive' : 'From'} (incl. fee)</Trans>
-          </TYPE.black>
-        </RowFixed>
-        <TYPE.black textAlign="right" fontSize={12} color={theme.text1}>
-          {formatSmart(isExactIn ? trade.outputAmount : trade.inputAmountWithFee)}{' '}
-          {(isExactIn ? trade.outputAmount : trade.inputAmount).currency.symbol}
-        </TYPE.black>
-      </RowBetween> */}
-
-      {/* 
-      <RowBetween>
-          <RowFixed>
-            <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
-              <Trans>Route</Trans>
-            </TYPE.black>
-          </RowFixed>
-          <TYPE.black textAlign="right" fontSize={12} color={theme.text1}>
-            <SwapRoute trade={trade} />
-          </TYPE.black>
-        </RowBetween> 
-        */}
-
-      {/* 
-      <RowBetween>
-          <RowFixed>
-            <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
-              <Trans>Price Impact</Trans>
-            </TYPE.black>
-          </RowFixed>
-          <TYPE.black textAlign="right" fontSize={12} color={theme.text1}>
-            <FormattedPriceImpact priceImpact={priceImpact} />
-          </TYPE.black>
-        </RowBetween> 
-        */}
-
       {/* Slippage */}
       <RowSlippage allowedSlippage={allowedSlippage} fontSize={12} fontWeight={400} rowHeight={24} />
 
@@ -118,17 +75,6 @@ export default function TradeSummary({
         fontWeight={400}
         rowHeight={24}
       />
-
-      {/* <RowBetween>
-        <RowFixed>
-          <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
-            <Trans>Slippage tolerance</Trans>
-          </TYPE.black>
-        </RowFixed>
-        <TYPE.black textAlign="right" fontSize={12} color={theme.text1}>
-          {allowedSlippage.toFixed(2)}%
-        </TYPE.black>
-      </RowBetween> */}
     </AutoColumn>
   )
 }

--- a/src/custom/components/swap/TradeSummary/TradeSummaryMod.tsx
+++ b/src/custom/components/swap/TradeSummary/TradeSummaryMod.tsx
@@ -1,12 +1,12 @@
-import { Trans } from '@lingui/macro'
-import React, { useContext, useMemo } from 'react'
+// import { Trans } from '@lingui/macro'
+import React, { useContext /*useMemo*/ } from 'react'
 import { ThemeContext } from 'styled-components'
 import { CurrencyAmount, Currency, TradeType } from '@uniswap/sdk-core'
 
-import { Field } from 'state/swap/actions'
+// import { Field } from 'state/swap/actions'
 import { TYPE } from 'theme'
-import { computeSlippageAdjustedAmounts } from 'utils/prices'
-import { getMinimumReceivedTooltip } from 'utils/tooltips'
+// import { computeSlippageAdjustedAmounts } from 'utils/prices'
+// import { getMinimumReceivedTooltip } from 'utils/tooltips'
 
 import { AutoColumn } from 'components/Column'
 import { RowBetween, RowFixed } from 'components/Row'
@@ -14,9 +14,7 @@ import TradeGp from 'state/swap/TradeGp'
 import { MouseoverTooltipContent } from 'components/Tooltip'
 import { StyledInfo } from 'pages/Swap/SwapMod'
 import { formatSmart } from 'utils/format'
-import { TradeSummaryProps } from '.'
-import { INPUT_OUTPUT_EXPLANATION } from 'constants/index'
-import { Percent } from '@uniswap/sdk-core'
+import { RowReceivedAfterSlippage, RowSlippage, TradeSummaryProps } from '.'
 
 // computes price breakdown for the trade
 export function computeTradePriceBreakdown(trade?: TradeGp | null): {
@@ -38,44 +36,6 @@ export function computeTradePriceBreakdown(trade?: TradeGp | null): {
 export const FEE_TOOLTIP_MSG =
   'On CowSwap you sign your order (hence no gas costs!). The fees are covering your gas costs already.'
 
-export interface RowSlippageProps {
-  allowedSlippage: Percent
-  fontWeight?: number
-  fontSize?: number
-  rowHeight?: number
-}
-export function RowSlippage({ allowedSlippage, fontSize = 14, fontWeight = 500, rowHeight }: RowSlippageProps) {
-  const theme = useContext(ThemeContext)
-
-  return (
-    <RowBetween height={rowHeight}>
-      <RowFixed>
-        <TYPE.black fontSize={fontSize} fontWeight={fontWeight} color={theme.text2}>
-          <Trans>Slippage tolerance</Trans>
-        </TYPE.black>
-        <MouseoverTooltipContent
-          bgColor={theme.bg3}
-          color={theme.text1}
-          content={
-            <Trans>
-              <p>Your slippage is MEV protected: all orders are submitted with tight spread (0.1%) on-chain.</p>
-              <p>
-                The slippage you pick here enables a resubmission of your order in case of unfavourable price movements.
-              </p>
-              <p>{INPUT_OUTPUT_EXPLANATION}</p>
-            </Trans>
-          }
-        >
-          <StyledInfo />
-        </MouseoverTooltipContent>
-      </RowFixed>
-      <TYPE.black textAlign="right" fontSize={fontSize} color={theme.text1}>
-        {allowedSlippage.toFixed(2)}%
-      </TYPE.black>
-    </RowBetween>
-  )
-}
-
 export default function TradeSummary({
   trade,
   allowedSlippage,
@@ -85,13 +45,7 @@ export default function TradeSummary({
   const theme = useContext(ThemeContext)
   // const { priceImpactWithoutFee, realizedLPFee } = computeTradePriceBreakdown(trade)
   const { /* priceImpactWithoutFee, */ realizedFee } = React.useMemo(() => computeTradePriceBreakdown(trade), [trade])
-  const isExactIn = trade.tradeType === TradeType.EXACT_INPUT
-  const slippageAdjustedAmounts = computeSlippageAdjustedAmounts(trade, allowedSlippage)
-
-  const [slippageOut, slippageIn] = useMemo(
-    () => [slippageAdjustedAmounts[Field.OUTPUT], slippageAdjustedAmounts[Field.INPUT]],
-    [slippageAdjustedAmounts]
-  )
+  // const isExactIn = trade.tradeType === TradeType.EXACT_INPUT
 
   return (
     <AutoColumn gap="2px">
@@ -152,37 +106,18 @@ export default function TradeSummary({
         </RowBetween> 
         */}
 
+      {/* Slippage */}
       <RowSlippage allowedSlippage={allowedSlippage} fontSize={12} fontWeight={400} rowHeight={24} />
 
-      <RowBetween height={24}>
-        <RowFixed>
-          <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
-            {trade.tradeType === TradeType.EXACT_INPUT ? (
-              <Trans>Minimum received (incl. fee)</Trans>
-            ) : (
-              <Trans>Maximum sent (incl. fee)</Trans>
-            )}
-          </TYPE.black>
-          {showHelpers && (
-            <MouseoverTooltipContent
-              content={getMinimumReceivedTooltip(allowedSlippage, isExactIn)}
-              bgColor={theme.bg1}
-              color={theme.text1}
-            >
-              <StyledInfo />
-            </MouseoverTooltipContent>
-          )}
-        </RowFixed>
-
-        <TYPE.black textAlign="right" fontSize={12} color={theme.text1}>
-          {/* {trade.tradeType === TradeType.EXACT_INPUT
-                ? `${trade.minimumAmountOut(allowedSlippage).toSignificant(6)} ${trade.outputAmount.currency.symbol}`
-                : `${trade.maximumAmountIn(allowedSlippage).toSignificant(6)} ${trade.inputAmount.currency.symbol}`} */}
-          {isExactIn
-            ? `${formatSmart(slippageOut) || '-'} ${trade.outputAmount.currency.symbol}`
-            : `${formatSmart(slippageIn) || '-'} ${trade.inputAmount.currency.symbol}`}
-        </TYPE.black>
-      </RowBetween>
+      {/* Min/Max received */}
+      <RowReceivedAfterSlippage
+        trade={trade}
+        showHelpers={showHelpers}
+        allowedSlippage={allowedSlippage}
+        fontSize={12}
+        fontWeight={400}
+        rowHeight={24}
+      />
 
       {/* <RowBetween>
         <RowFixed>

--- a/src/custom/components/swap/TradeSummary/TradeSummaryMod.tsx
+++ b/src/custom/components/swap/TradeSummary/TradeSummaryMod.tsx
@@ -16,6 +16,7 @@ import { StyledInfo } from 'pages/Swap/SwapMod'
 import { formatSmart } from 'utils/format'
 import { TradeSummaryProps } from '.'
 import { INPUT_OUTPUT_EXPLANATION } from 'constants/index'
+import { Percent } from '@uniswap/sdk-core'
 
 // computes price breakdown for the trade
 export function computeTradePriceBreakdown(trade?: TradeGp | null): {
@@ -36,6 +37,44 @@ export function computeTradePriceBreakdown(trade?: TradeGp | null): {
 
 export const FEE_TOOLTIP_MSG =
   'On CowSwap you sign your order (hence no gas costs!). The fees are covering your gas costs already.'
+
+export interface RowSlippageProps {
+  allowedSlippage: Percent
+  fontWeight?: number
+  fontSize?: number
+  rowHeight?: number
+}
+export function RowSlippage({ allowedSlippage, fontSize = 14, fontWeight = 500, rowHeight }: RowSlippageProps) {
+  const theme = useContext(ThemeContext)
+
+  return (
+    <RowBetween height={rowHeight}>
+      <RowFixed>
+        <TYPE.black fontSize={fontSize} fontWeight={fontWeight} color={theme.text2}>
+          <Trans>Slippage tolerance</Trans>
+        </TYPE.black>
+        <MouseoverTooltipContent
+          bgColor={theme.bg3}
+          color={theme.text1}
+          content={
+            <Trans>
+              <p>Your slippage is MEV protected: all orders are submitted with tight spread (0.1%) on-chain.</p>
+              <p>
+                The slippage you pick here enables a resubmission of your order in case of unfavourable price movements.
+              </p>
+              <p>{INPUT_OUTPUT_EXPLANATION}</p>
+            </Trans>
+          }
+        >
+          <StyledInfo />
+        </MouseoverTooltipContent>
+      </RowFixed>
+      <TYPE.black textAlign="right" fontSize={fontSize} color={theme.text1}>
+        {allowedSlippage.toFixed(2)}%
+      </TYPE.black>
+    </RowBetween>
+  )
+}
 
 export default function TradeSummary({
   trade,
@@ -113,32 +152,7 @@ export default function TradeSummary({
         </RowBetween> 
         */}
 
-      <RowBetween height={24}>
-        <RowFixed>
-          <TYPE.black fontSize={12} fontWeight={400} color={theme.text2}>
-            <Trans>Slippage tolerance</Trans>
-          </TYPE.black>
-          <MouseoverTooltipContent
-            bgColor={theme.bg3}
-            color={theme.text1}
-            content={
-              <Trans>
-                <p>Your slippage is MEV protected: all orders are submitted with tight spread (0.1%) on-chain.</p>
-                <p>
-                  The slippage you pick here enables a resubmission of your order in case of unfavourable price
-                  movements.
-                </p>
-                <p>{INPUT_OUTPUT_EXPLANATION}</p>
-              </Trans>
-            }
-          >
-            <StyledInfo />
-          </MouseoverTooltipContent>
-        </RowFixed>
-        <TYPE.black textAlign="right" fontSize={12} color={theme.text1}>
-          {allowedSlippage.toFixed(2)}%
-        </TYPE.black>
-      </RowBetween>
+      <RowSlippage allowedSlippage={allowedSlippage} fontSize={12} fontWeight={400} rowHeight={24} />
 
       <RowBetween height={24}>
         <RowFixed>

--- a/src/custom/components/swap/TradeSummary/index.tsx
+++ b/src/custom/components/swap/TradeSummary/index.tsx
@@ -67,8 +67,8 @@ export interface RowReceivedAfterSlippageProps {
 export function RowReceivedAfterSlippage({
   trade,
   allowedSlippage,
-  fontSize,
-  fontWeight,
+  fontSize = 14,
+  fontWeight = 500,
   rowHeight,
   showHelpers = true,
 }: RowReceivedAfterSlippageProps) {

--- a/src/custom/components/swap/TradeSummary/index.tsx
+++ b/src/custom/components/swap/TradeSummary/index.tsx
@@ -1,9 +1,118 @@
-import React from 'react'
-import styled from 'styled-components'
+import React, { useContext, useMemo } from 'react'
+import { Percent, TradeType } from '@uniswap/sdk-core'
+import styled, { ThemeContext } from 'styled-components'
+import { Trans } from '@lingui/macro'
+import { TYPE } from 'theme'
+
+import { Field } from 'state/swap/actions'
 import TradeSummaryMod from './TradeSummaryMod'
-import { RowFixed } from 'components/Row'
 import { WithClassName } from 'types'
 import { AdvancedSwapDetailsProps } from '../AdvancedSwapDetails'
+import { RowBetween, RowFixed } from 'components/Row'
+import { MouseoverTooltipContent } from 'components/Tooltip'
+import { INPUT_OUTPUT_EXPLANATION } from 'constants/index'
+import { StyledInfo } from 'pages/Swap/SwapMod'
+import TradeGp from 'state/swap/TradeGp'
+import { computeSlippageAdjustedAmounts } from 'utils/prices'
+import { getMinimumReceivedTooltip } from 'utils/tooltips'
+import { formatSmart } from 'utils/format'
+
+export interface RowSlippageProps {
+  allowedSlippage: Percent
+  fontWeight?: number
+  fontSize?: number
+  rowHeight?: number
+}
+export function RowSlippage({ allowedSlippage, fontSize = 14, fontWeight = 500, rowHeight }: RowSlippageProps) {
+  const theme = useContext(ThemeContext)
+
+  return (
+    <RowBetween height={rowHeight}>
+      <RowFixed>
+        <TYPE.black fontSize={fontSize} fontWeight={fontWeight} color={theme.text2}>
+          <Trans>Slippage tolerance</Trans>
+        </TYPE.black>
+        <MouseoverTooltipContent
+          bgColor={theme.bg3}
+          color={theme.text1}
+          content={
+            <Trans>
+              <p>Your slippage is MEV protected: all orders are submitted with tight spread (0.1%) on-chain.</p>
+              <p>
+                The slippage you pick here enables a resubmission of your order in case of unfavourable price movements.
+              </p>
+              <p>{INPUT_OUTPUT_EXPLANATION}</p>
+            </Trans>
+          }
+        >
+          <StyledInfo />
+        </MouseoverTooltipContent>
+      </RowFixed>
+      <TYPE.black textAlign="right" fontSize={fontSize} color={theme.text1}>
+        {allowedSlippage.toFixed(2)}%
+      </TYPE.black>
+    </RowBetween>
+  )
+}
+
+export interface RowReceivedAfterSlippageProps {
+  trade: TradeGp
+  allowedSlippage: Percent
+  fontWeight?: number
+  fontSize?: number
+  rowHeight?: number
+  showHelpers: boolean
+}
+
+export function RowReceivedAfterSlippage({
+  trade,
+  allowedSlippage,
+  fontSize,
+  fontWeight,
+  rowHeight,
+  showHelpers = true,
+}: RowReceivedAfterSlippageProps) {
+  const theme = useContext(ThemeContext)
+  const slippageAdjustedAmounts = computeSlippageAdjustedAmounts(trade, allowedSlippage)
+
+  const [slippageOut, slippageIn] = useMemo(
+    () => [slippageAdjustedAmounts[Field.OUTPUT], slippageAdjustedAmounts[Field.INPUT]],
+    [slippageAdjustedAmounts]
+  )
+  const isExactIn = trade.tradeType === TradeType.EXACT_INPUT
+
+  return (
+    <RowBetween height={rowHeight}>
+      <RowFixed>
+        <TYPE.black fontSize={fontSize} fontWeight={fontWeight} color={theme.text2}>
+          {trade.tradeType === TradeType.EXACT_INPUT ? (
+            <Trans>Minimum received (incl. fee)</Trans>
+          ) : (
+            <Trans>Maximum sent (incl. fee)</Trans>
+          )}
+        </TYPE.black>
+        {showHelpers && (
+          <MouseoverTooltipContent
+            content={getMinimumReceivedTooltip(allowedSlippage, isExactIn)}
+            bgColor={theme.bg1}
+            color={theme.text1}
+          >
+            <StyledInfo />
+          </MouseoverTooltipContent>
+        )}
+      </RowFixed>
+
+      <TYPE.black textAlign="right" fontSize={fontSize} color={theme.text1}>
+        {/* {trade.tradeType === TradeType.EXACT_INPUT
+            ? `${trade.minimumAmountOut(allowedSlippage).toSignificant(6)} ${trade.outputAmount.currency.symbol}`
+            : `${trade.maximumAmountIn(allowedSlippage).toSignificant(6)} ${trade.inputAmount.currency.symbol}`} */}
+        {isExactIn
+          ? `${formatSmart(slippageOut) || '-'} ${trade.outputAmount.currency.symbol}`
+          : `${formatSmart(slippageIn) || '-'} ${trade.inputAmount.currency.symbol}`}
+      </TYPE.black>
+    </RowBetween>
+  )
+}
 
 const Wrapper = styled.div`
   ${RowFixed} {

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -91,7 +91,7 @@ export const StyledInfo = styled(Info)`
 
 export default function Swap({
   history,
-  FeeGreaterMessage,
+  TradeBasicDetails,
   EthWethWrapMessage,
   SwitchToWethBtn,
   FeesExceedFromAmountMessage,
@@ -663,7 +663,7 @@ export default function Swap({
                       </ClickableText>
                     </RowBetween>
                   )}
-                  {(isFeeGreater || trade) && fee && <FeeGreaterMessage fee={fee} trade={trade} />}
+                  {(isFeeGreater || trade) && fee && <TradeBasicDetails fee={fee} trade={trade} />}
                 </AutoColumn>
                 {/* ETH exactIn && wrapCallback returned us cb */}
                 {isNativeIn && onWrap && (

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -25,7 +25,7 @@ import { /* Column, */ AutoColumn } from 'components/Column'
 import CurrencyInputPanel from 'components/CurrencyInputPanel'
 import CurrencyLogo from 'components/CurrencyLogo'
 import Loader from 'components/Loader'
-import { /* Row, */ AutoRow, RowBetween /* RowFixed */ } from 'components/Row'
+import { /* Row, */ AutoRow /*RowBetween, RowFixed */ } from 'components/Row'
 // import BetterTradeLink from 'components/swap/BetterTradeLink'
 import confirmPriceImpactWithoutFee from 'components/swap/confirmPriceImpactWithoutFee'
 import ConfirmSwapModal from 'components/swap/ConfirmSwapModal'
@@ -47,7 +47,7 @@ import { /* useToggledVersion, */ Version } from 'hooks/useToggledVersion'
 import { useUSDCValue } from 'hooks/useUSDCPrice'
 import useWrapCallback, { WrapType } from 'hooks/useWrapCallback'
 import { useActiveWeb3React } from 'hooks/web3'
-import { useWalletModalToggle, useToggleSettingsMenu } from 'state/application/hooks'
+import { useWalletModalToggle /*, useToggleSettingsMenu */ } from 'state/application/hooks'
 import { Field } from 'state/swap/actions'
 import {
   useDefaultsFromURLSearch,
@@ -136,7 +136,7 @@ export default function Swap({
   const toggleWalletModal = useWalletModalToggle()
 
   // for expert mode
-  const toggleSettings = useToggleSettingsMenu()
+  // const toggleSettings = useToggleSettingsMenu()
   const [isExpertMode] = useExpertModeManager()
 
   // get version from the url

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -66,9 +66,9 @@ import { maxAmountSpend } from 'utils/maxAmountSpend'
 // import { warningSeverity } from 'utils/prices'
 import AppBody from 'pages/AppBody'
 
-import { PERCENTAGE_PRECISION, INITIAL_ALLOWED_SLIPPAGE_PERCENT } from 'constants/index'
+import { /*PERCENTAGE_PRECISION,*/ INITIAL_ALLOWED_SLIPPAGE_PERCENT } from 'constants/index'
 import { computeSlippageAdjustedAmounts } from 'utils/prices'
-import { ClickableText } from 'pages/Pool/styleds'
+// import { ClickableText } from 'pages/Pool/styleds'
 import FeeInformationTooltip from 'components/swap/FeeInformationTooltip'
 import { useWalletInfo } from 'hooks/useWalletInfo'
 import { HashLink } from 'react-router-hash-link'
@@ -78,6 +78,7 @@ import { SwapProps, ButtonError, ButtonPrimary, ButtonLight } from '.' // mod
 import TradeGp from 'state/swap/TradeGp'
 import AdvancedSwapDetailsDropdown from 'components/swap/AdvancedSwapDetailsDropdown'
 import { formatSmart } from 'utils/format'
+import { RowSlippage } from '@src/custom/components/swap/TradeSummary'
 
 export const StyledInfo = styled(Info)`
   opacity: 0.4;
@@ -653,15 +654,16 @@ export default function Swap({
                     <Price trade={trade} theme={theme} showInverted={showInverted} setShowInverted={setShowInverted} />
                   )}
 
-                  {!allowedSlippage.equalTo(INITIAL_ALLOWED_SLIPPAGE_PERCENT) && (
-                    <RowBetween height={24} align="center">
-                      <ClickableText fontWeight={500} fontSize={14} color={theme.text2} onClick={toggleSettings}>
-                        <Trans>Slippage Tolerance</Trans>
-                      </ClickableText>
-                      <ClickableText fontWeight={500} fontSize={14} color={theme.text2} onClick={toggleSettings}>
-                        {formatSmart(allowedSlippage, PERCENTAGE_PRECISION)}%
-                      </ClickableText>
-                    </RowBetween>
+                  {!isExpertMode && !allowedSlippage.equalTo(INITIAL_ALLOWED_SLIPPAGE_PERCENT) && (
+                    // <RowBetween height={24} align="center">
+                    //   <ClickableText fontWeight={500} fontSize={14} color={theme.text2} onClick={toggleSettings}>
+                    //     <Trans>Slippage Tolerance</Trans>
+                    //   </ClickableText>
+                    //   <ClickableText fontWeight={500} fontSize={14} color={theme.text2} onClick={toggleSettings}>
+                    //     {formatSmart(allowedSlippage, PERCENTAGE_PRECISION)}%
+                    //   </ClickableText>
+                    // </RowBetween>
+                    <RowSlippage allowedSlippage={allowedSlippage} fontSize={12} fontWeight={400} rowHeight={24} />
                   )}
                   {(isFeeGreater || trade) && fee && <TradeBasicDetails fee={fee} trade={trade} />}
                 </AutoColumn>

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -32,7 +32,7 @@ import { Trans } from '@lingui/macro'
 import TradePrice from 'components/swap/TradePrice'
 import TradeGp from 'state/swap/TradeGp'
 import { useUSDCValue } from 'hooks/useUSDCPrice'
-import { computeTradePriceBreakdown } from 'components/swap/TradeSummary/TradeSummaryMod'
+import { computeTradePriceBreakdown, RowSlippage } from 'components/swap/TradeSummary/TradeSummaryMod'
 import { TradeType } from '@uniswap/sdk'
 import { getMinimumReceivedTooltip } from 'utils/tooltips'
 import { useExpertModeManager, useUserSlippageToleranceWithDefault } from 'state/user/hooks'
@@ -259,32 +259,7 @@ function TradeBasicDetails({ trade, fee, ...boxProps }: TradeBasicDetailsProp) {
       {isExpertMode && trade && (
         <>
           {/* Slippage */}
-          <RowBetween>
-            <RowFixed>
-              <TYPE.black fontSize={14} fontWeight={500} color={theme.text2}>
-                <Trans>Slippage tolerance</Trans>
-              </TYPE.black>
-              <MouseoverTooltipContent
-                bgColor={theme.bg3}
-                color={theme.text1}
-                content={
-                  <Trans>
-                    <p>Your slippage is MEV protected: all orders are submitted with tight spread (0.1%) on-chain.</p>
-                    <p>
-                      The slippage you pick here enables a resubmission of your order in case of unfavourable price
-                      movements.
-                    </p>
-                    <p>{INPUT_OUTPUT_EXPLANATION}</p>
-                  </Trans>
-                }
-              >
-                <StyledInfo />
-              </MouseoverTooltipContent>
-            </RowFixed>
-            <TYPE.black textAlign="right" fontSize={14} color={theme.text1}>
-              {allowedSlippage.toFixed(2)}%
-            </TYPE.black>
-          </RowBetween>
+          <RowSlippage allowedSlippage={allowedSlippage} />
 
           {/* Min/Max received */}
           <RowFixed>
@@ -306,9 +281,6 @@ function TradeBasicDetails({ trade, fee, ...boxProps }: TradeBasicDetailsProp) {
             }
           </RowFixed>
           <TYPE.black textAlign="right" fontSize={14} color={theme.text1}>
-            {/* {trade.tradeType === TradeType.EXACT_INPUT
-              ? `${trade.minimumAmountOut(allowedSlippage).toSignificant(6)} ${trade.outputAmount.currency.symbol}`
-              : `${trade.maximumAmountIn(allowedSlippage).toSignificant(6)} ${trade.inputAmount.currency.symbol}`} */}
             {isExactIn
               ? `${formatSmart(slippageOut) || '-'} ${trade.outputAmount.currency.symbol}`
               : `${formatSmart(slippageIn) || '-'} ${trade.inputAmount.currency.symbol}`}

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useContext, useEffect, useState } from 'react'
 import { RouteComponentProps } from 'react-router-dom'
 import styled, { DefaultTheme, ThemeContext } from 'styled-components'
 import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
@@ -32,14 +32,10 @@ import { Trans } from '@lingui/macro'
 import TradePrice from 'components/swap/TradePrice'
 import TradeGp from 'state/swap/TradeGp'
 import { useUSDCValue } from 'hooks/useUSDCPrice'
-import { computeTradePriceBreakdown, RowSlippage } from 'components/swap/TradeSummary/TradeSummaryMod'
-import { TradeType } from '@uniswap/sdk'
-import { getMinimumReceivedTooltip } from 'utils/tooltips'
+import { computeTradePriceBreakdown } from 'components/swap/TradeSummary/TradeSummaryMod'
 import { useExpertModeManager, useUserSlippageToleranceWithDefault } from 'state/user/hooks'
-import { computeSlippageAdjustedAmounts } from 'utils/prices'
 import { V2_SWAP_DEFAULT_SLIPPAGE } from 'hooks/useSwapSlippageTolerance'
-import { Field } from 'state/swap/actions'
-import { INPUT_OUTPUT_EXPLANATION } from 'constants/index'
+import { RowReceivedAfterSlippage, RowSlippage } from '@src/custom/components/swap/TradeSummary'
 
 interface TradeBasicDetailsProp extends BoxProps {
   trade?: TradeGp
@@ -228,12 +224,6 @@ function TradeBasicDetails({ trade, fee, ...boxProps }: TradeBasicDetailsProp) {
   const feeFiatDisplay = `(≈$${formatSmart(feeFiatValue, FIAT_PRECISION)})`
 
   const allowedSlippage = useUserSlippageToleranceWithDefault(V2_SWAP_DEFAULT_SLIPPAGE)
-  const slippageAdjustedAmounts = computeSlippageAdjustedAmounts(trade, allowedSlippage)
-  const [slippageOut, slippageIn] = useMemo(
-    () => [slippageAdjustedAmounts[Field.OUTPUT], slippageAdjustedAmounts[Field.INPUT]],
-    [slippageAdjustedAmounts]
-  )
-  const isExactIn = trade?.tradeType === TradeType.EXACT_INPUT
   const [isExpertMode] = useExpertModeManager()
 
   return (
@@ -262,29 +252,7 @@ function TradeBasicDetails({ trade, fee, ...boxProps }: TradeBasicDetailsProp) {
           <RowSlippage allowedSlippage={allowedSlippage} />
 
           {/* Min/Max received */}
-          <RowFixed>
-            <TYPE.black fontSize={14} fontWeight={500} color={theme.text2}>
-              {trade.tradeType === TradeType.EXACT_INPUT ? (
-                <Trans>Minimum received (incl. fee)</Trans>
-              ) : (
-                <Trans>Maximum sent (incl. fee)</Trans>
-              )}
-            </TYPE.black>
-            {
-              /*showHelpers &&*/ <MouseoverTooltipContent
-                content={getMinimumReceivedTooltip(allowedSlippage, isExactIn)}
-                bgColor={theme.bg1}
-                color={theme.text1}
-              >
-                <StyledInfo />
-              </MouseoverTooltipContent>
-            }
-          </RowFixed>
-          <TYPE.black textAlign="right" fontSize={14} color={theme.text1}>
-            {isExactIn
-              ? `${formatSmart(slippageOut) || '-'} ${trade.outputAmount.currency.symbol}`
-              : `${formatSmart(slippageIn) || '-'} ${trade.inputAmount.currency.symbol}`}
-          </TYPE.black>
+          <RowReceivedAfterSlippage trade={trade} allowedSlippage={allowedSlippage} showHelpers={true} />
         </>
       )}
     </LowerSectionWrapper>

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -35,7 +35,7 @@ import { useUSDCValue } from 'hooks/useUSDCPrice'
 import { computeTradePriceBreakdown } from 'components/swap/TradeSummary/TradeSummaryMod'
 import { TradeType } from '@uniswap/sdk'
 import { getMinimumReceivedTooltip } from 'utils/tooltips'
-import { useUserSlippageToleranceWithDefault } from 'state/user/hooks'
+import { useExpertModeManager, useUserSlippageToleranceWithDefault } from 'state/user/hooks'
 import { computeSlippageAdjustedAmounts } from 'utils/prices'
 import { V2_SWAP_DEFAULT_SLIPPAGE } from 'hooks/useSwapSlippageTolerance'
 import { Field } from 'state/swap/actions'
@@ -234,6 +234,7 @@ function TradeBasicDetails({ trade, fee, ...boxProps }: TradeBasicDetailsProp) {
     [slippageAdjustedAmounts]
   )
   const isExactIn = trade?.tradeType === TradeType.EXACT_INPUT
+  const [isExpertMode] = useExpertModeManager()
 
   return (
     <LowerSectionWrapper {...boxProps}>
@@ -255,7 +256,7 @@ function TradeBasicDetails({ trade, fee, ...boxProps }: TradeBasicDetailsProp) {
         {feeFiatValue && <LightGreyText>{feeFiatDisplay}</LightGreyText>}
       </TYPE.black>
 
-      {trade && (
+      {isExpertMode && trade && (
         <>
           {/* Slippage */}
           <RowBetween>


### PR DESCRIPTION
# Summary: Shows slippage and amount after slippage in expert mode

Closes #1141 

# Notes for reviewer
The main goal of this PR is to show the slippage and amounts after slippage, however, in order to show the slippage in the widget and not copy-past the code I had to refactor the two elements into 2 components:
* `RowSlippage`
* `RowReceivedAfterSlippage`

These 2 components were used both in the confirmation modal and in the widget.

On top of this, this uses `RowSlippage` in the widget when the slippage is non-AUTO, this fixes one issue we had and was not reported yet where:
- we didn't have tooltip for the slippage
- style was a bit different



# To Test

1. Verify that non expert mode doesn't show the slippage in the swap component directly. It's only shown in the confirmation modal.
![image](https://user-images.githubusercontent.com/2352112/127902813-29859596-3aaf-45a7-8804-6d3645bbd23b.png)


![image](https://user-images.githubusercontent.com/2352112/127902849-1b78ec44-2f62-4b68-8d0d-5d4529765be4.png)


2. Test that advanced mode, show the slippage and the min receive amount already in the swap component.
![image](https://user-images.githubusercontent.com/2352112/127903111-d696933b-459c-46d2-a0a4-595e5874ae3a.png)
