### PR TITLE
WIP - Orders panel part 2 (Open ordersPanel on click connect wallet) 

### DIFF
--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -145,6 +145,7 @@ export default function Header() {
   const [darkMode, toggleDarkMode] = useDarkModeManager()
   const [ordersPanelOpen, setOrdersPanelOpen] = useState<boolean>(false)
   const closeOrdersPanel = () => setOrdersPanelOpen(false)
+  const openOrdersPanel = () => setOrdersPanelOpen(true)
 
   return (
     <HeaderModWrapper>
@@ -175,7 +176,7 @@ export default function Header() {
                 {formatSmart(userEthBalance, SHORT_PRECISION)} {nativeToken}
               </BalanceText>
             ) : null}
-            <Web3Status />
+            <Web3Status openOrdersPanel={openOrdersPanel} />
           </AccountElement>
         </HeaderElement>
         <HeaderElementWrap>

--- a/src/custom/components/Web3Status/Web3StatusMod.tsx
+++ b/src/custom/components/Web3Status/Web3StatusMod.tsx
@@ -168,9 +168,11 @@ function StatusIcon({ connector }: { connector: AbstractConnector }) {
 export function Web3StatusInner({
   pendingCount,
   StatusIconComponent,
+  openOrdersPanel, // mod
 }: {
   pendingCount?: number
   StatusIconComponent: (props: { connector: AbstractConnector }) => JSX.Element | null
+  openOrdersPanel: () => void // mod
 }) {
   const { account, connector, error } = useWeb3React()
 
@@ -194,7 +196,12 @@ export function Web3StatusInner({
 
   if (account) {
     return (
-      <Web3StatusConnected id="web3-status-connected" onClick={toggleWalletModal} pending={hasPendingTransactions}>
+      <Web3StatusConnected
+        id="web3-status-connected"
+        // onClick={toggleWalletModal}
+        onClick={openOrdersPanel} // mod
+        pending={hasPendingTransactions}
+      >
         {hasPendingTransactions ? (
           <RowBetween>
             <Text>

--- a/src/custom/components/Web3Status/index.tsx
+++ b/src/custom/components/Web3Status/index.tsx
@@ -30,7 +30,11 @@ function StatusIcon({ connector }: { connector: AbstractConnector }): JSX.Elemen
   return getStatusIcon(connector, walletInfo)
 }
 
-export default function Web3Status() {
+interface Web3StatusProps {
+  openOrdersPanel: () => void
+}
+
+export default function Web3Status({ openOrdersPanel }: Web3StatusProps) {
   const walletInfo = useWalletInfo()
 
   // Returns all RECENT (last day) transaction and orders in 2 arrays: pending and confirmed
@@ -54,7 +58,11 @@ export default function Web3Status() {
 
   return (
     <Wrapper>
-      <Web3StatusInner pendingCount={pendingActivity.length} StatusIconComponent={StatusIcon} />
+      <Web3StatusInner
+        pendingCount={pendingActivity.length}
+        StatusIconComponent={StatusIcon}
+        openOrdersPanel={openOrdersPanel}
+      />
       <WalletModal ENSName={ensName} pendingTransactions={pendingActivity} confirmedTransactions={confirmedActivity} />
     </Wrapper>
   )


### PR DESCRIPTION
# Summary

This implements functionality to *open* the orders panel, when you click on your connected wallet.

  # To Test

1. Connect a wallet
2. Click on your wallet after being connected.
3. Should open the orders panel.
4. That's it.
