### PR TITLE
Fix tooltip styles.

### DIFF
--- a/src/custom/components/Popover/index.tsx
+++ b/src/custom/components/Popover/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PopoverMod, { Arrow as ArrowMod, PopoverContainer as PopoverContainerMod } from './PopoverMod'
 import styled from 'styled-components/macro'
 import { PopoverProps } from './PopoverMod'
+import { transparentize } from 'polished'
 
 export * from './PopoverMod'
 
@@ -12,13 +13,17 @@ export interface PopoverContainerProps {
 }
 
 const PopoverContainer = styled(PopoverContainerMod)<PopoverContainerProps>`
-  background: ${({ theme, bgColor }) => bgColor || theme.bg2};
-  color: ${({ theme, color }) => color || theme.text2};
+  background: ${({ theme }) => theme.bg4};
+  color: ${({ theme, color }) => color || theme.text1};
+  box-shadow: 0 4px 16px 0 ${({ theme }) => transparentize(0.8, theme.shadow1)};
+  border-radius: 12px;
+  border: 0;
+  padding: 6px 3px;
 `
 
 const Arrow = styled(ArrowMod)<Omit<PopoverContainerProps, 'color' | 'show'>>`
   ::before {
-    background: ${({ theme, bgColor }) => bgColor || theme.bg2};
+    background: ${({ theme }) => theme.bg4};
   }
 `
 


### PR DESCRIPTION
# Summary

Improves tooltip styles by using an appropriate background color, providing better contrast:

<img width="491" alt="Screen Shot 2021-08-04 at 15 54 03" src="https://user-images.githubusercontent.com/31534717/128193453-bce81963-f6fb-4ef3-9799-7c7af9de2892.png">
<img width="507" alt="Screen Shot 2021-08-04 at 15 53 54" src="https://user-images.githubusercontent.com/31534717/128193470-bb0f0ccc-2743-4c64-83e9-42c0e932a4ed.png">
<img width="512" alt="Screen Shot 2021-08-04 at 15 52 04" src="https://user-images.githubusercontent.com/31534717/128193475-cae0696a-7c8b-4a92-8d21-3d23e40cda36.png">
<img width="501" alt="Screen Shot 2021-08-04 at 15 51 56" src="https://user-images.githubusercontent.com/31534717/128193479-75faea27-cde0-4e1d-a201-3a86e197dc21.png">
<img width="507" alt="Screen Shot 2021-08-04 at 15 51 48" src="https://user-images.githubusercontent.com/31534717/128193481-5c58e8b1-04a9-4743-be5b-85a3259a92d0.png">
