### PR TITLE
Add appDataHash to state

### DIFF
--- a/src/custom/state/affiliate/actions.ts
+++ b/src/custom/state/affiliate/actions.ts
@@ -1,3 +1,4 @@
 import { createAction } from '@reduxjs/toolkit'
 
-export const updateReferralAddress = createAction<{ referralAddress: string }>('affiliate/updateReferralAddress')
+export const updateReferralAddress = createAction<string>('affiliate/updateReferralAddress')
+export const updateAppDataHash = createAction<string>('affiliate/updateAppDataHash')

--- a/src/custom/state/affiliate/actions.ts
+++ b/src/custom/state/affiliate/actions.ts
@@ -1,3 +1,3 @@
 import { createAction } from '@reduxjs/toolkit'
 
-export const updateReferrerAddress = createAction<{ referrer: string }>('affiliate/updateReferrerAddress')
+export const updateReferralAddress = createAction<{ referralAddress: string }>('affiliate/updateReferralAddress')

--- a/src/custom/state/affiliate/reducer.ts
+++ b/src/custom/state/affiliate/reducer.ts
@@ -1,16 +1,16 @@
 import { createReducer } from '@reduxjs/toolkit'
-import { updateReferrerAddress } from './actions'
+import { updateReferralAddress } from './actions'
 
 export interface AffiliateLinkState {
-  referrerAddress: string
+  referralAddress: string
 }
 
 export const initialState: AffiliateLinkState = {
-  referrerAddress: '',
+  referralAddress: '',
 }
 
 export default createReducer(initialState, (builder) =>
-  builder.addCase(updateReferrerAddress, (state, action) => {
-    state.referrerAddress = action.payload.referrer
+  builder.addCase(updateReferralAddress, (state, action) => {
+    state.referralAddress = action.payload.referralAddress
   })
 )

--- a/src/custom/state/affiliate/reducer.ts
+++ b/src/custom/state/affiliate/reducer.ts
@@ -1,6 +1,6 @@
 import { createReducer } from '@reduxjs/toolkit'
 import { updateAppDataHash, updateReferralAddress } from './actions'
-import { METADATA_DIGEST_HEX } from '/constants'
+import { METADATA_DIGEST_HEX } from 'constants/index'
 
 export interface AffiliateState {
   referralAddress?: string

--- a/src/custom/state/affiliate/reducer.ts
+++ b/src/custom/state/affiliate/reducer.ts
@@ -1,16 +1,23 @@
 import { createReducer } from '@reduxjs/toolkit'
-import { updateReferralAddress } from './actions'
+import { updateAppDataHash, updateReferralAddress } from './actions'
+import { METADATA_DIGEST_HEX } from '/constants'
 
-export interface AffiliateLinkState {
-  referralAddress: string
+export interface AffiliateState {
+  referralAddress?: string
+  appDataHash?: string
 }
 
-export const initialState: AffiliateLinkState = {
+export const initialState: AffiliateState = {
   referralAddress: '',
+  appDataHash: METADATA_DIGEST_HEX,
 }
 
 export default createReducer(initialState, (builder) =>
-  builder.addCase(updateReferralAddress, (state, action) => {
-    state.referralAddress = action.payload.referralAddress
-  })
+  builder
+    .addCase(updateReferralAddress, (state, action) => {
+      state.referralAddress = action.payload
+    })
+    .addCase(updateAppDataHash, (state, action) => {
+      state.appDataHash = action.payload
+    })
 )

--- a/src/custom/state/affiliate/reducer.ts
+++ b/src/custom/state/affiliate/reducer.ts
@@ -1,6 +1,6 @@
 import { createReducer } from '@reduxjs/toolkit'
 import { updateAppDataHash, updateReferralAddress } from './actions'
-import { METADATA_DIGEST_HEX } from 'constants/index'
+import { APP_DATA_HASH } from 'constants/index'
 
 export interface AffiliateState {
   referralAddress?: string
@@ -9,7 +9,7 @@ export interface AffiliateState {
 
 export const initialState: AffiliateState = {
   referralAddress: '',
-  appDataHash: METADATA_DIGEST_HEX,
+  appDataHash: APP_DATA_HASH,
 }
 
 export default createReducer(initialState, (builder) =>

--- a/src/custom/state/affiliate/updater.tsx
+++ b/src/custom/state/affiliate/updater.tsx
@@ -1,20 +1,20 @@
 import { useEffect } from 'react'
 
-import { updateReferrerAddress } from 'state/affiliate/actions'
+import { updateReferralAddress } from 'state/affiliate/actions'
 import useParseReferralQueryParam from 'hooks/useParseReferralQueryParam'
 import { useWalletInfo } from 'hooks/useWalletInfo'
 import { useAppDispatch } from 'state/hooks'
 
 export default function ReferralLinkUpdater() {
   const dispatch = useAppDispatch()
-  const referralLink = useParseReferralQueryParam()
+  const referralAddress = useParseReferralQueryParam()
   const { account } = useWalletInfo()
 
   useEffect(() => {
-    if (referralLink && account) {
-      dispatch(updateReferrerAddress({ referrer: referralLink }))
+    if (referralAddress && account) {
+      dispatch(updateReferralAddress({ referralAddress: referralAddress }))
     }
-  }, [account, referralLink, dispatch])
+  }, [account, referralAddress, dispatch])
 
   return null
 }

--- a/src/custom/state/affiliate/updater.tsx
+++ b/src/custom/state/affiliate/updater.tsx
@@ -12,7 +12,7 @@ export default function ReferralLinkUpdater() {
 
   useEffect(() => {
     if (referralAddress && account) {
-      dispatch(updateReferralAddress({ referralAddress: referralAddress }))
+      dispatch(updateReferralAddress(referralAddress))
     }
   }, [account, referralAddress, dispatch])
 


### PR DESCRIPTION
# Summary

Closes #945

Adds a default appDataHash to state based on the `APP_DATA_HASH` constant value. I also renamed some variable names from referrer to referral.

The PR depends on https://github.com/gnosis/cowswap/pull/1178 to be merged first as it uses the new constant value `METADATA_DIGEST_HEX`.