### PR TITLE
Handle cow sound error

### DIFF
--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -158,7 +158,7 @@ export const popupMiddleware: Middleware<Record<string, unknown>, AppState> = (s
 }
 
 let moooooSend: HTMLAudioElement
-function getMoooooSend(): HTMLAudioElement {
+function getCowSoundSend(): HTMLAudioElement {
   if (!moooooSend) {
     moooooSend = new Audio('/audio/mooooo-send__lower-90.mp3')
   }
@@ -167,7 +167,7 @@ function getMoooooSend(): HTMLAudioElement {
 }
 
 let moooooSuccess: HTMLAudioElement
-function getMoooooSuccess(): HTMLAudioElement {
+function getCowSoundSuccess(): HTMLAudioElement {
   if (!moooooSuccess) {
     moooooSuccess = new Audio('/audio/mooooo-success__ben__lower-90.mp3')
   }
@@ -176,7 +176,7 @@ function getMoooooSuccess(): HTMLAudioElement {
 }
 
 let moooooError: HTMLAudioElement
-function getMoooooError(): HTMLAudioElement {
+function getCowSoundError(): HTMLAudioElement {
   if (!moooooError) {
     moooooError = new Audio('/audio/mooooo-error__lower-90.mp3')
   }
@@ -201,16 +201,19 @@ export const soundMiddleware: Middleware<Record<string, unknown>, AppState> = (s
     if (updatedElements.length === 0) return result
   }
 
+  let cowSound
   if (isPendingOrderAction(action)) {
-    getMoooooSend().play()
+    cowSound = getCowSoundSend()
   } else if (isFulfillOrderAction(action)) {
-    getMoooooSuccess().play()
+    cowSound = getCowSoundSuccess()
   } else if (isExpireOrdersAction(action)) {
-    getMoooooError().play()
+    cowSound = getCowSoundError()
   } else if (isCancelOrderAction(action)) {
     // TODO: find a unique sound for order cancellation
-    getMoooooError().play()
+    cowSound = getCowSoundError()
   }
+
+  cowSound?.play().catch((e) => console.error('🐮 Moooooo sound cannot be played', e))
 
   return result
 }


### PR DESCRIPTION
# Summary

![image](https://user-images.githubusercontent.com/2352112/131104266-a4a442ea-3594-471c-8e73-092c67e2c572.png)


Handles an issue with Safari through Wallet Connect.

The sound was breaking the app, because we were trying to play a sound without the user permission (Wallet Connect is triggering an action, not the user), so Safari is more restrictive than other browsers on this. 

This PR just handle the error. So it logs the error instead of crashing. 

Once handled, doesn't crash any more.
![image](https://user-images.githubusercontent.com/2352112/131104296-8b85c46d-b2e3-452a-b6a0-c9a0ee39be0a.png)


# To Test

1. Use safari
2. Connect with WC using Metamask for example
3. Try to trade
