### PR TITLE
[presign] Enable smart contracts

### DIFF
--- a/src/custom/components/swap/ConfirmSwapModal/ConfirmSwapModalMod.tsx
+++ b/src/custom/components/swap/ConfirmSwapModal/ConfirmSwapModalMod.tsx
@@ -11,6 +11,7 @@ import SwapModalFooter from 'components/swap/SwapModalFooter'
 import SwapModalHeader from 'components/swap/SwapModalHeader'
 // MOD
 import TradeGp from 'state/swap/TradeGp'
+import { useWalletInfo } from '@src/custom/hooks/useWalletInfo'
 
 /**
  * Returns true if the trade requires a confirmation of details before we can submit it
@@ -64,6 +65,7 @@ export default function ConfirmSwapModal({
   onDismiss: () => void
   PendingTextComponent: (props: { trade: TradeGp | undefined }) => JSX.Element // mod
 }) {
+  const { allowsOffchainSigning } = useWalletInfo()
   const showAcceptChanges = useMemo(
     /* 
     () =>
@@ -84,13 +86,14 @@ export default function ConfirmSwapModal({
     return trade ? (
       <SwapModalHeader
         trade={trade}
+        allowsOffchainSigning={allowsOffchainSigning}
         allowedSlippage={allowedSlippage}
         recipient={recipient}
         showAcceptChanges={showAcceptChanges}
         onAcceptChanges={onAcceptChanges}
       />
     ) : null
-  }, [allowedSlippage, onAcceptChanges, recipient, showAcceptChanges, trade])
+  }, [allowedSlippage, onAcceptChanges, recipient, showAcceptChanges, trade, allowsOffchainSigning])
 
   const modalBottom = useCallback(() => {
     return trade ? (

--- a/src/custom/components/swap/FeeInformationTooltip.tsx
+++ b/src/custom/components/swap/FeeInformationTooltip.tsx
@@ -16,6 +16,7 @@ interface FeeInformationTooltipProps {
   feeAmount?: string
   type: 'From' | 'To'
   showFiat?: boolean
+  allowsOffchainSigning: boolean
 }
 
 const WrappedQuestionHelper = styled(QuestionHelper)`
@@ -73,7 +74,17 @@ const FeeInnerWrapper = styled.div`
 `
 
 export default function FeeInformationTooltip(props: FeeInformationTooltipProps) {
-  const { trade, label, amountBeforeFees, amountAfterFees, feeAmount, type, showHelper, showFiat = false } = props
+  const {
+    trade,
+    label,
+    amountBeforeFees,
+    amountAfterFees,
+    feeAmount,
+    type,
+    showHelper,
+    showFiat = false,
+    allowsOffchainSigning,
+  } = props
 
   const theme = useTheme()
   const fiatValue = useUSDCValue(type === 'From' ? trade?.inputAmount : trade?.outputAmount)
@@ -107,10 +118,12 @@ export default function FeeInformationTooltip(props: FeeInformationTooltipProps)
                   {feeAmount} {symbol}
                 </span>{' '}
               </FeeTooltipLine>
-              <FeeTooltipLine>
-                <span>Gas costs</span>
-                <strong className="green">Free</strong>{' '}
-              </FeeTooltipLine>
+              {allowsOffchainSigning && (
+                <FeeTooltipLine>
+                  <span>Gas costs</span>
+                  <strong className="green">Free</strong>
+                </FeeTooltipLine>
+              )}
               <Breakline />
               <FeeTooltipLine>
                 <strong>{type}</strong>

--- a/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
+++ b/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
@@ -32,6 +32,7 @@ import FeeInformationTooltip from '../FeeInformationTooltip'
 import { LightCardType } from '.'
 import { transparentize } from 'polished'
 import { Price } from 'pages/Swap'
+import { getIncludeFeeLabelSuffix } from 'components/swap/TradeSummary'
 
 export const ArrowWrapper = styled.div`
   padding: 4px;
@@ -60,6 +61,7 @@ export interface SwapModalHeaderProps {
   priceImpactWithoutFee?: Percent
   onAcceptChanges: () => void
   LightCard: LightCardType
+  allowsOffchainSigning: boolean
 }
 
 export default function SwapModalHeader({
@@ -69,6 +71,7 @@ export default function SwapModalHeader({
   showAcceptChanges,
   onAcceptChanges,
   LightCard,
+  allowsOffchainSigning,
 }: /* 
 {
   trade: V2Trade<Currency, Currency, TradeType> | V3Trade<Currency, Currency, TradeType>
@@ -97,13 +100,13 @@ SwapModalHeaderProps) {
     [slippageAdjustedAmounts]
   )
 
-  const [exactInLabel, exactOutLabel] = useMemo(
-    () => [
-      trade?.tradeType === TradeType.EXACT_OUTPUT ? <Trans>From (incl. fee)</Trans> : null,
-      trade?.tradeType === TradeType.EXACT_INPUT ? <Trans>Receive (incl. fee)</Trans> : null,
-    ],
-    [trade]
-  )
+  const [exactInLabel, exactOutLabel] = useMemo(() => {
+    const includeFeeLabelSuffix = getIncludeFeeLabelSuffix(allowsOffchainSigning)
+    return [
+      trade?.tradeType === TradeType.EXACT_OUTPUT ? <Trans>From{includeFeeLabelSuffix}</Trans> : null,
+      trade?.tradeType === TradeType.EXACT_INPUT ? <Trans>Receive{includeFeeLabelSuffix}</Trans> : null,
+    ]
+  }, [trade, allowsOffchainSigning])
 
   const fullInputWithoutFee = trade?.inputAmountWithoutFee?.toFixed(trade?.inputAmount.currency.decimals) || '-'
   const fullOutputWithoutFee = trade?.outputAmountWithoutFee?.toFixed(trade?.outputAmount.currency.decimals) || '-'
@@ -144,6 +147,7 @@ SwapModalHeaderProps) {
             amountAfterFees={formatSmart(trade.inputAmountWithFee)}
             amountBeforeFees={formatSmart(trade.inputAmountWithoutFee)}
             feeAmount={formatSmart(trade.fee.feeAsCurrency)}
+            allowsOffchainSigning={allowsOffchainSigning}
             label={exactInLabel}
             showHelper
             trade={trade}
@@ -196,6 +200,7 @@ SwapModalHeaderProps) {
             amountAfterFees={formatSmart(trade.outputAmount)}
             amountBeforeFees={formatSmart(trade.outputAmountWithoutFee)}
             feeAmount={formatSmart(trade.outputAmountWithoutFee?.subtract(trade.outputAmount))}
+            allowsOffchainSigning={allowsOffchainSigning}
             label={exactOutLabel}
             showHelper
             trade={trade}

--- a/src/custom/components/swap/SwapModalHeader/index.tsx
+++ b/src/custom/components/swap/SwapModalHeader/index.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 import { LightCard as LightCardUni } from 'components/Card'
 import { darken, transparentize } from 'polished'
 import { AuxInformationContainer } from 'components/CurrencyInputPanel'
+import { useWalletInfo } from 'hooks/useWalletInfo'
 
 // MOD
 const LightCard = styled(LightCardUni)<{ flatBorder?: boolean }>`
@@ -42,10 +43,16 @@ const Wrapper = styled.div`
 `
 
 export default function SwapModalHeader(props: Omit<SwapModalHeaderProps, 'LightCard'>) {
+  const { allowsOffchainSigning } = useWalletInfo()
+
   // const { priceImpactWithoutFee } = React.useMemo(() => computeTradePriceBreakdown(props.trade), [props.trade])
   return (
     <Wrapper>
-      <SwapModalHeaderMod {...props} LightCard={LightCard} /*priceImpactWithoutFee={priceImpactWithoutFee}*/ />
+      <SwapModalHeaderMod
+        {...props}
+        allowsOffchainSigning={allowsOffchainSigning}
+        LightCard={LightCard} /*priceImpactWithoutFee={priceImpactWithoutFee}*/
+      />
     </Wrapper>
   )
 }

