### PR TITLE
Change tooltip

### DIFF
--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -32,7 +32,7 @@ import { Trans } from '@lingui/macro'
 import TradePrice from 'components/swap/TradePrice'
 import TradeGp from 'state/swap/TradeGp'
 import { useUSDCValue } from 'hooks/useUSDCPrice'
-import { computeTradePriceBreakdown } from 'components/swap/TradeSummary/TradeSummaryMod'
+import { computeTradePriceBreakdown, FEE_TOOLTIP_MSG } from 'components/swap/TradeSummary/TradeSummaryMod'
 import { useExpertModeManager, useUserSlippageToleranceWithDefault } from 'state/user/hooks'
 import { V2_SWAP_DEFAULT_SLIPPAGE } from 'hooks/useSwapSlippageTolerance'
 import { RowReceivedAfterSlippage, RowSlippage } from '@src/custom/components/swap/TradeSummary'
@@ -233,11 +233,7 @@ function TradeBasicDetails({ trade, fee, ...boxProps }: TradeBasicDetailsProp) {
         <TYPE.black fontSize={14} fontWeight={500} color={theme.text1}>
           Fees (incl. gas costs)
         </TYPE.black>
-        <MouseoverTooltipContent
-          bgColor={theme.bg1}
-          color={theme.text1}
-          content="GP Swap has 0 gas fees. A portion of the sell amount in each trade goes to the GP Protocol."
-        >
+        <MouseoverTooltipContent bgColor={theme.bg1} color={theme.text1} content={FEE_TOOLTIP_MSG}>
           <StyledInfo />
         </MouseoverTooltipContent>
       </RowFixed>


### PR DESCRIPTION
# Summary

Uses the same message for the fee as in the confirmation modal so they are coherent:


![image](https://user-images.githubusercontent.com/2352112/128023968-b0d94312-020c-40d8-8425-af355c2675d9.png)


![image](https://user-images.githubusercontent.com/2352112/128023919-63da2f44-ccae-4168-8702-2af01971a83c.png)


