### PR TITLE
999/2 decimals percentage

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
   "license": "GPL-3.0-or-later",
   "dependencies": {
     "@gnosis.pm/cow-runner-game": "^0.2.9",
-    "@gnosis.pm/dex-js": "^0.11.0",
+    "@gnosis.pm/dex-js": "^0.12.0",
     "@gnosis.pm/gp-v2-contracts": "^1.0.2",
     "@sentry/react": "^6.11.0",
     "@sentry/tracing": "^6.11.0",

--- a/src/custom/components/CurrencyInputPanel/FiatValue/FiatValueMod.tsx
+++ b/src/custom/components/CurrencyInputPanel/FiatValue/FiatValueMod.tsx
@@ -42,8 +42,7 @@ export function FiatValue({
       )}
       {priceImpact ? (
         <span style={{ color: priceImpactColor }}>
-          {' '}
-          (<Trans>{formatSmart(priceImpact.multiply(-1), PERCENTAGE_PRECISION)}%</Trans>)
+          &nbsp;(<Trans>{formatSmart(priceImpact.multiply(-1), PERCENTAGE_PRECISION)}%</Trans>)
         </span>
       ) : null}
     </TYPE.body>

--- a/src/custom/components/CurrencyInputPanel/FiatValue/FiatValueMod.tsx
+++ b/src/custom/components/CurrencyInputPanel/FiatValue/FiatValueMod.tsx
@@ -6,7 +6,7 @@ import { warningSeverity } from 'utils/prices'
 import HoverInlineText from 'components/HoverInlineText'
 import { Trans } from '@lingui/macro'
 
-import { FIAT_PRECISION } from 'constants/index' // mod
+import { FIAT_PRECISION, PERCENTAGE_PRECISION } from 'constants/index' // mod
 import { formatSmart } from 'utils/format'
 
 export function FiatValue({
@@ -43,7 +43,7 @@ export function FiatValue({
       {priceImpact ? (
         <span style={{ color: priceImpactColor }}>
           {' '}
-          (<Trans>{priceImpact.multiply(-1).toSignificant(3)}%</Trans>)
+          (<Trans>{formatSmart(priceImpact.multiply(-1), PERCENTAGE_PRECISION)}%</Trans>)
         </span>
       ) : null}
     </TYPE.body>

--- a/src/custom/components/swap/TradeSummary/RowSlippage.tsx
+++ b/src/custom/components/swap/TradeSummary/RowSlippage.tsx
@@ -28,6 +28,7 @@ export function RowSlippage({
 }: RowSlippageProps) {
   const theme = useContext(ThemeContext)
   const toggleSettings = useToggleSettingsMenu()
+  const displaySlippage = `${formatSmart(allowedSlippage, PERCENTAGE_PRECISION)}%`
 
   return (
     <RowBetween height={rowHeight}>
@@ -59,9 +60,9 @@ export function RowSlippage({
       </RowFixed>
       <TYPE.black textAlign="right" fontSize={fontSize} color={theme.text1}>
         {showSettingOnClick ? (
-          <ClickableText onClick={toggleSettings}>{formatSmart(allowedSlippage, PERCENTAGE_PRECISION)}%</ClickableText>
+          <ClickableText onClick={toggleSettings}>{displaySlippage}</ClickableText>
         ) : (
-          <span>{formatSmart(allowedSlippage, PERCENTAGE_PRECISION)}%</span>
+          <span>{displaySlippage}</span>
         )}
       </TYPE.black>
     </RowBetween>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1837,10 +1837,10 @@
   dependencies:
     bn.js "^5.1.3"
 
-"@gnosis.pm/dex-js@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.11.0.tgz#463adaa0297192e3fd39d612896c661e3c05ca58"
-  integrity sha512-k5VPnIV6e5LtOf/wCdxro3kwaM29t9ZByLYAsOAkwpqt7Vpg0H8kWss/68UlQdfncaUcKDLyMVZs5F5mBIuOQA==
+"@gnosis.pm/dex-js@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.12.0.tgz#f46fc2d131aaeec34afecd8d903f31db5673d2cc"
+  integrity sha512-1TaXtxa3e/V3O0t1ChVPvRWqxotl0yY6sbEKJXBu4WHlmxr9Iy5LIz84riyWYPrSWG+iTvjRdtFBkmTfDg7+QA==
   dependencies:
     "@gnosis.pm/dex-contracts" "^0.5.0"
     bignumber.js "^9.0.0"


### PR DESCRIPTION
# Summary

Closes #999 
Closes https://github.com/gnosis/cowswap/issues/1148

2 decimals precision for price impact

![screenshot_2021-08-25_13-35-08](https://user-images.githubusercontent.com/43217/130860763-3c212bf4-04ba-4e69-b137-025a3a245a47.png)


  # To Test

1. Fill in all inputs while on Mainnet or xDai
* Observe price impact is limited to 2 decimals precision
* When percentage < 0.01, it shows `< 0.01`
* It does not display insignificant zeros: 0.90 => 0.9