--- a/src/custom/components/swap/TradeSummary/RowReceivedAfterSlippage.tsx
+++ b/src/custom/components/swap/TradeSummary/RowReceivedAfterSlippage.tsx
@@ -12,6 +12,7 @@ import { computeSlippageAdjustedAmounts } from 'utils/prices'
 import { RowBetween, RowFixed } from 'components/Row'
 import { MouseoverTooltipContent } from 'components/Tooltip'
 import { StyledInfo } from 'pages/Swap/SwapMod'
+import { getIncludeFeeLabelSuffix } from '.'
 
 export interface RowReceivedAfterSlippageProps {
   trade: TradeGp
@@ -46,7 +47,7 @@ export function RowReceivedAfterSlippage({
     : [slippageIn, trade.inputAmount.currency.symbol]
 
   const fullOutAmount = swapAmount?.toFixed(swapAmount?.currency.decimals) || '-'
-  const includeFeeMessage = allowsOffchainSigning ? ' (incl. fee)' : ''
+  const includeFeeMessage = getIncludeFeeLabelSuffix(allowsOffchainSigning)
 
   return (
     <RowBetween height={rowHeight}>

--- a/src/custom/components/swap/TradeSummary/index.tsx
+++ b/src/custom/components/swap/TradeSummary/index.tsx
@@ -11,6 +11,10 @@ import { RowSlippage } from './RowSlippage'
 import { RowReceivedAfterSlippage } from './RowReceivedAfterSlippage'
 import { useWalletInfo } from '@src/custom/hooks/useWalletInfo'
 
+export function getIncludeFeeLabelSuffix(allowsOffchainSigning: boolean) {
+  return allowsOffchainSigning ? ' (incl. fee)' : ''
+}
+
 const Wrapper = styled.div`
   ${RowFixed} {
     > div {

--- a/src/custom/hooks/useWalletInfo.ts
+++ b/src/custom/hooks/useWalletInfo.ts
@@ -34,8 +34,8 @@ async function checkIsSmartContractWallet(
   return code !== '0x'
 }
 
-function checkIsSupportedWallet(name: string | undefined, isSmartContractWallet: boolean): boolean {
-  return !isSmartContractWallet && !UNSUPPORTED_WC_WALLETS.has(name || '')
+function checkIsSupportedWallet(name: string | undefined): boolean {
+  return !UNSUPPORTED_WC_WALLETS.has(name || '')
 }
 
 async function getWcPeerMetadata(connector: WalletConnectConnector): Promise<{ walletName?: string; icon?: string }> {
@@ -96,7 +96,7 @@ export function useWalletInfo(): ConnectedWalletInfo {
     walletName,
     icon,
     ensName: ENSName || undefined,
-    isSupportedWallet: checkIsSupportedWallet(walletName, isSmartContractWallet),
+    isSupportedWallet: checkIsSupportedWallet(walletName),
 
     // TODO: For now, all SC wallets use pre-sign instead of offchain signing
     // In the future, once the API adds EIP-1271 support, we can allow some SC wallets to use offchain signing

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -79,6 +79,7 @@ import TradeGp from 'state/swap/TradeGp'
 import AdvancedSwapDetailsDropdown from 'components/swap/AdvancedSwapDetailsDropdown'
 import { formatSmart } from 'utils/format'
 import { RowSlippage } from '@src/custom/components/swap/TradeSummary/RowSlippage'
+import { getIncludeFeeLabelSuffix } from 'components/swap/TradeSummary'
 
 export const StyledInfo = styled(Info)`
   opacity: 0.4;
@@ -101,6 +102,7 @@ export default function Swap({
   ArrowWrapperLoader,
   Price,
   className,
+  allowsOffchainSigning,
 }: SwapProps) {
   const loadedUrlParams = useDefaultsFromURLSearch()
 
@@ -431,13 +433,13 @@ export default function Swap({
 
   // const priceImpactTooHigh = priceImpactSeverity > 3 && !isExpertMode
 
-  const [exactInLabel, exactOutLabel] = useMemo(
-    () => [
-      independentField === Field.OUTPUT && !showWrap && trade ? <Trans>From (incl. fee)</Trans> : null,
-      independentField === Field.INPUT && !showWrap && trade ? <Trans>Receive (incl. fee)</Trans> : null,
-    ],
-    [independentField, showWrap, trade]
-  )
+  const [exactInLabel, exactOutLabel] = useMemo(() => {
+    const includeFeeLabelSuffix = getIncludeFeeLabelSuffix(allowsOffchainSigning)
+    return [
+      trade?.tradeType === TradeType.EXACT_OUTPUT ? <Trans>From{includeFeeLabelSuffix}</Trans> : null,
+      trade?.tradeType === TradeType.EXACT_INPUT ? <Trans>Receive{includeFeeLabelSuffix}</Trans> : null,
+    ]
+  }, [trade, allowsOffchainSigning])
 
   const swapBlankState = !swapInputError && !trade
   let amountBeforeFees: string | undefined
@@ -490,6 +492,7 @@ export default function Swap({
                       amountAfterFees={formatSmart(trade?.inputAmountWithFee)}
                       type="From"
                       feeAmount={formatSmart(trade?.fee?.feeAsCurrency)}
+                      allowsOffchainSigning={allowsOffchainSigning}
                     />
                   )
                 }
@@ -545,6 +548,7 @@ export default function Swap({
                       amountAfterFees={formatSmart(trade?.outputAmount)}
                       type="To"
                       feeAmount={formatSmart(trade?.outputAmountWithoutFee?.subtract(trade?.outputAmount))}
+                      allowsOffchainSigning={allowsOffchainSigning}
                     />
                   )
                 }

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -148,6 +148,7 @@ export interface SwapProps extends RouteComponentProps {
   ArrowWrapperLoader: React.FC<ArrowWrapperLoaderProps>
   Price: React.FC<PriceProps>
   className?: string
+  allowsOffchainSigning: boolean
 }
 
 const LowerSectionWrapper = styled(RowBetween).attrs((props) => ({
@@ -358,6 +359,7 @@ const SwapButton = ({ children, showLoading, showButton = false }: SwapButtonPro
   )
 
 export default function Swap(props: RouteComponentProps) {
+  const { allowsOffchainSigning } = useWalletInfo()
   return (
     <SwapModWrapper
       TradeBasicDetails={TradeBasicDetails}
@@ -369,6 +371,7 @@ export default function Swap(props: RouteComponentProps) {
       TradeLoading={TradeLoading}
       ArrowWrapperLoader={ArrowWrapperLoader}
       Price={Price}
+      allowsOffchainSigning={allowsOffchainSigning}
       {...props}
     />
   )


### PR DESCRIPTION
# Summary

This PR does 2 things:
* Enables Smart Contract Wallets: So now you should be able to approve tokens (but not swap them, yet...)
* Removes some references to the `gassless nature` of cowswap


## If you connect with an EOA (i.e. Metamask)

You should see all references to gassless nature:


<img width="794" alt="Screenshot at Aug 26 16-18-46" src="https://user-images.githubusercontent.com/2352112/130981571-81f70a42-4c1a-4a37-b830-ef895510774c.png">


<img width="901" alt="Screenshot at Aug 26 16-19-15" src="https://user-images.githubusercontent.com/2352112/130981620-a74cc4d9-bb74-4852-8b31-d5969ca4197e.png">

## If you connect with an Smart contract (i.e. Gnosis Safe)
The references are gone

<img width="773" alt="Screenshot at Aug 26 16-20-08" src="https://user-images.githubusercontent.com/2352112/130981743-1fa7d789-ab40-48fc-829c-5eaf3d809a2b.png">



<img width="1140" alt="Screenshot at Aug 26 16-24-04" src="https://user-images.githubusercontent.com/2352112/130981841-0a5deda6-7664-44f6-b44b-118baa44878f.png">

# not included
* Final messages, or final UX
* Able to trade, u will get

<img width="1215" alt="Screenshot at Aug 26 16-24-27" src="https://user-images.githubusercontent.com/2352112/130981961-20d52788-1518-474e-9548-f98383ac4702.png">


# To Test

1. Try EOA. Verify that is like in production
2. Try Smart Contract. 
* Review if I left any important reference
* Try to approve a token