### PR TITLE
Add datatype for api additional data

### DIFF
--- a/src/custom/components/AccountDetails/Transaction/index.tsx
+++ b/src/custom/components/AccountDetails/Transaction/index.tsx
@@ -131,18 +131,19 @@ function ActivitySummary(params: {
       })
     )
 
-    const executionPrice =
-      order.status === OrderStatus.FULFILLED
-        ? formatSmart(
-            getExecutionPrice({
-              executedBuyAmount: '1234567890', // TODO: when we mutate to FULLFILLED (after getting the order from the API), we need to save the actual executed amounts
-              executedSellAmount: '1000000000',
-              buyTokenDecimals,
-              sellTokenDecimals,
-              inverted: false, // TODO: Handle invert price
-            })
-          )
-        : undefined
+    let executionPrice: string | undefined
+    if (order.apiAdditionalInfo && order.status === OrderStatus.FULFILLED) {
+      const { executedSellAmount, executedBuyAmount } = order.apiAdditionalInfo
+      executionPrice = formatSmart(
+        getExecutionPrice({
+          executedSellAmount,
+          executedBuyAmount,
+          buyTokenDecimals,
+          sellTokenDecimals,
+          inverted: false, // TODO: Handle invert price
+        })
+      )
+    }
 
     orderSummary = {
       ...DEFAULT_ORDER_SUMMARY,

--- a/src/custom/components/AccountDetails/Transaction/index.tsx
+++ b/src/custom/components/AccountDetails/Transaction/index.tsx
@@ -133,10 +133,10 @@ function ActivitySummary(params: {
 
     let executionPrice: string | undefined
     if (order.apiAdditionalInfo && order.status === OrderStatus.FULFILLED) {
-      const { executedSellAmount, executedBuyAmount } = order.apiAdditionalInfo
+      const { executedSellAmountBeforeFees, executedBuyAmount } = order.apiAdditionalInfo
       executionPrice = formatSmart(
         getExecutionPrice({
-          executedSellAmount,
+          executedSellAmountBeforeFees,
           executedBuyAmount,
           buyTokenDecimals,
           sellTokenDecimals,

--- a/src/custom/state/orders/actions.ts
+++ b/src/custom/state/orders/actions.ts
@@ -1,5 +1,5 @@
 import { createAction } from '@reduxjs/toolkit'
-import { OrderID } from 'utils/operator'
+import { OrderID, OrderMetaData } from 'utils/operator'
 import { OrderCreation } from 'utils/signatures'
 import { Token } from '@uniswap/sdk-core'
 import { SupportedChainId as ChainId } from 'constants/chains'
@@ -26,9 +26,24 @@ export interface BaseOrder extends Omit<OrderCreation, 'signingScheme'> {
   isUnfillable?: boolean // whether the order is out of the market, due to price movements since placement
 }
 
+/**
+ * The API provides some additional information
+ */
+type OrderInfoApi = Pick<
+  OrderMetaData,
+  | 'creationDate'
+  | 'availableBalance'
+  | 'executedBuyAmount'
+  | 'executedSellAmount'
+  | 'executedSellAmountBeforeFees'
+  | 'executedFeeAmount'
+  | 'invalidated'
+>
+
 export interface Order extends BaseOrder {
   inputToken: Token // for dapp use only, readable by user
   outputToken: Token // for dapp use only, readable by user
+  apiAdditionalInfo?: OrderInfoApi
 }
 
 export interface SerializedOrder extends BaseOrder {

--- a/src/custom/state/orders/mocks.ts
+++ b/src/custom/state/orders/mocks.ts
@@ -77,6 +77,7 @@ export const generateOrder = ({ owner, sellToken, buyToken }: GenerateOrderParam
     // hacky typing..
     signature: (orderN++).toString().repeat(65 * 2), // 65 bytes encoded as hex without `0x` prefix. v + r + s from the spec
     receiver: owner.replace('0x', ''),
+    apiAdditionalInfo: undefined,
   }
 }
 

--- a/src/custom/state/orders/utils.ts
+++ b/src/custom/state/orders/utils.ts
@@ -102,8 +102,8 @@ export function getLimitPrice({
 }
 
 type GetExecutionPriceParams = Omit<GetLimitPriceParams, 'buyAmount' | 'sellAmount'> & {
+  executedSellAmountBeforeFees?: string
   executedBuyAmount?: string
-  executedSellAmount?: string
 }
 
 // TODO: Use the SDK when ready
@@ -119,20 +119,25 @@ type GetExecutionPriceParams = Omit<GetLimitPriceParams, 'buyAmount' | 'sellAmou
  */
 export function getExecutionPrice({
   executedBuyAmount,
-  executedSellAmount,
+  executedSellAmountBeforeFees,
   buyTokenDecimals,
   sellTokenDecimals,
   inverted,
 }: GetExecutionPriceParams): BigNumber {
   // Only calculate the price when both values are set
   // Having only one value > 0 is anyway an invalid state
-  if (!executedBuyAmount || !executedSellAmount || executedBuyAmount === '0' || executedSellAmount === '0') {
+  if (
+    !executedBuyAmount ||
+    !executedSellAmountBeforeFees ||
+    executedBuyAmount === '0' ||
+    executedSellAmountBeforeFees === '0'
+  ) {
     return ZERO_BIG_NUMBER
   }
 
   const price = calculatePrice({
     numerator: { amount: executedBuyAmount, decimals: buyTokenDecimals },
-    denominator: { amount: executedSellAmount, decimals: sellTokenDecimals },
+    denominator: { amount: executedSellAmountBeforeFees, decimals: sellTokenDecimals },
   })
 
   return inverted ? invertPrice(price) : price

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -120,6 +120,7 @@ export async function sendOrder(params: PostOrderParams): Promise<string> {
       summary,
       inputToken: sellToken,
       outputToken: buyToken,
+      apiAdditionalInfo: undefined,
     },
   })
 


### PR DESCRIPTION
# Summary

Continues #1289, 

Augment the order datatype so we can have the executed volumes. 
Adds the datatype where we can save the API information

It also makes use of this data in the recent history. 

## Not included

Saving the actual data. 