### PR TITLE
1318/tiny amounts displayed as 0

### DIFF
--- a/src/custom/components/CurrencyInputPanel/CurrencyInputPanelMod.tsx
+++ b/src/custom/components/CurrencyInputPanel/CurrencyInputPanelMod.tsx
@@ -22,7 +22,7 @@ import { FiatValue } from 'components/CurrencyInputPanel/FiatValue'
 // import { formatCurrencyAmount } from 'utils/formatCurrencyAmount'
 
 import { WithClassName } from 'types'
-import { formatSmart } from 'utils/format'
+import { formatMax, formatSmart } from 'utils/format'
 import { AMOUNT_PRECISION } from 'constants/index'
 import { AuxInformationContainer } from '.' // mod
 
@@ -271,7 +271,9 @@ export default function CurrencyInputPanel({
                       fontWeight={400}
                       fontSize={14}
                       style={{ display: 'inline', cursor: 'pointer' }}
-                      title={`${selectedCurrencyBalance?.toFixed(currency?.decimals) || '-'} ${currency?.symbol || ''}`}
+                      title={`${formatMax(selectedCurrencyBalance, currency?.decimals) || '-'} ${
+                        currency?.symbol || ''
+                      }`}
                     >
                       {!hideBalance && currency && selectedCurrencyBalance ? (
                         renderBalance ? (

--- a/src/custom/components/swap/ConfirmSwapModal/index.tsx
+++ b/src/custom/components/swap/ConfirmSwapModal/index.tsx
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/macro'
 
 import ConfirmSwapModalMod from './ConfirmSwapModalMod'
 import TradeGp from 'state/swap/TradeGp'
-import { formatSmart } from 'utils/format'
+import { formatMax, formatSmart } from 'utils/format'
 import { AMOUNT_PRECISION } from 'constants/index'
 
 export * from './ConfirmSwapModalMod'
@@ -18,11 +18,11 @@ function PendingText(props: { trade: TradeGp | undefined }): JSX.Element {
   return (
     <Trans>
       Swapping{' '}
-      <span title={`${inputAmount?.toFixed(inputAmount?.currency.decimals)} ${inputSymbol}`}>
+      <span title={`${formatMax(inputAmount, inputAmount?.currency.decimals)} ${inputSymbol}`}>
         {formatSmart(inputAmount, AMOUNT_PRECISION)} {inputSymbol}
       </span>{' '}
       for{' '}
-      <span title={`${outputAmount?.toFixed(outputAmount?.currency.decimals)} ${outputSymbol}`}>
+      <span title={`${formatMax(outputAmount, outputAmount?.currency.decimals)} ${outputSymbol}`}>
         {formatSmart(outputAmount, AMOUNT_PRECISION)} {outputSymbol}
       </span>
     </Trans>

--- a/src/custom/components/swap/FeeInformationTooltip.tsx
+++ b/src/custom/components/swap/FeeInformationTooltip.tsx
@@ -3,7 +3,7 @@ import TradeGp from 'state/swap/TradeGp'
 import QuestionHelper from 'components/QuestionHelper'
 import styled from 'styled-components'
 import { useUSDCValue } from 'hooks/useUSDCPrice'
-import { formatSmart } from 'utils/format'
+import { formatMax, formatSmart } from 'utils/format'
 import useTheme from 'hooks/useTheme'
 import { FIAT_PRECISION } from 'constants/index'
 
@@ -80,7 +80,7 @@ export default function FeeInformationTooltip(props: FeeInformationTooltipProps)
 
   const [symbol, fullFeeAmount] = useMemo(() => {
     const amount = trade?.[type === 'From' ? 'inputAmount' : 'outputAmount']
-    return amount ? [amount.currency.symbol || '', amount.toFixed(amount.currency.decimals) || '-'] : []
+    return amount ? [amount.currency.symbol || '', formatMax(amount, amount.currency.decimals) || '-'] : []
   }, [trade, type])
 
   if (!trade || !showHelper) return null

--- a/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
+++ b/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
@@ -26,7 +26,7 @@ import TradeGp from 'state/swap/TradeGp'
 import { AMOUNT_PRECISION, INPUT_OUTPUT_EXPLANATION } from 'constants/index'
 import { computeSlippageAdjustedAmounts } from 'utils/prices'
 import { Field } from 'state/swap/actions'
-import { formatSmart } from 'utils/format'
+import { formatMax, formatSmart } from 'utils/format'
 import { AuxInformationContainer } from 'components/CurrencyInputPanel'
 import FeeInformationTooltip from '../FeeInformationTooltip'
 import { LightCardType } from '.'
@@ -69,7 +69,7 @@ export default function SwapModalHeader({
   showAcceptChanges,
   onAcceptChanges,
   LightCard,
-}: /* 
+}: /*
 {
   trade: V2Trade<Currency, Currency, TradeType> | V3Trade<Currency, Currency, TradeType>
   allowedSlippage: Percent
@@ -105,8 +105,8 @@ SwapModalHeaderProps) {
     [trade]
   )
 
-  const fullInputWithoutFee = trade?.inputAmountWithoutFee?.toFixed(trade?.inputAmount.currency.decimals) || '-'
-  const fullOutputWithoutFee = trade?.outputAmountWithoutFee?.toFixed(trade?.outputAmount.currency.decimals) || '-'
+  const fullInputWithoutFee = formatMax(trade?.inputAmountWithoutFee, trade?.inputAmount.currency.decimals) || '-'
+  const fullOutputWithoutFee = formatMax(trade?.outputAmountWithoutFee, trade?.outputAmount.currency.decimals) || '-'
 
   return (
     <AutoColumn gap={'4px'} style={{ marginTop: '1rem' }}>

--- a/src/custom/components/swap/TradePrice/TradePriceMod.tsx
+++ b/src/custom/components/swap/TradePrice/TradePriceMod.tsx
@@ -4,7 +4,6 @@ import { useContext } from 'react'
 import { Text } from 'rebass'
 import styled, { ThemeContext } from 'styled-components'
 import { formatMax, formatSmart } from 'utils/format' // mod
-import { FULL_PRICE_PRECISION } from 'constants/index' // mod
 import { LightGreyText } from 'pages/Swap'
 
 export interface TradePriceProps {

--- a/src/custom/components/swap/TradePrice/TradePriceMod.tsx
+++ b/src/custom/components/swap/TradePrice/TradePriceMod.tsx
@@ -3,7 +3,7 @@ import { Price, Currency } from '@uniswap/sdk-core'
 import { useContext } from 'react'
 import { Text } from 'rebass'
 import styled, { ThemeContext } from 'styled-components'
-import { formatSmart } from 'utils/format' // mod
+import { formatMax, formatSmart } from 'utils/format' // mod
 import { FULL_PRICE_PRECISION } from 'constants/index' // mod
 import { LightGreyText } from 'pages/Swap'
 
@@ -44,9 +44,7 @@ export default function TradePrice({ price, showInverted, fiatValue, setShowInve
     formattedPrice = 'N/A'
   }
 
-  const fullFormattedPrice = showInverted
-    ? price?.toFixed(FULL_PRICE_PRECISION)
-    : price?.invert().toFixed(FULL_PRICE_PRECISION)
+  const fullFormattedPrice = formatMax(showInverted ? price : price?.invert()) || '-'
 
   const label = showInverted ? `${price.quoteCurrency?.symbol}` : `${price.baseCurrency?.symbol} `
   const labelInverted = showInverted ? `${price.baseCurrency?.symbol} ` : `${price.quoteCurrency?.symbol}`
@@ -64,7 +62,7 @@ export default function TradePrice({ price, showInverted, fiatValue, setShowInve
         <Text fontWeight={500} fontSize={14} color={theme.text1}>
           {/* {text} */}
           <LightGreyText>{baseText}</LightGreyText>
-          <span title={`${fullFormattedPrice || '-'} ${label}`}>{quoteText}</span>
+          <span title={`${fullFormattedPrice} ${label}`}>{quoteText}</span>
           {fiatValue && <LightGreyText>{fiatText}</LightGreyText>}
         </Text>
       </div>

--- a/src/custom/components/swap/TradeSummary/RowFee.tsx
+++ b/src/custom/components/swap/TradeSummary/RowFee.tsx
@@ -3,7 +3,7 @@ import { CurrencyAmount, Currency, TradeType } from '@uniswap/sdk-core'
 import { ThemeContext } from 'styled-components'
 import { TYPE } from 'theme'
 
-import { formatSmart } from 'utils/format'
+import { formatMax, formatSmart } from 'utils/format'
 import TradeGp from 'state/swap/TradeGp'
 import { StyledInfo } from 'pages/Swap/SwapMod'
 import { RowBetween, RowFixed } from 'components/Row'
@@ -66,7 +66,7 @@ export function RowFee({
 
   const displayFee = realizedFee || fee
   const feeCurrencySymbol = displayFee?.currency.symbol || '-'
-  const fullDisplayFee = displayFee?.toFixed(displayFee?.currency.decimals) || '-'
+  const fullDisplayFee = formatMax(displayFee, displayFee?.currency.decimals) || '-'
 
   const includeGasMessage = allowsOffchainSigning ? ' (incl. gas costs)' : ''
   const tooltip = allowsOffchainSigning ? GASLESS_FEE_TOOLTIP_MSG : PRESIGN_FEE_TOOLTIP_MSG

--- a/src/custom/components/swap/TradeSummary/RowReceivedAfterSlippage.tsx
+++ b/src/custom/components/swap/TradeSummary/RowReceivedAfterSlippage.tsx
@@ -6,7 +6,7 @@ import { TYPE } from 'theme'
 
 import { Field } from 'state/swap/actions'
 import { getMinimumReceivedTooltip } from 'utils/tooltips'
-import { formatSmart } from 'utils/format'
+import { formatMax, formatSmart } from 'utils/format'
 import TradeGp from 'state/swap/TradeGp'
 import { computeSlippageAdjustedAmounts } from 'utils/prices'
 import { RowBetween, RowFixed } from 'components/Row'
@@ -46,7 +46,7 @@ export function RowReceivedAfterSlippage({
     ? [slippageOut, trade.outputAmount.currency.symbol]
     : [slippageIn, trade.inputAmount.currency.symbol]
 
-  const fullOutAmount = swapAmount?.toFixed(swapAmount?.currency.decimals) || '-'
+  const fullOutAmount = formatMax(swapAmount, swapAmount?.currency.decimals) || '-'
   const includeFeeMessage = allowsOffchainSigning ? ' (incl. fee)' : ''
 
   return (

--- a/src/custom/utils/format.ts
+++ b/src/custom/utils/format.ts
@@ -2,7 +2,13 @@ import BigNumber from 'bignumber.js'
 
 import { formatSmart as _formatSmart } from '@gnosis.pm/dex-js'
 import { Currency, CurrencyAmount, Percent, Fraction } from '@uniswap/sdk-core'
-import { DEFAULT_DECIMALS, DEFAULT_PRECISION, DEFAULT_SMALL_LIMIT, FULL_PRICE_PRECISION } from 'constants/index'
+import {
+  DEFAULT_DECIMALS,
+  DEFAULT_PRECISION,
+  DEFAULT_SMALL_LIMIT,
+  FULL_PRICE_PRECISION,
+  LONG_PRECISION,
+} from 'constants/index'
 
 const TEN = new BigNumber(10)
 
@@ -117,4 +123,34 @@ export function formatSmart(
     smallLimit: _buildSmallLimit(options?.smallLimit, smallLimitPrecision),
     isLocaleAware: !!options?.isLocaleAware,
   })
+}
+
+/**
+ * Formats CurrencyAmount with max precision
+ *
+ * If value has less that `decimals` precision, show the value with 1 significant digit
+ * E.g.:
+ *   Token decimals: `2`; value: `0.0014123`
+ *   => `0.001`
+ *
+ *   Token decimals: `5`; value: `0.0014123`
+ *   => `0.00141`
+ *
+ *   Token decimals: `10`; value: `412310.0014123`
+ *   => `412310.0014123000`
+ *
+ *
+ * @param value
+ * @param decimals
+ */
+export function formatMax(value?: Fraction, decimals?: number): string | undefined {
+  if (!value) {
+    return
+  }
+  let amount = value.toFixed(decimals || LONG_PRECISION)
+
+  if (+amount === 0) {
+    amount = value.toSignificant(1)
+  }
+  return amount
 }

--- a/src/custom/utils/format.ts
+++ b/src/custom/utils/format.ts
@@ -79,8 +79,16 @@ function _adjustCurrencyAmountPrecision(value: CurrencyAmount<Currency>): { amou
   // Adjust the precision and amount to indicate value is >0, even though tiny
   if (+amount === 0) {
     const remainder = value.remainder.toSignificant(1) // get only the first digit of the remainder
-    const decimalPart = remainder.slice(2) // drop `0.` part
-    precision += decimalPart.length // how many more digits do we have? add that to the precision
+    // It can happen that remainder is `1`.
+    // I know, how can the rest of the division be 1 is quotient is 0? o.O
+    // Turns out the answer is rounding.
+    // Requesting toSignificant(1) can return `0` if the value is something like 0.9
+    // For this reason, we only remove `0.` and increase the precision if necessary
+    let decimalPart = remainder
+    if (/^0\./.test(remainder)) {
+      decimalPart = remainder.slice(2) // drop `0.` part
+      precision += decimalPart.length // how many more digits do we have? add that to the precision
+    }
     amount = decimalPart.replace(/^0+/, '') // remove potential leading zeros, precision already accounts for it
   }
   return { amount, precision }

--- a/src/custom/utils/format.ts
+++ b/src/custom/utils/format.ts
@@ -126,7 +126,7 @@ export function formatSmart(
 }
 
 /**
- * Formats CurrencyAmount with max precision
+ * Formats Fraction with max precision
  *
  * If value has less that `decimals` precision, show the value with 1 significant digit
  * E.g.:


### PR DESCRIPTION
# Summary

Closes #1318 

Fixing edge case where tiny amounts are displayed as `0`

![screenshot_2021-08-27_13-48-08](https://user-images.githubusercontent.com/43217/131187575-378787fd-9dbb-435b-b7a7-b17318a46960.png)


# To Test

Follow test steps on #1318 
Issue should not be reproducible

# Background

Edge case with values with amounts < 1 atom.
The decimals were capped at max token precision, so in this case it'll always be shown as 0.

