### PR TITLE
Changing node version on CI scripts from 12 to lts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: lts/*
 
       - name: Set output of cache
         id: yarn-cache
@@ -65,7 +65,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: lts/*
 
       - name: Load dependencies
         id: cache-node-modules
@@ -96,7 +96,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: lts/*
 
       - name: Load dependencies
         id: cache-node-modules
@@ -188,7 +188,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v2
         with:
-          node-version: lts
+          node-version: lts/*
 
       # - name: Download website
       #   uses: actions/download-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,11 @@ name: CI
 on:
   # build on PR creation/updates, also when pushing to master/develop, or create a release
   pull_request:
-    types: [opened, synchronize] 
+    types: [opened, synchronize]
   push:
     branches: [master, develop]
     tags: [v*]
-    
+
 
 env:
   REPO_NAME_SLUG: gpswapui
@@ -134,7 +134,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
-      
+
       - name: 'Deploy to S3: PRaul'
         if: env.PR_NUMBER
         run: aws s3 sync website s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/${{ env.REPO_NAME_SLUG }}/pr${{ env.PR_NUMBER }} --delete
@@ -188,7 +188,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: lts
 
       # - name: Download website
       #   uses: actions/download-artifact@v2

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v2
         with:
-          node-version: lts
+          node-version: lts/*
 
       - name: Set output of cache
         id: yarn-cache

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -11,7 +11,7 @@ jobs:
   ipfs:
     name: IPFS
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -19,7 +19,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: lts
 
       - name: Set output of cache
         id: yarn-cache


### PR DESCRIPTION
# Summary

Changing node version on CI scripts from 12 to lts

New dependencies require node > 14 (https://github.com/gnosis/cowswap/pull/1393/checks?check_run_id=3509393198)
CI is currently configured to 12.

This PR updates the base node version to LTS https://nodejs.org/en/download/
As of now that is 
![screenshot_2021-09-03_13-22-47](https://user-images.githubusercontent.com/43217/132061620-0c290783-acca-4d59-b6e7-aafb2ee80457.png)


  # To Test

1. Make sure build completes
2. App works as before