### PR TITLE
1120/full amounts in titles

### DIFF
--- a/src/custom/components/CurrencyInputPanel/CurrencyInputPanelMod.tsx
+++ b/src/custom/components/CurrencyInputPanel/CurrencyInputPanelMod.tsx
@@ -271,6 +271,7 @@ export default function CurrencyInputPanel({
                       fontWeight={400}
                       fontSize={14}
                       style={{ display: 'inline', cursor: 'pointer' }}
+                      title={`${selectedCurrencyBalance?.toFixed(currency?.decimals) || '-'} ${currency?.symbol || ''}`}
                     >
                       {!hideBalance && currency && selectedCurrencyBalance ? (
                         renderBalance ? (

--- a/src/custom/components/swap/FeeInformationTooltip.tsx
+++ b/src/custom/components/swap/FeeInformationTooltip.tsx
@@ -78,7 +78,10 @@ export default function FeeInformationTooltip(props: FeeInformationTooltipProps)
   const theme = useTheme()
   const fiatValue = useUSDCValue(type === 'From' ? trade?.inputAmount : trade?.outputAmount)
 
-  const symbol = useMemo(() => trade?.[type === 'From' ? 'inputAmount' : 'outputAmount'].currency.symbol, [trade, type])
+  const [symbol, fullFeeAmount] = useMemo(() => {
+    const amount = trade?.[type === 'From' ? 'inputAmount' : 'outputAmount']
+    return amount ? [amount.currency.symbol, amount.toFixed(amount.currency.decimals)] : []
+  }, [trade, type])
 
   if (!trade || !showHelper) return null
 
@@ -119,7 +122,7 @@ export default function FeeInformationTooltip(props: FeeInformationTooltipProps)
           }
         />
       </span>
-      <FeeAmountAndFiat>
+      <FeeAmountAndFiat title={`${fullFeeAmount || '-'} ${symbol || ''}`}>
         {amountAfterFees} {showFiat && fiatValue && <small>≈ ${formatSmart(fiatValue, FIAT_PRECISION)}</small>}
       </FeeAmountAndFiat>
     </FeeInformationTooltipWrapper>

--- a/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
+++ b/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
@@ -105,6 +105,9 @@ SwapModalHeaderProps) {
     [trade]
   )
 
+  const fullInputWithoutFee = trade?.inputAmountWithoutFee?.toFixed(trade?.inputAmount.currency.decimals) || '-'
+  const fullOutputWithoutFee = trade?.outputAmountWithoutFee?.toFixed(trade?.outputAmount.currency.decimals) || '-'
+
   return (
     <AutoColumn gap={'4px'} style={{ marginTop: '1rem' }}>
       <LightCard flatBorder={!!exactInLabel} padding="0.75rem 1rem">
@@ -127,6 +130,7 @@ SwapModalHeaderProps) {
                 fontSize={24}
                 fontWeight={500}
                 color={showAcceptChanges && trade.tradeType === TradeType.EXACT_OUTPUT ? theme.primary1 : ''}
+                title={`${fullInputWithoutFee} ${trade.inputAmount.currency.symbol || ''}`}
               >
                 {formatSmart(trade.inputAmountWithoutFee)}
               </TruncatedText>
@@ -175,7 +179,11 @@ SwapModalHeaderProps) {
               </Text>
             </RowFixed>
             <RowFixed gap={'0px'}>
-              <TruncatedText fontSize={24} fontWeight={500}>
+              <TruncatedText
+                fontSize={24}
+                fontWeight={500}
+                title={`${fullOutputWithoutFee} ${trade.outputAmount.currency.symbol || ''}`}
+              >
                 {formatSmart(trade.outputAmountWithoutFee)}
               </TruncatedText>
             </RowFixed>

--- a/src/custom/components/swap/TradePrice/TradePriceMod.tsx
+++ b/src/custom/components/swap/TradePrice/TradePriceMod.tsx
@@ -4,6 +4,7 @@ import { useContext } from 'react'
 import { Text } from 'rebass'
 import styled, { ThemeContext } from 'styled-components'
 import { formatSmart } from 'utils/format' // mod
+import { LONG_PRECISION } from 'constants/index' // mod
 import { LightGreyText } from 'pages/Swap'
 
 export interface TradePriceProps {
@@ -43,6 +44,8 @@ export default function TradePrice({ price, showInverted, fiatValue, setShowInve
     formattedPrice = 'N/A'
   }
 
+  const fullFormattedPrice = showInverted ? price?.toFixed(LONG_PRECISION) : price?.invert().toFixed(LONG_PRECISION)
+
   const label = showInverted ? `${price.quoteCurrency?.symbol}` : `${price.baseCurrency?.symbol} `
   const labelInverted = showInverted ? `${price.baseCurrency?.symbol} ` : `${price.quoteCurrency?.symbol}`
   const flipPrice = useCallback(() => setShowInverted(!showInverted), [setShowInverted, showInverted])
@@ -59,7 +62,7 @@ export default function TradePrice({ price, showInverted, fiatValue, setShowInve
         <Text fontWeight={500} fontSize={14} color={theme.text1}>
           {/* {text} */}
           <LightGreyText>{baseText}</LightGreyText>
-          <span>{quoteText}</span>
+          <span title={`${fullFormattedPrice || '-'} ${label}`}>{quoteText}</span>
           {fiatValue && <LightGreyText>{fiatText}</LightGreyText>}
         </Text>
       </div>

--- a/src/custom/components/swap/TradeSummary/TradeSummaryMod.tsx
+++ b/src/custom/components/swap/TradeSummary/TradeSummaryMod.tsx
@@ -43,6 +43,8 @@ export default function TradeSummary({
   const theme = useContext(ThemeContext)
   const { realizedFee } = React.useMemo(() => computeTradePriceBreakdown(trade), [trade])
 
+  const fullRealizedFee = realizedFee?.toFixed(realizedFee?.currency.decimals) || '-'
+
   return (
     <AutoColumn gap="2px">
       {showFee && (
@@ -57,7 +59,12 @@ export default function TradeSummary({
               </MouseoverTooltipContent>
             )}
           </RowFixed>
-          <TYPE.black textAlign="right" fontSize={12} color={theme.text1}>
+          <TYPE.black
+            textAlign="right"
+            fontSize={12}
+            color={theme.text1}
+            title={`${fullRealizedFee} ${realizedFee?.currency.symbol}`}
+          >
             {`${formatSmart(realizedFee) || '-'} ${realizedFee?.currency.symbol}`}
           </TYPE.black>
         </RowBetween>

--- a/src/custom/components/swap/TradeSummary/index.tsx
+++ b/src/custom/components/swap/TradeSummary/index.tsx
@@ -101,6 +101,12 @@ export function RowReceivedAfterSlippage({
   )
   const isExactIn = trade.tradeType === TradeType.EXACT_INPUT
 
+  const [outAmount, outSymbol] = isExactIn
+    ? [slippageOut, trade.outputAmount.currency.symbol]
+    : [slippageIn, trade.inputAmount.currency.symbol]
+
+  const fullOutAmount = outAmount?.toFixed(outAmount?.currency.decimals) || '-'
+
   return (
     <RowBetween height={rowHeight}>
       <RowFixed>
@@ -122,13 +128,11 @@ export function RowReceivedAfterSlippage({
         )}
       </RowFixed>
 
-      <TYPE.black textAlign="right" fontSize={fontSize} color={theme.text1}>
+      <TYPE.black textAlign="right" fontSize={fontSize} color={theme.text1} title={`${fullOutAmount} ${outSymbol}`}>
         {/* {trade.tradeType === TradeType.EXACT_INPUT
             ? `${trade.minimumAmountOut(allowedSlippage).toSignificant(6)} ${trade.outputAmount.currency.symbol}`
             : `${trade.maximumAmountIn(allowedSlippage).toSignificant(6)} ${trade.inputAmount.currency.symbol}`} */}
-        {isExactIn
-          ? `${formatSmart(slippageOut) || '-'} ${trade.outputAmount.currency.symbol}`
-          : `${formatSmart(slippageIn) || '-'} ${trade.inputAmount.currency.symbol}`}
+        {`${formatSmart(outAmount) || '-'} ${outSymbol}`}
       </TYPE.black>
     </RowBetween>
   )

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -226,6 +226,10 @@ function TradeBasicDetails({ trade, fee, ...boxProps }: TradeBasicDetailsProp) {
   const allowedSlippage = useUserSlippageToleranceWithDefault(V2_SWAP_DEFAULT_SLIPPAGE)
   const [isExpertMode] = useExpertModeManager()
 
+  const displayFee = realizedFee || fee
+  const feeCurrencySymbol = displayFee?.currency.symbol || '-'
+  const fullDisplayFee = displayFee?.toFixed(displayFee?.currency.decimals) || '-'
+
   return (
     <LowerSectionWrapper {...boxProps}>
       {/* Fees */}
@@ -237,8 +241,8 @@ function TradeBasicDetails({ trade, fee, ...boxProps }: TradeBasicDetailsProp) {
           <StyledInfo />
         </MouseoverTooltipContent>
       </RowFixed>
-      <TYPE.black fontSize={14} color={theme.text1}>
-        {formatSmart(realizedFee || fee, SHORT_PRECISION)} {(realizedFee || fee)?.currency.symbol}{' '}
+      <TYPE.black fontSize={14} color={theme.text1} title={`${fullDisplayFee} ${feeCurrencySymbol}`}>
+        {formatSmart(displayFee, SHORT_PRECISION)} {feeCurrencySymbol}{' '}
         {feeFiatValue && <LightGreyText>{feeFiatDisplay}</LightGreyText>}
       </TYPE.black>
 


### PR DESCRIPTION
# Summary

Addressing comments https://github.com/gnosis/cowswap/pull/1127#pullrequestreview-718871330

"Titles, titles everywhere"

Impossible to screenshot all the titles at the same time, so just hover over any value in the UI.

1. On the swap page:
- Balances
- Send/Receive (buy/sell)
- Price
- [expert] Fees
- [expert] Minimum/maximum amounts

2. On the confirmation modal (not applicable on expert mode):
- From/to amounts
- Send/Receive amount (buy/sell)
- Price
- Fees
- Minimum/maximum amounts

  # To Test

1. On swap page with expert mode turned off, fill in all parameters.
2. Hover over every value from section `1` above
- [ ] Every section should display a title tooltip with the full amount of the respective field
3. Click on swap. Hover over every value from section `2` above
- [ ] On the confirmation modal, every section should display a title tooltilp with the full amount of the respective field
4. Repeat steps 1-3 for a buy order
- [ ] Result should be the same
5. Repeat steps 1-4 with the expert mode turned on

  # Background

*Optional: Give background information for changes you've made, that might be difficult to explain via comments*

