### PR TITLE
Fix status labels for transactions vs orders.

### DIFF
--- a/src/custom/components/AccountDetails/Transaction/index.tsx
+++ b/src/custom/components/AccountDetails/Transaction/index.tsx
@@ -382,8 +382,12 @@ export default function Transaction({ hash: id }: { hash: string }) {
 
         <StatusLabelWrapper>
           <StatusLabel color={determinePillColour(status, type)} isPending={isPending} isCancelling={isCancelling}>
-            {isConfirmed ? (
+            {isConfirmed && isTransaction ? (
+              <SVG src={OrderCheckImage} description="Transaction Confirmed" />
+            ) : isConfirmed ? (
               <SVG src={OrderCheckImage} description="Order Filled" />
+            ) : isExpired && isTransaction ? (
+              <SVG src={OrderCancelledImage} description="Transaction Failed" />
             ) : isExpired ? (
               <SVG src={OrderExpiredImage} description="Order Expired" />
             ) : isCancelled ? (
@@ -391,12 +395,15 @@ export default function Transaction({ hash: id }: { hash: string }) {
             ) : isCancelling ? null : (
               <SVG src={OrderOpenImage} description="Order Open" />
             )}
+
             {isPending
               ? 'Open'
               : isConfirmed && isTransaction
               ? 'Approved'
               : isConfirmed
               ? 'Filled'
+              : isExpired && isTransaction
+              ? 'Failed'
               : isExpired
               ? 'Expired'
               : isCancelling
@@ -405,7 +412,6 @@ export default function Transaction({ hash: id }: { hash: string }) {
               ? 'Cancelled'
               : 'Open'}
           </StatusLabel>
-
           {isCancellable && (
             <StatusLabelBelow>
               <LinkStyledButton onClick={onCancelClick}>Cancel order</LinkStyledButton>


### PR DESCRIPTION
# Summary

- To go with release 1.1
- Fixes #1353 

### OLD
<img width="991" alt="Screen Shot 2021-09-01 at 17 50 35" src="https://user-images.githubusercontent.com/31534717/131704942-13ae08fb-49e7-408f-8784-563014db70b5.png">

### NEW
<img width="839" alt="Screen Shot 2021-09-01 at 18 00 55" src="https://user-images.githubusercontent.com/31534717/131704921-67b5a5e9-1533-48d6-a0a8-d10dcd393935.png">
