### PR TITLE
Orders panel execution price

### DIFF
--- a/src/custom/components/AccountDetails/Transaction/index.tsx
+++ b/src/custom/components/AccountDetails/Transaction/index.tsx
@@ -110,8 +110,8 @@ function ActivitySummary(params: {
     const sellAmt = CurrencyAmount.fromRawAmount(inputToken, sellAmount.toString())
     const feeAmt = CurrencyAmount.fromRawAmount(inputToken, feeAmount.toString())
     const outputAmount = CurrencyAmount.fromRawAmount(outputToken, buyAmount.toString())
-    const buyTokenDecimals = order?.inputToken?.decimals ?? DEFAULT_PRECISION
     const sellTokenDecimals = order?.inputToken?.decimals ?? DEFAULT_PRECISION
+    const buyTokenDecimals = order?.outputToken?.decimals ?? DEFAULT_PRECISION
 
     const limitPrice = formatSmart(
       getLimitPrice({

--- a/src/custom/state/orders/actions.ts
+++ b/src/custom/state/orders/actions.ts
@@ -24,6 +24,7 @@ export interface BaseOrder extends Omit<OrderCreation, 'signingScheme'> {
   summary: string // for dapp use only, readable by user
   isCancelling?: boolean // intermediate state while the order has been cancelled but order is still pending
   isUnfillable?: boolean // whether the order is out of the market, due to price movements since placement
+  apiAdditionalInfo?: OrderInfoApi
 }
 
 /**
@@ -43,7 +44,6 @@ type OrderInfoApi = Pick<
 export interface Order extends BaseOrder {
   inputToken: Token // for dapp use only, readable by user
   outputToken: Token // for dapp use only, readable by user
-  apiAdditionalInfo?: OrderInfoApi
 }
 
 export interface SerializedOrder extends BaseOrder {

--- a/src/custom/state/orders/actions.ts
+++ b/src/custom/state/orders/actions.ts
@@ -80,6 +80,7 @@ export interface OrderFulfillmentData {
   fulfillmentTime: string
   transactionHash: string
   summary?: string
+  apiAdditionalInfo?: OrderInfoApi
 }
 
 export interface FulfillOrdersBatchParams {

--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -136,7 +136,7 @@ export default createReducer(initialState, (builder) =>
 
       // if there are any newly fulfilled orders
       // update them
-      ordersData.forEach(({ id, fulfillmentTime, transactionHash }) => {
+      ordersData.forEach(({ id, fulfillmentTime, transactionHash, apiAdditionalInfo }) => {
         const orderObject = pendingOrders[id] || cancelledOrders[id]
 
         if (orderObject) {
@@ -148,6 +148,8 @@ export default createReducer(initialState, (builder) =>
 
           orderObject.order.fulfilledTransactionHash = transactionHash
           orderObject.order.isCancelling = false
+
+          orderObject.order.apiAdditionalInfo = apiAdditionalInfo
 
           fulfilledOrders[id] = orderObject
         }

--- a/src/custom/state/orders/updaters/utils.ts
+++ b/src/custom/state/orders/updaters/utils.ts
@@ -63,6 +63,11 @@ export async function fetchOrderPopupData(orderFromStore: Order, chainId: ChainI
         fulfillmentTime: new Date().toISOString(),
         transactionHash: '', // there's no need  for a txHash as we'll link the notification to the Explorer
         summary: _computeFulfilledSummary({ orderFromStore, orderFromApi }),
+        apiAdditionalInfo: orderFromApi
+          ? {
+              ...orderFromApi,
+            }
+          : undefined,
       }
       break
     case 'expired':


### PR DESCRIPTION
# Summary

Adding api metadata to order obj on fulfillment to calculate execution price

![screenshot_2021-08-24_09-41-59](https://user-images.githubusercontent.com/43217/130656011-d81af488-b861-4348-89d7-d78a3bc8f272.png)

  # To Test

1. Place order, wait for it to get matched
* Activity details for given order should display the `execution price` instead of `limit price`

  # Background

This PR only adds the background logic.
Does not touch on any styles.

