### PR TITLE
Fix buy ETH

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -53,14 +53,14 @@ export const GP_VAULT_RELAYER: Partial<Record<number, string>> = {
 }
 
 // See https://github.com/gnosis/gp-v2-contracts/commit/821b5a8da213297b0f7f1d8b17c893c5627020af#diff-12bbbe13cd5cf42d639e34a39d8795021ba40d3ee1e1a8282df652eb161a11d6R13
-export const BUY_ETHER_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
-export const BUY_ETHER_TOKEN: { [chainId in ChainId]: Token } = {
-  [ChainId.MAINNET]: new Token(ChainId.MAINNET, BUY_ETHER_ADDRESS, 18, 'ETH', 'Ether'),
-  [ChainId.RINKEBY]: new Token(ChainId.RINKEBY, BUY_ETHER_ADDRESS, 18, 'ETH', 'Ether'),
-  [ChainId.ROPSTEN]: new Token(ChainId.ROPSTEN, BUY_ETHER_ADDRESS, 18, 'ETH', 'Ether'),
-  [ChainId.GOERLI]: new Token(ChainId.GOERLI, BUY_ETHER_ADDRESS, 18, 'ETH', 'Ether'),
-  [ChainId.KOVAN]: new Token(ChainId.KOVAN, BUY_ETHER_ADDRESS, 18, 'ETH', 'Ether'),
-  [ChainId.XDAI]: new Token(ChainId.XDAI, BUY_ETHER_ADDRESS, 18, 'xDAI', 'xDAI'),
+export const NATIVE_CURRENCY_BUY_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
+export const NATIVE_CURRENCY_BUY_TOKEN: { [chainId in ChainId | number]: Token } = {
+  [ChainId.MAINNET]: new Token(ChainId.MAINNET, NATIVE_CURRENCY_BUY_ADDRESS, 18, 'ETH', 'Ether'),
+  [ChainId.RINKEBY]: new Token(ChainId.RINKEBY, NATIVE_CURRENCY_BUY_ADDRESS, 18, 'ETH', 'Ether'),
+  [ChainId.ROPSTEN]: new Token(ChainId.ROPSTEN, NATIVE_CURRENCY_BUY_ADDRESS, 18, 'ETH', 'Ether'),
+  [ChainId.GOERLI]: new Token(ChainId.GOERLI, NATIVE_CURRENCY_BUY_ADDRESS, 18, 'ETH', 'Ether'),
+  [ChainId.KOVAN]: new Token(ChainId.KOVAN, NATIVE_CURRENCY_BUY_ADDRESS, 18, 'ETH', 'Ether'),
+  [ChainId.XDAI]: new Token(ChainId.XDAI, NATIVE_CURRENCY_BUY_ADDRESS, 18, 'xDAI', 'xDAI'),
 }
 
 export const ORDER_ID_SHORT_LENGTH = 8

--- a/src/custom/hooks/useSwapCallback.ts
+++ b/src/custom/hooks/useSwapCallback.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { Currency, /* Ether as ETHER, */ Percent, TradeType, CurrencyAmount } from '@uniswap/sdk-core'
 import { OrderKind } from '@gnosis.pm/gp-v2-contracts'
 
-import { INITIAL_ALLOWED_SLIPPAGE_PERCENT } from 'constants/index'
+import { INITIAL_ALLOWED_SLIPPAGE_PERCENT, NATIVE_CURRENCY_BUY_TOKEN } from 'constants/index'
 
 import { useAddPendingOrder } from 'state/orders/hooks'
 
@@ -86,8 +86,7 @@ export function useSwapCallback(
     const isSellEth = ETHER.onChain(chainId).equals(trade.inputAmount.currency)
 
     const sellToken = trade.inputAmount.currency.wrapped
-    // TODO: check this ETHER.onChain AND .wrapped
-    const buyToken = isBuyEth ? ETHER.onChain(chainId).wrapped : trade.outputAmount.currency.wrapped
+    const buyToken = isBuyEth ? NATIVE_CURRENCY_BUY_TOKEN[chainId] : trade.outputAmount.currency.wrapped
 
     if (!sellToken || !buyToken || (isSellEth && !wrapEther)) {
       return { state: SwapCallbackState.INVALID, callback: null, error: 'Missing dependencies' }


### PR DESCRIPTION
# Summary

Since the latest release (v0.17.0) users are not able to buy ETH.
The order is converted to WETH without user's consent.

  # To Test

1. On any network, pick as a buy token the native currency (xDai on xDai, ETH everywhere else)
2. Pick as sell token any token besides the wrapped native currency. We don't want to send a "unwrap" tx.
3. Place the order
- [ ] The signature prompt should have as buy token the address 0xeeee....
![screenshot_2021-08-04_13-53-39](https://user-images.githubusercontent.com/43217/128253439-d37420e2-32e3-41e1-94a9-a9f25bed607c.png)
- [ ] The explorer should show the corresponding native currency as "to"
![screenshot_2021-08-04_13-56-22](https://user-images.githubusercontent.com/43217/128253541-17fa72a3-391a-42b3-9763-402689e936dc.png)
![screenshot_2021-08-04_13-56-14](https://user-images.githubusercontent.com/43217/128253542-7b1ba77d-8d86-4fe0-a1a8-85c028e2fdda.png)

  # Background

Why is this pointing to `develop` instead of `hotfix/0.17.1`?

Because the smart contract has been updated on backend `staging`.
We can only test this change on hotfix branch from our `staging` or `prod`.

Once this is approved, it should be cherry-picked onto the hotfix branch.

