### PR TITLE
WIP - Orders panel part 1 (simple component)

### DIFF
--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { SupportedChainId as ChainId } from 'constants/chains'
 import Web3Status from 'components/Web3Status'
 import { ExternalLink } from 'theme'
@@ -27,6 +27,7 @@ import { SHORT_PRECISION } from 'constants/index'
 import { useDarkModeManager } from 'state/user/hooks'
 import { darken } from 'polished'
 import TwitterImage from 'assets/cow-swap/twitter.svg'
+import OrdersPanel from 'components/ordersPanel'
 
 import { supportedChainId } from 'utils/supportedChainId'
 import { formatSmart } from 'utils/format'
@@ -142,6 +143,7 @@ export default function Header() {
   const userEthBalance = useETHBalances(account ? [account] : [])?.[account ?? '']
   const nativeToken = chainId && (CHAIN_CURRENCY_LABELS[chainId] || 'ETH')
   const [darkMode, toggleDarkMode] = useDarkModeManager()
+  const [ordersPanelOpen, setOrdersPanelOpen] = useState<boolean>(false)
 
   return (
     <HeaderModWrapper>
@@ -155,6 +157,8 @@ export default function Header() {
           <StyledNavLink to="/swap">Swap</StyledNavLink>
           <StyledNavLink to="/about">About</StyledNavLink>
           <StyledNavLink to="/profile">Profile</StyledNavLink>
+
+          <button onClick={() => setOrdersPanelOpen(true)}>Orders panel (test)</button>
         </HeaderLinks>
       </HeaderRow>
       <HeaderControls>
@@ -185,6 +189,7 @@ export default function Header() {
           <Menu />
         </HeaderElementWrap>
       </HeaderControls>
+      <OrdersPanel ordersPanelOpen={ordersPanelOpen} setOrdersPanelOpen={setOrdersPanelOpen} />
     </HeaderModWrapper>
   )
 }

--- a/src/custom/components/ordersPanel/index.tsx
+++ b/src/custom/components/ordersPanel/index.tsx
@@ -1,0 +1,67 @@
+import React, { useRef } from 'react'
+import styled from 'styled-components/macro'
+import { ReactComponent as Close } from 'assets/images/x.svg'
+import { useOnClickOutside } from 'hooks/useOnClickOutside'
+
+const SideBar = styled.div<{ isOpen: boolean }>`
+  display: ${({ isOpen }) => (isOpen ? 'flex' : 'none')};
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 500px;
+  height: 100%;
+  z-index: 99999;
+  padding: 0;
+  background: ${({ theme }) => theme.bg1};
+  box-shadow: 0 0 100vh 100vw rgb(0 0 0 / 25%);
+  cursor: default;
+
+  ${({ theme }) => theme.mediaWidth.upToMedium`    
+    width: 100%;
+    height: 100%;
+  `};
+`
+
+const CloseIcon = styled(Close)`
+  position: absolute;
+  right: 1rem;
+  top: 14px;
+
+  &:hover {
+    cursor: pointer;
+    opacity: 0.6;
+  }
+
+  path {
+    stroke: ${({ theme }) => theme.text4};
+  }
+`
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-flow: column wrap;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  overflow-y: auto;
+`
+
+export interface OrdersPanelProps {
+  ordersPanelOpen: boolean
+  setOrdersPanelOpen: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+export default function OrdersPanel({ ordersPanelOpen, setOrdersPanelOpen }: OrdersPanelProps) {
+  // Close sidebar if clicked/tapped outside
+  const ref = useRef<HTMLDivElement | null>(null)
+  useOnClickOutside(ref, ordersPanelOpen ? () => setOrdersPanelOpen(false) : undefined)
+
+  return (
+    <SideBar ref={ref} isOpen={ordersPanelOpen}>
+      <CloseIcon onClick={() => setOrdersPanelOpen(false)} />
+      <Wrapper>- getModalContent() -</Wrapper>
+    </SideBar>
+  )
+}
+
+// onDismiss={() => setOrdersPanelOpen(false)}


### PR DESCRIPTION
# Summary

This is part 1 of a series of waterfall PR's to gradually implement the orders panel. 
- This PR adds a orders panel component. 

<img width="1270" alt="Screen Shot 2021-08-06 at 16 30 24" src="https://user-images.githubusercontent.com/31534717/128525967-64a580e6-aa71-48a6-8d86-98844cc43c89.png">


# Test 
1. You should be able to toggle its visibility using the `Orders Panel (test)` button in the header. 
2. You should be able to close the orders panel by clicking 'outside' the panel (shadow).
3. You should be able to close it by clicking the X in the corner.