### PR TITLE
Balancer sc upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
   "dependencies": {
     "@gnosis.pm/cow-runner-game": "^0.2.9",
     "@gnosis.pm/dex-js": "^0.11.0",
-    "@gnosis.pm/gp-v2-contracts": "^0.0.1-alpha.20",
+    "@gnosis.pm/gp-v2-contracts": "^1.0.1",
     "@uniswap/default-token-list": "^2.0.0",
     "@web3-react/walletconnect-connector": "^6.2.0",
     "fast-safe-stringify": "^2.0.8",

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
   "dependencies": {
     "@gnosis.pm/cow-runner-game": "^0.2.9",
     "@gnosis.pm/dex-js": "^0.11.0",
-    "@gnosis.pm/gp-v2-contracts": "^1.0.1",
+    "@gnosis.pm/gp-v2-contracts": "^1.0.2",
     "@uniswap/default-token-list": "^2.0.0",
     "@web3-react/walletconnect-connector": "^6.2.0",
     "fast-safe-stringify": "^2.0.8",

--- a/src/custom/components/Version/index.tsx
+++ b/src/custom/components/Version/index.tsx
@@ -6,7 +6,7 @@ import { version as WEB_VERSION } from '@src/../package.json'
 import { version as CONTRACTS_VERSION } from '@gnosis.pm/gp-v2-contracts/package.json'
 import { SupportedChainId as ChainId } from 'constants/chains'
 import { getEtherscanLink } from 'utils'
-import { CODE_LINK, GP_ALLOWANCE_MANAGER_CONTRACT_ADDRESS, GP_SETTLEMENT_CONTRACT_ADDRESS } from 'constants/index'
+import { CODE_LINK, GP_VAULT_RELAYER, GP_SETTLEMENT_CONTRACT_ADDRESS } from 'constants/index'
 import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
 import { useActiveWeb3React } from 'hooks/web3'
 
@@ -34,12 +34,12 @@ const VERSIONS: Record<
       return CODE_LINK
     },
   },
-  'Allowance manager contract': {
+  'Vault Relayer': {
     version: 'v' + CONTRACTS_VERSION,
     href(chainId: ChainId) {
       return {
-        etherscan: _getContractsUrls(chainId, GP_ALLOWANCE_MANAGER_CONTRACT_ADDRESS),
-        github: `https://github.com/gnosis/gp-v2-contracts/blob/v${CONTRACTS_VERSION}/src/contracts/GPv2AllowListAuthentication.sol`,
+        etherscan: _getContractsUrls(chainId, GP_VAULT_RELAYER),
+        github: `https://github.com/gnosis/gp-v2-contracts/blob/v${CONTRACTS_VERSION}/src/contracts/GPv2VaultRelayer.sol`,
       }
     },
   },

--- a/src/custom/constants/GPv2Settlement.json
+++ b/src/custom/constants/GPv2Settlement.json
@@ -47,18 +47,5 @@
     ],
     "name": "Trade",
     "type": "event"
