### PR TITLE
node removeChild hackaround

### DIFF
--- a/src/custom/utils/node.ts
+++ b/src/custom/utils/node.ts
@@ -1,0 +1,26 @@
+/* eslint-disable prefer-rest-params */
+export function nodeRemoveChildFix() {
+  if (typeof Node === 'function' && Node.prototype) {
+    const originalRemoveChild = Node.prototype.removeChild
+    Node.prototype.removeChild = function <T extends Node>(child: T): T {
+      if (child.parentNode !== this) {
+        if (console) {
+          console.error('Cannot remove a child from a different parent', child, this)
+        }
+        return child
+      }
+      return originalRemoveChild.apply(this, arguments as unknown as [child: Node]) as T
+    }
+
+    const originalInsertBefore = Node.prototype.insertBefore
+    Node.prototype.insertBefore = function <T extends Node>(newNode: T, referenceNode: Node | null): T {
+      if (referenceNode && referenceNode.parentNode !== this) {
+        if (console) {
+          console.error('Cannot insert before a reference node from a different parent', referenceNode, this)
+        }
+        return newNode
+      }
+      return originalInsertBefore.apply(this, arguments as unknown as [node: Node, child: Node | null]) as T
+    }
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,6 +26,11 @@ import ThemeProvider, { FixedGlobalStyle, ThemedGlobalStyle } from 'theme'
 import getLibrary from './utils/getLibrary'
 import { analyticsId } from './custom/utils/analytics'
 import AppziButton from 'components/AppziButton'
+import { nodeRemoveChildFix } from 'utils/node'
+
+// Node removeChild hackaround
+// based on: https://github.com/facebook/react/issues/11538#issuecomment-417504600
+nodeRemoveChildFix()
 
 const Web3ProviderNetwork = createWeb3ReactRoot(NetworkContextName)
 


### PR DESCRIPTION
# Summary

Closes #1304 and closes #1298

`removeChild` from node due to google manipulating the DOM via translate extension

There is no longer an error but there is a new one logged to indiciate what is happening. Can easily be removed (the error) and perhaps made into a warning or just a log:
![image](https://user-images.githubusercontent.com/21335563/131684662-fa9d4c38-3b1b-4b33-aab7-93324c0567d9.png)

  # To Test

1. Open this pr build
2. via Google Translate extension set language to kurdish or sth else
3. open token picker, choose token//use the app
4. doesnt crash
5. check error logs for error in screenshot

  # Background

this is a google/extension external mutation messing with our code. 

