### PR TITLE
1261/default slippage 1pct

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -3,13 +3,10 @@ import { Token, Fraction, Percent } from '@uniswap/sdk-core'
 import { GPv2Settlement, GPv2VaultRelayer } from '@gnosis.pm/gp-v2-contracts/networks.json'
 import { WalletInfo, SUPPORTED_WALLETS as SUPPORTED_WALLETS_UNISWAP } from 'constants/wallet'
 
-import JSBI from 'jsbi'
 import { SupportedChainId as ChainId } from 'constants/chains'
 import { getAppDataHash } from './appDataHash'
 
-// default allowed slippage, in bips
-export const INITIAL_ALLOWED_SLIPPAGE = 50
-export const INITIAL_ALLOWED_SLIPPAGE_PERCENT = new Percent(JSBI.BigInt(INITIAL_ALLOWED_SLIPPAGE), JSBI.BigInt(10000))
+export const INITIAL_ALLOWED_SLIPPAGE_PERCENT = new Percent('1', '100') // 1%
 export const RADIX_DECIMAL = 10
 export const RADIX_HEX = 16
 

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -23,7 +23,7 @@ import {
 import EthWethWrap, { Props as EthWethWrapProps } from 'components/swap/EthWethWrap'
 import { useReplaceSwapState, useSwapState } from 'state/swap/hooks'
 import { ArrowWrapperLoader, ArrowWrapperLoaderProps, Wrapper as ArrowWrapper } from 'components/ArrowWrapperLoader'
-import { FIAT_PRECISION, LONG_LOAD_THRESHOLD, SHORT_PRECISION } from 'constants/index'
+import { FIAT_PRECISION, INITIAL_ALLOWED_SLIPPAGE_PERCENT, LONG_LOAD_THRESHOLD, SHORT_PRECISION } from 'constants/index'
 import { formatSmart } from 'utils/format'
 import { MouseoverTooltipContent } from 'components/Tooltip'
 import { StyledInfo } from 'pages/Swap/SwapMod'
@@ -34,7 +34,6 @@ import TradeGp from 'state/swap/TradeGp'
 import { useUSDCValue } from 'hooks/useUSDCPrice'
 import { computeTradePriceBreakdown, FEE_TOOLTIP_MSG } from 'components/swap/TradeSummary/TradeSummaryMod'
 import { useExpertModeManager, useUserSlippageToleranceWithDefault } from 'state/user/hooks'
-import { V2_SWAP_DEFAULT_SLIPPAGE } from 'hooks/useSwapSlippageTolerance'
 import { RowReceivedAfterSlippage, RowSlippage } from '@src/custom/components/swap/TradeSummary'
 
 interface TradeBasicDetailsProp extends BoxProps {
@@ -223,7 +222,7 @@ function TradeBasicDetails({ trade, fee, ...boxProps }: TradeBasicDetailsProp) {
   const { realizedFee } = computeTradePriceBreakdown(trade)
   const feeFiatDisplay = `(≈$${formatSmart(feeFiatValue, FIAT_PRECISION)})`
 
-  const allowedSlippage = useUserSlippageToleranceWithDefault(V2_SWAP_DEFAULT_SLIPPAGE)
+  const allowedSlippage = useUserSlippageToleranceWithDefault(INITIAL_ALLOWED_SLIPPAGE_PERCENT)
   const [isExpertMode] = useExpertModeManager()
 
   const displayFee = realizedFee || fee

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -34,7 +34,7 @@ import TradeGp from 'state/swap/TradeGp'
 import { useUSDCValue } from 'hooks/useUSDCPrice'
 import { computeTradePriceBreakdown, FEE_TOOLTIP_MSG } from 'components/swap/TradeSummary/TradeSummaryMod'
 import { useExpertModeManager, useUserSlippageToleranceWithDefault } from 'state/user/hooks'
-import { RowReceivedAfterSlippage, RowSlippage } from '@src/custom/components/swap/TradeSummary'
+import { RowReceivedAfterSlippage, RowSlippage } from 'components/swap/TradeSummary'
 
 interface TradeBasicDetailsProp extends BoxProps {
   trade?: TradeGp

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -10,7 +10,7 @@ import { ParsedQs } from 'qs'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useActiveWeb3React } from 'hooks/web3'
 import { useCurrency } from 'hooks/Tokens'
-import { V2_SWAP_DEFAULT_SLIPPAGE } from 'hooks/useSwapSlippageTolerance'
+// import { V2_SWAP_DEFAULT_SLIPPAGE } from 'hooks/useSwapSlippageTolerance'
 // import { Version } from 'hooks/useToggledVersion'
 // import { useV2TradeExactIn, useV2TradeExactOut } from 'hooks/useV2Trade'
 import useParsedQueryString from 'hooks/useParsedQueryString'
@@ -37,7 +37,7 @@ import { useGetQuoteAndStatus, useQuote } from '../price/hooks'
 import { registerOnWindow } from 'utils/misc'
 import { useTradeExactInWithFee, useTradeExactOutWithFee, stringToCurrency } from './extension'
 import { /* DEFAULT_LIST_OF_LISTS, */ DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
-import { WETH_LOGO_URI, XDAI_LOGO_URI } from 'constants/index'
+import { INITIAL_ALLOWED_SLIPPAGE_PERCENT, WETH_LOGO_URI, XDAI_LOGO_URI } from 'constants/index'
 import TradeGp from './TradeGp'
 
 import { SupportedChainId as ChainId } from 'constants/chains'
@@ -262,8 +262,7 @@ export function useDerivedSwapInfo(): /* {
   const toggledTrade = v2Trade /* (toggledVersion === Version.v2 ? v2Trade : v3Trade.trade) ?? undefined */
   // const allowedSlippage = useSwapSlippageTolerance(toggledTrade)
 
-  // MOD: hook requires a default, use V2 UNI's for now but review
-  const allowedSlippage = useUserSlippageToleranceWithDefault(V2_SWAP_DEFAULT_SLIPPAGE) // 0.5%
+  const allowedSlippage = useUserSlippageToleranceWithDefault(INITIAL_ALLOWED_SLIPPAGE_PERCENT)
 
   // compare input balance to max input based on version
   const [balanceIn, amountIn] = [currencyBalances[Field.INPUT], v2Trade?.maximumAmountIn(allowedSlippage)]

--- a/src/custom/state/swap/trade.test.ts
+++ b/src/custom/state/swap/trade.test.ts
@@ -1,6 +1,5 @@
-import JSBI from 'jsbi'
 import { parseUnits } from '@ethersproject/units'
-import { DEFAULT_PRECISION, INITIAL_ALLOWED_SLIPPAGE, LONG_PRECISION } from 'constants/index'
+import { DEFAULT_PRECISION, LONG_PRECISION } from 'constants/index'
 import { CurrencyAmount, Fraction, Price, Currency, Percent, Token, TradeType } from '@uniswap/sdk-core'
 import { OrderKind } from '@gnosis.pm/gp-v2-contracts'
 import { stringToCurrency } from './extension'
@@ -12,6 +11,8 @@ import TradeGp from './TradeGp'
 
 const WETH_MAINNET = new Token(ChainId.MAINNET, WETH[1].address, 18)
 const DAI_MAINNET = new Token(ChainId.MAINNET, '0x6b175474e89094c44da98b954eedeac495271d0f', 18)
+
+const SLIPPAGE_HALF_PERCENT = new Percent('5', '1000') // => 0.5%
 
 describe('Swap PRICE Quote test', () => {
   // mocked price response for in trade
@@ -79,7 +80,7 @@ describe('Swap PRICE Quote test', () => {
       })
       it('Shows the proper minimumAmountOut', () => {
         // GIVEN --> slippage is set @ 0.5%
-        const slippage = new Percent(JSBI.BigInt(INITIAL_ALLOWED_SLIPPAGE), JSBI.BigInt(10000))
+        const slippage = SLIPPAGE_HALF_PERCENT
         // Min_price => Price_displayed * (1+slippage)
         // Min_price_displayed = 0.000225 * (1.005) = 0.000226125
 
@@ -147,7 +148,7 @@ describe('Swap PRICE Quote test', () => {
       })
       it('Price with 0.5% slippage correct', () => {
         const displayPrice = trade.executionPrice.invert()
-        const userSlippage = new Percent(JSBI.BigInt(INITIAL_ALLOWED_SLIPPAGE), JSBI.BigInt(10000))
+        const userSlippage = SLIPPAGE_HALF_PERCENT
         // 0.995
         const slippage = new Fraction('1').subtract(userSlippage)
 
@@ -164,7 +165,7 @@ describe('Swap PRICE Quote test', () => {
         // THEN
         // 4000000000000000000000 / 3980 + 100000000000000000 = 1,105025125e18
         // 1,105025125e18 * 1e-18 = 1,105025125
-        const userSlippage = new Percent(JSBI.BigInt(INITIAL_ALLOWED_SLIPPAGE), JSBI.BigInt(10000))
+        const userSlippage = SLIPPAGE_HALF_PERCENT
         const expectedMaximumSold = '1.105025125'
         const actualMaximumSold = trade.maximumAmountIn(userSlippage).toSignificant(LONG_PRECISION)
         expect(expectedMaximumSold).toEqual(actualMaximumSold)


### PR DESCRIPTION
# Summary

Closes #1261 

Default slippage set to 1%

![screenshot_2021-08-18_16-18-10](https://user-images.githubusercontent.com/43217/129984132-58844842-eb2b-4039-9b22-ecbdcaef7c46.png)

![screenshot_2021-08-18_16-18-29](https://user-images.githubusercontent.com/43217/129984131-e24c5e4e-2b1e-41ac-9b2a-6b92fca12414.png)

  # To Test

1. Check the settings modal
* Prefilled value should be 1.00
2. Leave slippage on `Auto`
3. Fill in input
4. Click on swap
* Slippage displayed should be 1%