-  },
-  {
-    "inputs": [],
-    "name": "allowanceManager",
-    "outputs": [
-      {
-        "internalType": "contract GPv2AllowanceManager",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
   }
 ]

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -1,6 +1,6 @@
 import { Token, Fraction, Percent } from '@uniswap/sdk-core'
 
-import { GPv2Settlement, GPv2AllowanceManager } from '@gnosis.pm/gp-v2-contracts/networks.json'
+import { GPv2Settlement, GPv2VaultRelayer } from '@gnosis.pm/gp-v2-contracts/networks.json'
 import { WalletInfo, SUPPORTED_WALLETS as SUPPORTED_WALLETS_UNISWAP } from 'constants/wallet'
 
 import JSBI from 'jsbi'
@@ -46,10 +46,10 @@ export const GP_SETTLEMENT_CONTRACT_ADDRESS: Partial<Record<number, string>> = {
   [ChainId.XDAI]: GPv2Settlement[ChainId.XDAI].address,
 }
 
-export const GP_ALLOWANCE_MANAGER_CONTRACT_ADDRESS: Partial<Record<number, string>> = {
-  [ChainId.MAINNET]: GPv2AllowanceManager[ChainId.MAINNET].address,
-  [ChainId.RINKEBY]: GPv2AllowanceManager[ChainId.RINKEBY].address,
-  [ChainId.XDAI]: GPv2AllowanceManager[ChainId.XDAI].address,
+export const GP_VAULT_RELAYER: Partial<Record<number, string>> = {
+  [ChainId.MAINNET]: GPv2VaultRelayer[ChainId.MAINNET].address,
+  [ChainId.RINKEBY]: GPv2VaultRelayer[ChainId.RINKEBY].address,
+  [ChainId.XDAI]: GPv2VaultRelayer[ChainId.XDAI].address,
 }
 
 // See https://github.com/gnosis/gp-v2-contracts/commit/821b5a8da213297b0f7f1d8b17c893c5627020af#diff-12bbbe13cd5cf42d639e34a39d8795021ba40d3ee1e1a8282df652eb161a11d6R13

--- a/src/custom/hooks/useApproveCallback.ts
+++ b/src/custom/hooks/useApproveCallback.ts
@@ -3,7 +3,7 @@ import { useApproveCallback } from '@src/hooks/useApproveCallback'
 import { Field } from '@src/state/swap/actions'
 import { computeSlippageAdjustedAmounts } from 'utils/prices'
 import { useMemo } from 'react'
-import { GP_ALLOWANCE_MANAGER_CONTRACT_ADDRESS } from 'constants/index'
+import { GP_VAULT_RELAYER } from 'constants/index'
 import TradeGp from 'state/swap/TradeGp'
 import { ZERO_PERCENT } from 'constants/misc'
 
@@ -21,7 +21,7 @@ export function useApproveCallbackFromTrade(trade?: TradeGp, allowedSlippage = Z
     return undefined
   }, [trade, allowedSlippage])
 
-  const allowanceManager = chainId ? GP_ALLOWANCE_MANAGER_CONTRACT_ADDRESS[chainId] : undefined
+  const vaultRelayer = chainId ? GP_VAULT_RELAYER[chainId] : undefined
 
-  return useApproveCallback(amountToApprove, allowanceManager)
+  return useApproveCallback(amountToApprove, vaultRelayer)
 }

--- a/src/custom/hooks/useERC20Permit/useERC20PermitMod.ts
+++ b/src/custom/hooks/useERC20Permit/useERC20PermitMod.ts
@@ -14,7 +14,7 @@ import { useActiveWeb3React } from 'hooks/web3'
 
 import { PermitInfo, SignatureData, UseERC20PermitState } from '@src/hooks/useERC20Permit'
 import TradeGp from 'state/swap/TradeGp'
-import { GP_ALLOWANCE_MANAGER_CONTRACT_ADDRESS } from 'custom/constants'
+import { GP_VAULT_RELAYER } from 'custom/constants'
 
 export * from '@src/hooks/useERC20Permit'
 
