### PR TITLE
Error page improvements.

### DIFF
--- a/src/custom/components/ErrorBoundary/ErrorBoundaryMod.tsx
+++ b/src/custom/components/ErrorBoundary/ErrorBoundaryMod.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components/macro'
 import ReactGA from 'react-ga'
 import { getUserAgent } from 'utils/getUserAgent'
 import { AutoRow } from 'components/Row'
+import Header from 'components/Header'
 
 const FallbackWrapper = styled.div`
   display: flex;
@@ -15,11 +16,27 @@ const FallbackWrapper = styled.div`
   align-items: center;
   z-index: 1;
 `
-
 const BodyWrapper = styled.div<{ margin?: string }>`
-  padding: 1rem;
+  display: flex;
+  flex-direction: column;
   width: 100%;
+  padding-top: 120px;
+  align-items: center;
+  flex: 1;
+  z-index: 1;
   white-space: pre;
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    padding: 16px;
+    padding-top: 6rem;
+  `};
+`
+const HeaderWrapper = styled.div`
+  ${({ theme }) => theme.flexRowNoWrap}
+  width: 100%;
+  justify-content: space-between;
+  position: fixed;
+  top: 0;
+  z-index: 2;
 `
 
 const CodeBlockWrapper = styled.div`
@@ -70,6 +87,9 @@ export default class ErrorBoundary extends React.Component<unknown, ErrorBoundar
       const encodedBody = encodeURIComponent(issueBody(error))
       return (
         <FallbackWrapper>
+          <HeaderWrapper>
+            <Header />
+          </HeaderWrapper>
           <BodyWrapper>
             <AutoColumn gap={'md'}>
               <SomethingWentWrongWrapper>

--- a/src/custom/pages/CowGame/index.tsx
+++ b/src/custom/pages/CowGame/index.tsx
@@ -30,6 +30,11 @@ const Wrapper = styled(Page)`
 `
 
 export default function CowGamePage() {
+  // force an error - REMOVE THIS
+  if (0 === 0) {
+    throw new Error('This cow is dropping some serious milk 🥛!!')
+  }
+
   return (
     <Wrapper>
       <p>


### PR DESCRIPTION
# Summary
**Work in progress**
Closes #1255 

Improvements to the layout and styles of the Error page.

- [x] Add Header component.
- [ ] Solve links issue on Header.
- [ ] Add cow meme
- [ ] Add labels on GH query.
- [ ] Fix links.
- [ ] Mobile fixes.
- [ ] Delete forced error. IMPORTANT


![image](https://user-images.githubusercontent.com/622217/129406253-3b8f356e-b160-4592-b120-3fa5c5af0728.png)

  # To Test
Open the page "Cow Game" to throw an error so we can see the app crashing.


