### PR TITLE
Fix price format

### DIFF
--- a/src/custom/components/AccountDetails/Transaction/index.tsx
+++ b/src/custom/components/AccountDetails/Transaction/index.tsx
@@ -137,17 +137,19 @@ function ActivitySummary(params: {
       )
     }
 
+    const getPriceFormat = ({ price, kind }: { price: string; kind: string }): string => {
+      return `${price} ${kind === 'buy' ? outputAmount.currency.symbol : sellAmt.currency.symbol} per ${
+        kind === 'buy' ? sellAmt.currency.symbol : outputAmount.currency.symbol
+      }`
+    }
+
     orderSummary = {
       ...DEFAULT_ORDER_SUMMARY,
       from: `${formatSmart(sellAmt.add(feeAmt))} ${sellAmt.currency.symbol}`,
       to: `${formatSmart(outputAmount)} ${outputAmount.currency.symbol}`,
-      limitPrice: `${limitPrice} ${outputAmount.currency.symbol} per ${sellAmt.currency.symbol}`,
+      limitPrice: limitPrice ? getPriceFormat({ price: limitPrice, kind: kind }) : undefined,
       validTo: new Date((validTo as number) * 1000).toLocaleString(),
-      executionPrice: executionPrice
-        ? `${executionPrice} ${kind === 'buy' ? outputAmount.currency.symbol : sellAmt.currency.symbol} per ${
-            kind === 'buy' ? sellAmt.currency.symbol : outputAmount.currency.symbol
-          }`
-        : undefined,
+      executionPrice: executionPrice ? getPriceFormat({ price: executionPrice, kind: kind }) : undefined,
       fulfillmentTime: fulfillmentTime ? new Date(fulfillmentTime).toLocaleString() : undefined,
       kind: kind.toString(),
     }
@@ -156,6 +158,7 @@ function ActivitySummary(params: {
   }
 
   const { kind, from, to, executionPrice, limitPrice, fulfillmentTime, validTo } = orderSummary
+  console.log(orderSummary)
   return (
     <Summary>
       <b>{isOrder ? `${kind} order` : 'Transaction'} ↗</b>


### PR DESCRIPTION
# Summary

- Shows the right price format for a BUY or SELL order.
- Addresses comment https://github.com/gnosis/cowswap/pull/1279#issuecomment-904747268
- Introduces a function called `getPriceFormat` to show the right price format for either a limit or executed price. Will need to be iterated on, once we allow switching inverse prices.

<img width="482" alt="Screen Shot 2021-08-24 at 18 57 27" src="https://user-images.githubusercontent.com/31534717/130658384-80f17067-28e6-4f95-a3a2-9af9fe3c3978.png">

  # To Test

1. Create a buy/sell order.
2. Check the limit price
3. Should be in format INPUT amount > OUTPUT amount token for a SELL order.
4. Should be in format OUTPUT amount > INPUT amount token for a BUY order.