### PR TITLE
set default api to local host

### DIFF
--- a/src/custom/utils/operator/operatorApi.ts
+++ b/src/custom/utils/operator/operatorApi.ts
@@ -23,19 +23,17 @@ import MetadataError, {
 function getOperatorUrl(): Partial<Record<ChainId, string>> {
   if (isLocal || isDev || isPr || isBarn) {
     return {
-      [ChainId.MAINNET]:
-        process.env.REACT_APP_API_URL_STAGING_MAINNET || 'https://protocol-mainnet.dev.gnosisdev.com/api',
-      [ChainId.RINKEBY]:
-        process.env.REACT_APP_API_URL_STAGING_RINKEBY || 'https://protocol-rinkeby.dev.gnosisdev.com/api',
-      [ChainId.XDAI]: process.env.REACT_APP_API_URL_STAGING_XDAI || 'https://protocol-xdai.dev.gnosisdev.com/api',
+      [ChainId.MAINNET]: process.env.REACT_APP_API_URL_STAGING_MAINNET || 'http://localhost:8080/api',
+      [ChainId.RINKEBY]: process.env.REACT_APP_API_URL_STAGING_RINKEBY || 'http://localhost:8080/api',
+      [ChainId.XDAI]: process.env.REACT_APP_API_URL_STAGING_XDAI || 'http://localhost:8080/api',
     }
   }
 
   // Production, staging, ens, ...
   return {
-    [ChainId.MAINNET]: process.env.REACT_APP_API_URL_PROD_MAINNET || 'https://protocol-mainnet.gnosis.io/api',
-    [ChainId.RINKEBY]: process.env.REACT_APP_API_URL_PROD_RINKEBY || 'https://protocol-rinkeby.gnosis.io/api',
-    [ChainId.XDAI]: process.env.REACT_APP_API_URL_PROD_XDAI || 'https://protocol-xdai.gnosis.io/api',
+    [ChainId.MAINNET]: process.env.REACT_APP_API_URL_PROD_MAINNET || 'http://localhost:8080/api',
+    [ChainId.RINKEBY]: process.env.REACT_APP_API_URL_PROD_RINKEBY || 'http://localhost:8080/api',
+    [ChainId.XDAI]: process.env.REACT_APP_API_URL_PROD_XDAI || 'http://localhost:8080/api',
   }
 }
 


### PR DESCRIPTION
Not sure if this will be accepted, but when testing against local instances, it has been quite cumbersome to manually enter these default values directly in the code. Wouldn't it be more appropriate to default to localhost and have people configure production/staging values to their own environment?

There may be other places where we could default to localhost but these are the one I am currently aware of.