@@ -291,7 +291,7 @@ export function useERC20PermitFromTrade(
   allowedSlippage: Percent
 ) {
   const { chainId } = useActiveWeb3React()
-  const gpAllowanceManagerAddress = chainId ? GP_ALLOWANCE_MANAGER_CONTRACT_ADDRESS[chainId] : undefined
+  const vaultRelayerAddress = chainId ? GP_VAULT_RELAYER[chainId] : undefined
   const amountToApprove = useMemo(
     () => (trade ? trade.maximumAmountIn(allowedSlippage) : undefined),
     [trade, allowedSlippage]
@@ -301,7 +301,7 @@ export function useERC20PermitFromTrade(
     amountToApprove,
     // v2 router does not support
     // trade instanceof V2Trade ? undefined : trade instanceof V3Trade ? swapRouterAddress : undefined,
-    gpAllowanceManagerAddress,
+    vaultRelayerAddress,
     null
   )
 }

--- a/src/custom/utils/signatures.ts
+++ b/src/custom/utils/signatures.ts
@@ -7,7 +7,7 @@ import {
   OrderCancellation as OrderCancellationGp,
   Signature,
   TypedDataV3Signer,
-  // IntChainIdTypedDataV4Signer,
+  IntChainIdTypedDataV4Signer,
 } from '@gnosis.pm/gp-v2-contracts'
 import { SupportedChainId as ChainId } from 'constants/chains'
 import { GP_SETTLEMENT_CONTRACT_ADDRESS } from 'constants/index'
@@ -164,10 +164,9 @@ async function _signPayload(
       case 'v3':
         _signer = new TypedDataV3Signer(signer)
         break
-      // TODO: This signer was remove from the SC npm package. Is it because this was a temporal fix because MM was broken in the past?
-      // case 'int_v4':
-      //   _signer = new IntChainIdTypedDataV4Signer(signer)
-      //   break
+      case 'int_v4':
+        _signer = new IntChainIdTypedDataV4Signer(signer)
+        break
       default:
         _signer = signer
     }

--- a/src/custom/utils/signatures.ts
+++ b/src/custom/utils/signatures.ts
@@ -7,7 +7,7 @@ import {
   OrderCancellation as OrderCancellationGp,
   Signature,
   TypedDataV3Signer,
-  IntChainIdTypedDataV4Signer,
+  // IntChainIdTypedDataV4Signer,
 } from '@gnosis.pm/gp-v2-contracts'
 import { SupportedChainId as ChainId } from 'constants/chains'
 import { GP_SETTLEMENT_CONTRACT_ADDRESS } from 'constants/index'
@@ -164,9 +164,10 @@ async function _signPayload(
       case 'v3':
         _signer = new TypedDataV3Signer(signer)
         break
-      case 'int_v4':
-        _signer = new IntChainIdTypedDataV4Signer(signer)
-        break
+      // TODO: This signer was remove from the SC npm package. Is it because this was a temporal fix because MM was broken in the past?
+      // case 'int_v4':
+      //   _signer = new IntChainIdTypedDataV4Signer(signer)
+      //   break
       default:
         _signer = signer
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1845,10 +1845,10 @@
     "@gnosis.pm/dex-contracts" "^0.5.0"
     bignumber.js "^9.0.0"
 
-"@gnosis.pm/gp-v2-contracts@^0.0.1-alpha.20":
-  version "0.0.1-alpha.20"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/gp-v2-contracts/-/gp-v2-contracts-0.0.1-alpha.20.tgz#8a53a1495c9dc356080b3ec3ec4f29808726952b"
-  integrity sha512-+R+JKMbzC4SDEdbg86yRbWEBom5ZW0eRGfvNCJ3qUg5KSNKJvA/2bCYHpfWBiQ7fETKHyYH2mlO3XziWplwa2A==
+"@gnosis.pm/gp-v2-contracts@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/gp-v2-contracts/-/gp-v2-contracts-1.0.1.tgz#42a71f0d136981734da9d4b7eac3f2bd7771141c"
+  integrity sha512-YR6FGMGn+pkoSXLwMAtBD7PoXbOU4Lgf/tgiTgxdF08uLCL8z30RkA6Q1EBFy3zw5fuBK5HiEl9JnORIbyE+ag==
 
 "@hapi/address@2.x.x":
   version "2.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1845,10 +1845,10 @@
     "@gnosis.pm/dex-contracts" "^0.5.0"
     bignumber.js "^9.0.0"
 
-"@gnosis.pm/gp-v2-contracts@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/gp-v2-contracts/-/gp-v2-contracts-1.0.1.tgz#42a71f0d136981734da9d4b7eac3f2bd7771141c"
-  integrity sha512-YR6FGMGn+pkoSXLwMAtBD7PoXbOU4Lgf/tgiTgxdF08uLCL8z30RkA6Q1EBFy3zw5fuBK5HiEl9JnORIbyE+ag==
+"@gnosis.pm/gp-v2-contracts@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/gp-v2-contracts/-/gp-v2-contracts-1.0.2.tgz#bcc1f6a07061df6ab55298d7fe6ee93fcd1025aa"
+  integrity sha512-bsWB8r8RENvpAGMRfRfENtMU7tPdfa1AtgTidUpxC9f3HREZ2FdiAvAghE3XZwy7BzJ0CQJ2lNl4ANKCZ+kj8Q==
 
 "@hapi/address@2.x.x":
   version "2.1.4"


### PR DESCRIPTION
# Summary
Closes #762

Main change is that now, we should use the VaultRelayer instead of the AllowanceManager for the approvals.

See this doc: https://docs.google.com/document/d/1Mb4vIvIB535G8yApG5Gk3dgkoCDcwcwxwvD6wTaN5VY/edit#heading=h.l8vi2hr6s5c 

## WIP
This is a WIP, also backend is not ready yet. I will pause this PR until backend is ready, then we will do better testings.

## Note about API
For this release, and as an exception, we should use our new environment `barn.cowswap.exchange` to do the QA testing, because it shouldn't be used PRODUCTION API during the tests. This is because PRODUCTION API will only be upgraded in coordination with CowSwap, so both version will need to be tested in the same environment.

For the `PRauls` and `DEVELOP` version, it will just work because it should point to the DEV API.




## To Test

Just trade: buy orders, sell orders, buy ETH, sell ETH, etc

Notice the footer shows the Vault Relayer and the new version:
![image](https://user-images.githubusercontent.com/2352112/128057267-2e25a1f7-f61c-4c45-a943-7b5f8ac2d4f8.png)
