### PR TITLE
Extrapolate hooks/smart logic into containers to stop mem leaks

### DIFF
--- a/src/custom/components/swap/TradePrice/index.tsx
+++ b/src/custom/components/swap/TradePrice/index.tsx
@@ -1,25 +1,8 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import TradePriceMod, { TradePriceProps } from './TradePriceMod'
-import { useHigherUSDValue /*  useUSDCValue */ } from 'hooks/useUSDCPrice'
-import { formatSmart } from 'utils/format'
-import { tryParseAmount } from 'state/swap/hooks'
-import { FIAT_PRECISION } from 'constants/index'
 
 export * from './TradePriceMod'
 
-export default function TradePrice(props: Omit<TradePriceProps, 'fiatValue'>) {
-  const { price, showInverted } = props
-
-  const priceSide = useMemo(
-    () =>
-      !showInverted
-        ? tryParseAmount(price.invert().toFixed(price.baseCurrency.decimals), price.baseCurrency)
-        : tryParseAmount(price.toFixed(price.quoteCurrency.decimals), price.quoteCurrency),
-    [price, showInverted]
-  )
-  // const amount = useUSDCValue(priceSide)
-  const amount = useHigherUSDValue(priceSide)
-  const fiatValueFormatted = formatSmart(amount, FIAT_PRECISION)
-
-  return <TradePriceMod {...props} fiatValue={fiatValueFormatted} />
+export default function TradePrice(props: TradePriceProps) {
+  return <TradePriceMod {...props} />
 }

--- a/src/custom/hooks/useUSDCPrice/index.ts
+++ b/src/custom/hooks/useUSDCPrice/index.ts
@@ -90,7 +90,7 @@ export default function useUSDCPrice(currency?: Currency) {
 }
 
 interface GetPriceQuoteParams {
-  currencyAmount?: CurrencyAmount<Currency>
+  currencyAmount?: CurrencyAmount<Currency> | null
   error: Error | null
   price: Price<Token, Currency> | null
 }
@@ -112,7 +112,7 @@ function useGetPriceQuote({ price, error, currencyAmount }: GetPriceQuoteParams)
  * Returns the price in USDC of the input currency from price APIs
  * @param currencyAmount currency to compute the USDC price of
  */
-export function useUSDCValue(currencyAmount?: CurrencyAmount<Currency>) {
+export function useUSDCValue(currencyAmount?: CurrencyAmount<Currency> | null) {
   const usdcPrice = useUSDCPrice(currencyAmount?.currency)
 
   return useGetPriceQuote({ ...usdcPrice, currencyAmount })
@@ -176,7 +176,7 @@ export function useCoingeckoUsdPrice({ tokenAddress }: Pick<CoinGeckoUsdPricePar
 }
 
 type CoinGeckoUsdValueParams = Pick<CoinGeckoUsdPriceParams, 'tokenAddress'> & {
-  currencyAmount?: CurrencyAmount<Currency>
+  currencyAmount?: CurrencyAmount<Currency> | null
 }
 
 export function useCoingeckoUSDValue(params: CoinGeckoUsdValueParams) {
@@ -186,7 +186,7 @@ export function useCoingeckoUSDValue(params: CoinGeckoUsdValueParams) {
   return useGetPriceQuote({ ...coingeckoUsdPrice, currencyAmount })
 }
 
-export function useHigherUSDValue(currencyAmount: CurrencyAmount<Currency> | undefined) {
+export function useHigherUSDValue(currencyAmount: CurrencyAmount<Currency> | undefined | null) {
   const usdcValue = useUSDCValue(currencyAmount)
   const coingeckoUsdPrice = useCoingeckoUSDValue({
     tokenAddress: currencyAmount ? currencyId(currencyAmount.currency) : '',

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -230,8 +230,8 @@ export default function Swap({
 
   // const fiatValueInput = useUSDCValue(parsedAmounts[Field.INPUT])
   // const fiatValueOutput = useUSDCValue(parsedAmounts[Field.OUTPUT])
-  const fiatValueInput = useHigherUSDValue(parsedAmounts[Field.INPUT])
-  const fiatValueOutput = useHigherUSDValue(parsedAmounts[Field.OUTPUT])
+  const fiatValueInput = useHigherUSDValue(parsedAmounts[Field.INPUT]) // mod
+  const fiatValueOutput = useHigherUSDValue(parsedAmounts[Field.OUTPUT]) // mod
   const priceImpact = computeFiatValuePriceImpact(fiatValueInput, fiatValueOutput)
 
   const { onSwitchTokens, onCurrencySelection, onUserInput, onChangeRecipient } = useSwapActionHandlers()
@@ -657,9 +657,7 @@ export default function Swap({
                     // gap: 8 // mod
                   }}
                 >
-                  {trade && (
-                    <Price trade={trade} theme={theme} showInverted={showInverted} setShowInverted={setShowInverted} />
-                  )}
+                  <Price trade={trade} theme={theme} showInverted={showInverted} setShowInverted={setShowInverted} />
 
                   {!isExpertMode && !allowedSlippage.equalTo(INITIAL_ALLOWED_SLIPPAGE_PERCENT) && (
                     // <RowBetween height={24} align="center">
@@ -672,7 +670,7 @@ export default function Swap({
                     // </RowBetween>
                     <RowSlippage allowedSlippage={allowedSlippage} fontSize={12} fontWeight={400} rowHeight={24} />
                   )}
-                  {(isFeeGreater || trade) && fee && <TradeBasicDetails trade={trade} fee={fee} />}
+                  <TradeBasicDetails trade={trade} fee={fee} isFeeGreater={isFeeGreater} />
                 </AutoColumn>
                 {/* ETH exactIn && wrapCallback returned us cb */}
                 {isNativeIn && onWrap && (


### PR DESCRIPTION
# Summary

There was smart logic (hooks, async logic etc) causing memory leaks when these components were being unmounted conditionally inside of SwapMod.

Examples: TradeBasicDetails, RowFee, RowSlippage whom all calculated USD estimation inside their funciton body but were being unmounted inside SwapMod. Now the logic is moved to the relevant parent containers and unmounted inside the render method to safely avoid mem leaks.

  # To Test

1. use this pr and try different prices to show fee warning, then quickly switch amounts
- [ ] in this PR there should be NO errors concerning sth like "can't setState on unmounted component blah blah"
2. Compare this with #1356 where you should see the errors in the console
