### PR TITLE
1334/activity-orders-from-api

### DIFF
--- a/src/components/AccountDetails/index.tsx
+++ b/src/components/AccountDetails/index.tsx
@@ -135,7 +135,6 @@ const AddressLink = styled(ExternalLink)<{ hasENS: boolean; isENS: boolean }>`
   font-size: 0.825rem;
   color: ${({ theme }) => theme.text3};
   margin-left: 1rem;
-  font-size: 0.825rem;
   display: flex;
   :hover {
     color: ${({ theme }) => theme.text2};

--- a/src/custom/api/gnosisProtocol/api.ts
+++ b/src/custom/api/gnosisProtocol/api.ts
@@ -1,6 +1,6 @@
 import { SupportedChainId as ChainId } from 'constants/chains'
 import { OrderKind } from '@gnosis.pm/gp-v2-contracts'
-import { stringify } from 'qs'
+import qs from 'qs'
 import { getSigningSchemeApiValue, OrderCreation, OrderCancellation } from 'utils/signatures'
 import { APP_DATA_HASH } from 'constants/index'
 import { registerOnWindow } from '../../utils/misc'
@@ -311,7 +311,7 @@ export async function getProfileData(chainId: ChainId, address: string): Promise
 export async function getOrders(chainId: ChainId, owner: string, limit = 1000, offset = 0): Promise<OrderMetaData[]> {
   console.log(`[api:${API_NAME}] Get orders for `, chainId, owner, limit, offset)
 
-  const queryString = stringify({ limit, offset }, { addQueryPrefix: true })
+  const queryString = qs.stringify({ limit, offset }, { addQueryPrefix: true })
 
   try {
     const response = await _get(chainId, `/account/${owner}/orders/${queryString}`)

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -198,7 +198,7 @@ export default function AccountDetails({
               {chainId && account && (
                 <AddressLink
                   hasENS={!!ENSName}
-                  isENS={ENSName ? true : false}
+                  isENS={!!ENSName}
                   href={getEtherscanLink(chainId, ENSName ? ENSName : account, 'address')}
                 >
                   <LinkIcon size={16} />

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -223,6 +223,7 @@ export default function AccountDetails({
           <div>
             {renderTransactions(pendingTransactions)}
             {renderTransactions(confirmedTransactions)}
+            {explorerOrdersLink && <ExternalLink href={explorerOrdersLink}>View all orders</ExternalLink>}
           </div>
         </LowerSection>
       ) : (

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -1,9 +1,6 @@
-import React, { useCallback } from 'react'
-import { batch, useDispatch } from 'react-redux'
+import React from 'react'
 
 import { useActiveWeb3React } from 'hooks/web3'
-import { AppDispatch } from 'state'
-import { clearAllTransactions } from 'state/transactions/actions'
 import { getExplorerLabel, shortenAddress } from 'utils'
 
 import Copy from 'components/Copy'
@@ -18,8 +15,6 @@ import FortmaticIcon from 'assets/images/fortmaticIcon.png'
 import PortisIcon from 'assets/images/portisIcon.png'
 import Identicon from 'components/Identicon'
 import { ExternalLink as LinkIcon } from 'react-feather'
-import { LinkStyledButton } from 'theme'
-import { clearOrders } from 'state/orders/actions'
 import { NETWORK_LABELS } from 'components/Header'
 import {
   WalletName,
@@ -44,6 +39,8 @@ import {
 import { ConnectedWalletInfo, useWalletInfo } from 'hooks/useWalletInfo'
 import { MouseoverTooltip } from 'components/Tooltip'
 import { supportedChainId } from 'utils/supportedChainId'
+import { ExternalLink } from 'theme'
+import { getExplorerAddressLink } from 'utils/explorer'
 
 type AbstractConnector = Pick<ReturnType<typeof useActiveWeb3React>, 'connector'>['connector']
 
@@ -148,17 +145,8 @@ export default function AccountDetails({
   const { account, connector, chainId: connectedChainId } = useActiveWeb3React()
   const chainId = supportedChainId(connectedChainId)
   const walletInfo = useWalletInfo()
-  // const theme = useContext(ThemeContext)
-  const dispatch = useDispatch<AppDispatch>()
 
-  const clearAllActivityCallback = useCallback(() => {
-    if (chainId) {
-      batch(() => {
-        dispatch(clearAllTransactions({ chainId }))
-        dispatch(clearOrders({ chainId }))
-      })
-    }
-  }, [dispatch, chainId])
+  const explorerOrdersLink = account && connectedChainId && getExplorerAddressLink(connectedChainId, account)
   const explorerLabel = chainId && account ? getExplorerLabel(chainId, account, 'address') : undefined
   const activityTotalCount = (pendingTransactions?.length || 0) + (confirmedTransactions?.length || 0)
 
@@ -229,7 +217,7 @@ export default function AccountDetails({
             <h5>
               Recent Activity <span>{`(${activityTotalCount})`}</span>
             </h5>
-            <LinkStyledButton onClick={clearAllActivityCallback}>Clear activity</LinkStyledButton>
+            {explorerOrdersLink && <ExternalLink href={explorerOrdersLink}>View all orders</ExternalLink>}
           </span>
 
           <div>

--- a/src/custom/components/AccountDetails/styled.ts
+++ b/src/custom/components/AccountDetails/styled.ts
@@ -172,7 +172,12 @@ export const LowerSection = styled.div`
     flex-flow: column wrap;
     width: 100%;
     background-color: ${({ theme }) => theme.bg2};
-    padding: 0 0 100px;
+    padding: 0;
+
+    ${StyledLink} {
+      align-self: center;
+      margin: 20px 0;
+    }
   }
 
   h5 {

--- a/src/custom/components/AccountDetails/styled.ts
+++ b/src/custom/components/AccountDetails/styled.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 import { CopyIcon, TransactionStatusText } from 'components/Copy'
-import { LinkStyledButton } from 'theme'
+import { LinkStyledButton, StyledLink } from 'theme'
 import { NetworkCard as NetworkCardUni } from 'components/Header/HeaderMod'
 import {
   WalletName,
@@ -188,7 +188,8 @@ export const LowerSection = styled.div`
     }
   }
 
-  ${LinkStyledButton} {
+  ${LinkStyledButton},${StyledLink} {
     text-decoration: underline;
+    font-size: 14px;
   }
 `

--- a/src/custom/components/AccountDetails/styled.ts
+++ b/src/custom/components/AccountDetails/styled.ts
@@ -170,7 +170,6 @@ export const LowerSection = styled.div`
   > div {
     display: flex;
     flex-flow: column wrap;
-    padding: 0;
     width: 100%;
     background-color: ${({ theme }) => theme.bg2};
     padding: 0 0 100px;

--- a/src/custom/components/SearchModal/ImportRow/ImportRowMod.tsx
+++ b/src/custom/components/SearchModal/ImportRow/ImportRowMod.tsx
@@ -35,7 +35,6 @@ const NameOverflow = styled.div`
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
-  text-overflow: ellipsis;
   max-width: 140px;
   font-size: 12px;
 `

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -105,3 +105,4 @@ export const FEE_SIZE_THRESHOLD = new Fraction(10, 100) // 30%
 export const SOLVER_ADDRESS = '0xa6ddbd0de6b310819b49f680f65871bee85f517e'
 
 export const MAXIMUM_ORDERS_TO_DISPLAY = 10
+export const AMOUNT_OF_ORDERS_TO_FETCH = 100

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -103,3 +103,5 @@ export const FEE_SIZE_THRESHOLD = new Fraction(10, 100) // 30%
 
 // default value provided as userAddress to Paraswap API if the user wallet is not connected
 export const SOLVER_ADDRESS = '0xa6ddbd0de6b310819b49f680f65871bee85f517e'
+
+export const MAXIMUM_ORDERS_TO_DISPLAY = 10

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -39,7 +39,6 @@ export const SUPPORTED_WALLETS = Object.keys(SUPPORTED_WALLETS_UNISWAP).reduce((
 // Smart contract wallets are filtered out by default, no need to add them to this list
 export const UNSUPPORTED_WC_WALLETS = new Set(['DeFi Wallet', '1inch Wallet', 'Pillar Wallet', 'WallETH'])
 
-// TODO: When contracts are deployed, we can load this from the NPM package
 export const GP_SETTLEMENT_CONTRACT_ADDRESS: Partial<Record<number, string>> = {
   [ChainId.MAINNET]: GPv2Settlement[ChainId.MAINNET].address,
   [ChainId.RINKEBY]: GPv2Settlement[ChainId.RINKEBY].address,

--- a/src/custom/hooks/useContract.ts
+++ b/src/custom/hooks/useContract.ts
@@ -1,4 +1,5 @@
 import { Contract } from '@ethersproject/contracts'
+import { Web3Provider } from '@ethersproject/providers'
 import { useActiveWeb3React } from 'hooks/web3'
 
 import { useContract } from '@src/hooks/useContract'
@@ -7,6 +8,10 @@ import { GP_SETTLEMENT_CONTRACT_ADDRESS } from 'constants/index'
 import { GP_V2_SETTLEMENT_INTERFACE } from 'constants/GPv2Settlement'
 import { SupportedChainId as ChainId } from 'constants/chains'
 import ENS_ABI from 'abis/ens-registrar.json'
+import { getContract } from 'utils'
+import { Erc20 } from 'abis/types'
+import ERC20_ABI from 'abis/erc20.json'
+import ERC20_BYTES32_ABI from 'abis/erc20_bytes32.json'
 
 export * from '@src/hooks/useContract'
 
@@ -32,4 +37,54 @@ export function useENSRegistrarContract(withSignerIfPossible?: boolean): Contrac
     }
   }
   return useContract(address, ENS_ABI, withSignerIfPossible)
+}
+
+/**
+ * Non-hook version of useContract
+ */
+function _getContract<T extends Contract = Contract>(
+  addressOrAddressMap: string | { [chainId: number]: string } | undefined,
+  ABI: any,
+  withSignerIfPossible = true,
+  library?: Web3Provider,
+  account?: string,
+  chainId?: ChainId
+): T | null {
+  if (!addressOrAddressMap || !ABI || !library || !chainId) return null
+  let address: string | undefined
+  if (typeof addressOrAddressMap === 'string') address = addressOrAddressMap
+  else address = addressOrAddressMap[chainId]
+  if (!address) return null
+  try {
+    return getContract(address, ABI, library, withSignerIfPossible && account ? account : undefined) as T
+  } catch (error) {
+    console.error('Failed to get contract', error)
+    return null
+  }
+}
+
+/**
+ * Non-hook version of useTokenContract
+ */
+export function getTokenContract(
+  tokenAddress?: string,
+  withSignerIfPossible?: boolean,
+  library?: Web3Provider,
+  account?: string,
+  chainId?: ChainId
+): Erc20 | null {
+  return _getContract<Erc20>(tokenAddress, ERC20_ABI, withSignerIfPossible, library, account, chainId)
+}
+
+/**
+ * Non-hook version of useBytes32TokenContract
+ */
+export function getBytes32TokenContract(
+  tokenAddress?: string,
+  withSignerIfPossible?: boolean,
+  library?: Web3Provider,
+  account?: string,
+  chainId?: ChainId
+): Contract | null {
+  return _getContract(tokenAddress, ERC20_BYTES32_ABI, withSignerIfPossible, library, account, chainId)
 }

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -5,6 +5,7 @@ import { useActiveWeb3React } from 'hooks/web3'
 import { Order, OrderStatus } from 'state/orders/actions'
 import { TransactionDetails } from 'state/transactions/reducer'
 import { SupportedChainId as ChainId } from 'constants/chains'
+import { MAXIMUM_ORDERS_TO_DISPLAY } from 'constants/index'
 
 export type TransactionAndOrder =
   | (Order & { addedTime: number })
@@ -58,8 +59,8 @@ export default function useRecentActivity() {
         )
         // sort orders by calculated `addedTime` descending
         .sort((a, b) => b.addedTime - a.addedTime)
-        // show at most 10 regular orders, and as much pending as there are
-        .filter((order, index) => index < 10 || order.status === OrderStatus.PENDING)
+        // show at most MAXIMUM_ORDERS_TO_DISPLAY regular orders, and as much pending as there are
+        .filter((order, index) => index < MAXIMUM_ORDERS_TO_DISPLAY || order.status === OrderStatus.PENDING)
     )
   }, [account, allNonEmptyOrders, chainId])
 

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -31,12 +31,6 @@ enum TxReceiptStatus {
   CONFIRMED,
 }
 
-function sortByDate(a: Order, b: Order): number {
-  const dateA = new Date(a.creationTime)
-  const dateB = new Date(b.creationTime)
-
-  return dateA > dateB ? -1 : dateA < dateB ? 1 : 0
-}
 /**
  * useRecentActivity
  * @description returns all RECENT (last day) transaction and orders in 2 arrays: pending and confirmed
@@ -62,7 +56,7 @@ export default function useRecentActivity() {
             addedTime: Date.parse(order.creationTime),
           })
         )
-        .sort(sortByDate)
+        .sort((a, b) => b.addedTime - a.addedTime)
         // show at most 10 regular orders, and as much pending as there are
         .filter((order, index) => index < 10 || order.status === OrderStatus.PENDING)
     )

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -54,48 +54,44 @@ export default function useRecentActivity() {
       allNonEmptyOrders
         // only show orders for connected account
         .filter((order) => order.owner.toLowerCase() === account.toLowerCase())
-        .map((order) => {
+        .map((order) =>
           // we need to essentially match TransactionDetails type which uses "addedTime" for date checking
           // and time in MS vs ISO string as Orders uses
-          return {
+          ({
             ...order,
             addedTime: Date.parse(order.creationTime),
-          }
-        })
+          })
+        )
         .sort(sortByDate)
         // show at most 10 regular orders, and as much pending as there are
         .filter((order, index) => index < 10 || order.status === OrderStatus.PENDING)
     )
   }, [account, allNonEmptyOrders, chainId])
 
-  const recentTransactionsAdjusted = useMemo<TransactionAndOrder[]>(() => {
-    // Filter out any pending/fulfilled transactions OLDER than 1 day
-    // and adjust order object to match Order id + status format
-    // which is used later in app to render list of activity
-    const adjustedTransactions = Object.values(allTransactions)
-      .filter(isTransactionRecent)
-      .filter((tx) => tx.from === account)
-      .map((tx) => {
-        return {
+  const recentTransactionsAdjusted = useMemo<TransactionAndOrder[]>(
+    () =>
+      // Filter out any pending/fulfilled transactions OLDER than 1 day
+      // and adjust order object to match Order id + status format
+      // which is used later in app to render list of activity
+      Object.values(allTransactions)
+        .filter(isTransactionRecent)
+        .filter((tx) => tx.from === account)
+        .map((tx) => ({
           ...tx,
           // we need to adjust Transaction object and add "id" + "status" to match Orders type
           id: tx.hash,
           status: tx.receipt ? OrderStatus.FULFILLED : OrderStatus.PENDING,
-        }
-      })
+        })),
+    [account, allTransactions]
+  )
 
-    return adjustedTransactions
-  }, [allTransactions])
-
-  return useMemo(() => {
-    // Concat together the TransactionDetails[] and Orders[]
-    // then sort them by newest first
-    const sortedActivities = recentTransactionsAdjusted.concat(recentOrdersAdjusted).sort((a, b) => {
-      return b.addedTime - a.addedTime
-    })
-
-    return sortedActivities
-  }, [recentOrdersAdjusted, recentTransactionsAdjusted])
+  return useMemo(
+    () =>
+      // Concat together the TransactionDetails[] and Orders[]
+      // then sort them by newest first
+      recentTransactionsAdjusted.concat(recentOrdersAdjusted).sort((a, b) => b.addedTime - a.addedTime),
+    [recentOrdersAdjusted, recentTransactionsAdjusted]
+  )
 }
 
 interface ActivityDescriptors {

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -56,6 +56,7 @@ export default function useRecentActivity() {
             addedTime: Date.parse(order.creationTime),
           })
         )
+        // sort orders by calculated `addedTime` descending
         .sort((a, b) => b.addedTime - a.addedTime)
         // show at most 10 regular orders, and as much pending as there are
         .filter((order, index) => index < 10 || order.status === OrderStatus.PENDING)

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -31,41 +31,42 @@ enum TxReceiptStatus {
   CONFIRMED,
 }
 
-// One FULL day in MS (milliseconds not Microsoft)
-const DAY_MS = 86_400_000
+function sortByDate(a: Order, b: Order): number {
+  const dateA = new Date(a.creationTime)
+  const dateB = new Date(b.creationTime)
 
-/**
- * Returns whether a order happened in the last day (86400 seconds * 1000 milliseconds / second)
- * @param order
- */
-function isOrderRecent(order: Order): boolean {
-  return Date.now() - Date.parse(order.creationTime) < DAY_MS
+  return dateA > dateB ? -1 : dateA < dateB ? 1 : 0
 }
-
 /**
  * useRecentActivity
  * @description returns all RECENT (last day) transaction and orders in 2 arrays: pending and confirmed
  */
 export default function useRecentActivity() {
-  const { chainId } = useActiveWeb3React()
+  const { chainId, account } = useActiveWeb3React()
   const allTransactions = useAllTransactions()
   const allNonEmptyOrders = useOrders({ chainId })
 
   const recentOrdersAdjusted = useMemo<TransactionAndOrder[]>(() => {
-    // Filter out any pending/fulfilled orders OLDER than 1 day
-    // and adjust order object to match TransactionDetail addedTime format
-    // which is used later in app to render list of activity
-    const adjustedOrders = allNonEmptyOrders.filter(isOrderRecent).map((order) => {
-      // we need to essentially match TransactionDetails type which uses "addedTime" for date checking
-      // and time in MS vs ISO string as Orders uses
-      return {
-        ...order,
-        addedTime: Date.parse(order.creationTime),
-      }
-    })
-
-    return adjustedOrders
-  }, [allNonEmptyOrders])
+    if (!chainId || !account) {
+      return []
+    }
+    return (
+      allNonEmptyOrders
+        // only show orders for connected account
+        .filter((order) => order.owner.toLowerCase() === account.toLowerCase())
+        .map((order) => {
+          // we need to essentially match TransactionDetails type which uses "addedTime" for date checking
+          // and time in MS vs ISO string as Orders uses
+          return {
+            ...order,
+            addedTime: Date.parse(order.creationTime),
+          }
+        })
+        .sort(sortByDate)
+        // show at most 10 regular orders, and as much pending as there are
+        .filter((order, index) => index < 10 || order.status === OrderStatus.PENDING)
+    )
+  }, [account, allNonEmptyOrders, chainId])
 
   const recentTransactionsAdjusted = useMemo<TransactionAndOrder[]>(() => {
     // Filter out any pending/fulfilled transactions OLDER than 1 day

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -74,6 +74,7 @@ export default function useRecentActivity() {
     // which is used later in app to render list of activity
     const adjustedTransactions = Object.values(allTransactions)
       .filter(isTransactionRecent)
+      .filter((tx) => tx.from === account)
       .map((tx) => {
         return {
           ...tx,

--- a/src/custom/hooks/useTokensLazy.ts
+++ b/src/custom/hooks/useTokensLazy.ts
@@ -1,0 +1,113 @@
+import { useCallback } from 'react'
+
+import { Token } from '@uniswap/sdk-core'
+import { Contract } from '@ethersproject/contracts'
+
+import { useActiveWeb3React } from '@src/hooks/web3'
+import { getBytes32TokenContract, getTokenContract, useMulticall2Contract } from 'hooks/useContract'
+import { CallParams, getMultipleCallsResults } from 'state/multicall/utils'
+import { parseStringOrBytes32 } from '@src/hooks/Tokens'
+import { useAddUserToken } from '@src/state/user/hooks'
+import { Erc20 } from 'abis/types'
+
+const contractsCache: Record<string, Erc20> = {}
+const bytes32ContractsCache: Record<string, Contract> = {}
+
+/**
+ * Hook that exposes a function for lazy (non-hook) fetching tokens info async
+ *
+ * Similar to useToken, except it fetches multiple tokens at once, and does it after component hook phase
+ *
+ * All the logic is heavily adapted from /src/hooks/Tokens.ts > useToken
+ */
+export function useTokensLazy() {
+  const { library, account, chainId } = useActiveWeb3React()
+  const multicall2Contract = useMulticall2Contract()
+  const addUserToken = useAddUserToken()
+
+  return useCallback(
+    async (addresses: string[], withSignerIfPossible?: boolean): Promise<Record<string, Token | null> | null> => {
+      if (!library || !account || !chainId || !multicall2Contract) {
+        console.warn(`useTokensLazy::not initialized`)
+        return null
+      }
+
+      // For every token that we need fetch 5 properties:
+      // - name, symbol, decimals, name (bytes32), symbol (bytes32)
+      // For that we are using the multicall contract, combining multiple calls into a single one
+      // In this reduce, we group all of them together and unwind them later
+      const callsParams = addresses.reduce<CallParams[]>((acc, address) => {
+        // Fetch the (regular) token contract, from cache if any
+        contractsCache[address] =
+          contractsCache[address] || getTokenContract(address, withSignerIfPossible, library, account, chainId)
+        // Fetch the (bytes32) token contract, from cache if any
+        bytes32ContractsCache[address] =
+          bytes32ContractsCache[address] ||
+          getBytes32TokenContract(address, withSignerIfPossible, library, account, chainId)
+
+        // For every address, create 5 queries, one for each property
+        // Each query is an object of type `CallParams`, which is the format expected by Multicall
+
+        // Merge them into a single array to be used by the multicall contract
+        return acc.concat([
+          {
+            contract: contractsCache[address],
+            methodName: 'name',
+          },
+          {
+            contract: contractsCache[address],
+            methodName: 'symbol',
+          },
+          {
+            contract: contractsCache[address],
+            methodName: 'decimals',
+          },
+          {
+            contract: bytes32ContractsCache[address],
+            methodName: 'name',
+          },
+          {
+            contract: bytes32ContractsCache[address],
+            methodName: 'symbol',
+          },
+        ])
+      }, [])
+
+      // Single multicall to all tokens
+      const results = await getMultipleCallsResults({
+        callsParams,
+        multicall2Contract,
+      })
+
+      // Map addresses list into map where the address is the key and the value is the Token obj or null
+      // In this step we unwind the multicall results that are all grouped together
+      // We rely on the original order, unpacking results per token based on token addresses rather than call results
+      return addresses.reduce<Record<string, Token | null>>((acc, address, index) => {
+        // Each token sent 5 queries, so we navigate the results 5 by 5
+        // Unpack the array with properties in the order which they were queried
+        const [tokenName, symbol, decimals, tokenNameBytes32, symbolBytes32] = results.slice(index * 5, (index + 1) * 5)
+
+        // Make no assumptions regarding decimals (same as base code on `useToken`)
+        if (!decimals) {
+          console.warn(`useTokensLazy::no decimals for token ${address}`)
+          acc[address] = null
+        } else {
+          const token = new Token(
+            chainId,
+            address,
+            decimals[0],
+            parseStringOrBytes32(symbol?.[0], symbolBytes32?.[0], 'UNKNOWN'),
+            parseStringOrBytes32(tokenName?.[0], tokenNameBytes32?.[0], 'Unknown Token')
+          )
+          // Adding new token to the list of User tokens
+          addUserToken(token)
+
+          acc[address] = token
+        }
+
+        return acc
+      }, {})
+    },
+    [account, addUserToken, chainId, library, multicall2Contract]
+  )
+}

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -16,8 +16,8 @@ import AddressInputPanel from 'components/AddressInputPanel'
 import {
   ButtonConfirmed,
   /* ButtonError,
-  ButtonGray, 
-  ButtonLight, 
+  ButtonGray,
+  ButtonLight,
   ButtonPrimary */
 } from 'components/Button'
 import Card, { GreyCard } from 'components/Card'
@@ -506,8 +506,6 @@ export default function Swap({
     }
   }
 
-  console.log('{isNativeIn && onWrap', { isNativeIn, onWrap })
-
   return (
     <>
       <TokenWarningModal
@@ -572,7 +570,7 @@ export default function Swap({
                 id="swap-currency-input"
               />
               {/* UNI ARROW SWITCHER */}
-              {/* 
+              {/*
               <ArrowWrapper clickable>
                 <ArrowDown
                   size="16"

--- a/src/custom/state/multicall/utils.ts
+++ b/src/custom/state/multicall/utils.ts
@@ -1,0 +1,226 @@
+import { Contract } from '@ethersproject/contracts'
+
+import { Call, ListenerOptions } from 'state/multicall/actions'
+import { CallResult, isValidMethodArgs, OptionalMethodInputs, Result, toCallState } from 'state/multicall/hooks'
+import { Multicall2 } from 'abis/types'
+import { fetchChunk } from 'state/multicall/updater'
+
+export type CallParams = {
+  contract: Contract | null | undefined
+  methodName: string
+  inputs?: OptionalMethodInputs
+  gasRequired?: number
+}
+
+export type GetSingleCallParams = CallParams & {
+  multicall2Contract: Multicall2
+  options?: ListenerOptions
+  latestBlockNumber?: number
+}
+
+export type GetMultipleCallsParams = Omit<GetSingleCallParams, 'contract' | 'methodName' | 'inputs' | 'gasRequired'> & {
+  callsParams: CallParams[]
+}
+
+type CreateCallParams = CallParams
+type ExecuteCallsParams = Pick<GetSingleCallParams, 'options' | 'multicall2Contract' | 'latestBlockNumber'> & {
+  calls: (Call | null)[]
+}
+
+type ExecuteCallsResponse = {
+  results: { success: boolean; returnData: string }[]
+  blockNumber: number
+}
+
+function createCall({ contract, methodName, inputs, gasRequired }: CreateCallParams): Call | null {
+  const fragment = contract?.interface?.getFunction(methodName)
+
+  if (!contract || !fragment || !isValidMethodArgs(inputs)) {
+    console.warn(`createCall::no contract or fragment or not valid`, !contract, !fragment, !isValidMethodArgs(inputs))
+    return null
+  }
+
+  return {
+    address: contract.address,
+    callData: contract.interface.encodeFunctionData(fragment, inputs),
+    ...(gasRequired ? { gasRequired } : {}),
+  }
+}
+
+async function executeCalls({
+  calls,
+  multicall2Contract,
+  latestBlockNumber,
+}: ExecuteCallsParams): Promise<ExecuteCallsResponse | null> {
+  if (!multicall2Contract || calls.length === 0) {
+    console.warn(`executeCalls::no multicall or no calls`, !multicall2Contract, calls.length)
+    return null
+  }
+
+  // Keep track of position of non-null Calls
+  const validCallsOriginalIds: Record<number, number> = {}
+  // Also create a list only with valid calls
+  const validCalls: Call[] = []
+
+  calls.forEach((call, index) => {
+    if (call) {
+      validCallsOriginalIds[index] = validCalls.length
+      validCalls.push(call)
+    }
+  })
+
+  if (validCalls.length === 0) {
+    console.warn(`executeCalls:no valid calls to execute`)
+    return null
+  }
+
+  try {
+    const { results, blockNumber } = await fetchChunk(multicall2Contract, validCalls, latestBlockNumber || 1)
+    // Return results in same order as received
+    const fixedResults = calls.map((call, index) =>
+      !call ? { success: false, returnData: '' } : results[validCallsOriginalIds[index]]
+    )
+
+    return { results: fixedResults, blockNumber }
+  } catch (e) {
+    console.error(`Failed to execute calls`, calls, e)
+    return null
+  }
+}
+
+/**
+ * Non-hook version of useSingleCallResult
+ *
+ * Based on /src/state/multicall/hooks.ts > useSingleCallResult
+ *
+ * All types and intermediate steps are based on the original hooks
+ * This was kept as close as possible to original.
+ * Probably not all steps/types make sense for our use-case but changing them
+ * might require changing the base multicall implementation.
+ */
+export async function getSingleCallResult(params: GetSingleCallParams) {
+  const { contract, methodName } = params
+  const fragment = contract?.interface?.getFunction(methodName)
+
+  const call = createCall(params)
+
+  if (!call) {
+    console.warn(`getSingleCallResult::no call`)
+    return null
+  }
+
+  const callResults = await executeCalls({ calls: [call], ...params })
+
+  if (!callResults) {
+    console.warn(`getSingleCallResult::no call results`)
+    return null
+  }
+
+  const {
+    results: [{ success, returnData }],
+    blockNumber,
+  } = callResults
+
+  if (!success || returnData === '0x') {
+    console.warn(`getSingleCallResult::no success of return data`, success, returnData)
+    return null
+  }
+
+  // TODO: we might move away from this type, only here for now
+  const callResult: CallResult = { valid: true, data: returnData, blockNumber }
+
+  console.warn(`getSingleCallResult::callResult`, callResult)
+
+  const callState = toCallState(callResult, contract?.interface, fragment, blockNumber)
+
+  if (!callState) {
+    console.warn(`getSingleCallResult::no callState`)
+    return null
+  }
+
+  console.warn(`getSingleCallResult::callState`, callState)
+
+  const { valid, error, result } = callState
+
+  if (!valid || error) {
+    console.warn(`getSingleCallResult::not valid or error`, valid, error)
+    return null
+  }
+
+  return result
+}
+
+type ExtractResultsParams = Omit<ExecuteCallsResponse, 'results'> & {
+  results: (ExecuteCallsResponse['results'][0] & CallParams)[]
+}
+
+function extractResults(params: ExtractResultsParams) {
+  const { results, blockNumber } = params
+
+  return results.map((_result) => {
+    const { success, returnData, contract, methodName } = _result
+    const fragment = contract?.interface?.getFunction(methodName)
+
+    if (!success || returnData === '0x' || !contract || !fragment) {
+      console.warn(`extractResults::invalid params`, !success, returnData === '0x', !contract, !fragment)
+      return null
+    }
+
+    const callResult: CallResult = { valid: true, data: returnData, blockNumber }
+    // Re-using original `toCallState`
+    const callState = toCallState(callResult, contract.interface, fragment, blockNumber)
+
+    if (!callState) {
+      console.warn(`extractResults::no callState`)
+      return null
+    }
+
+    const { valid, error, result } = callState
+
+    if (!valid || error) {
+      console.warn(`extractResults::not valid callState or error`, valid, error)
+      return null
+    }
+
+    return result
+  })
+}
+
+/**
+ * Version of `getSingleCallResult` that handles multiple calls at once
+ *
+ * Based on /src/state/multicall/hooks.ts > useSingleCallResult
+ *
+ * All types and intermediate steps are based on the original hooks
+ * This was kept as close as possible to original.
+ * Probably not all steps/types make sense for our use-case but changing them
+ * might require changing the base multicall implementation.
+ *
+ * One thing to keep in mind is that multicalls are stored on redux and executed via an updater
+ * This function makes the execution "immediate" instead. Well, kind of. It still is async, but
+ * the results can be awaited.
+ * The original implementation can be summarized in 3 parts:
+ * 1. A hook to prepare the Call objects and add them to the redux
+ * 2. The updater that gets Call objects, executes them and add the results to redux
+ * 3. A hook to get the results from redux
+ *
+ * Here there's just one part, doing all at once.
+ */
+export async function getMultipleCallsResults(params: GetMultipleCallsParams): Promise<(Result | null | undefined)[]> {
+  const { callsParams, multicall2Contract, latestBlockNumber } = params
+
+  const calls = callsParams.map((callParams) => createCall(callParams))
+
+  const callsResults = await executeCalls({ calls, multicall2Contract, latestBlockNumber })
+
+  if (!callsResults) {
+    console.warn(`getMultipleCallsResults::no callsResults`)
+    // TODO: this looks dumb. Maybe throw instead?
+    return Array(callsParams.length).fill(null)
+  }
+
+  // Assumes nothing went wrong and callsResults are still aligned with callsParams
+  const results = callsResults.results.map((results, index) => ({ ...results, ...callsParams[index] }))
+
+  return extractResults({ ...callsResults, results })
+}

--- a/src/custom/state/orders/actions.ts
+++ b/src/custom/state/orders/actions.ts
@@ -83,6 +83,11 @@ export interface OrderFulfillmentData {
   apiAdditionalInfo?: OrderInfoApi
 }
 
+export interface AddOrUpdateOrdersBatchParams {
+  chainId: ChainId
+  orders: SerializedOrder[]
+}
+
 export interface FulfillOrdersBatchParams {
   ordersData: OrderFulfillmentData[]
   chainId: ChainId
@@ -94,6 +99,8 @@ export interface BatchOrdersUpdateParams {
 }
 export type ExpireOrdersBatchParams = BatchOrdersUpdateParams
 export type CancelOrdersBatchParams = BatchOrdersUpdateParams
+
+export const addOrUpdateOrdersBatch = createAction<AddOrUpdateOrdersBatchParams>('order/addOrUpdateOrdersBatch')
 
 export const fulfillOrdersBatch = createAction<FulfillOrdersBatchParams>('order/fullfillOrdersBatch')
 

--- a/src/custom/state/orders/actions.ts
+++ b/src/custom/state/orders/actions.ts
@@ -83,7 +83,7 @@ export interface OrderFulfillmentData {
   apiAdditionalInfo?: OrderInfoApi
 }
 
-export interface AddOrUpdateOrdersBatchParams {
+export interface AddOrUpdateOrdersParams {
   chainId: ChainId
   orders: SerializedOrder[]
 }
@@ -100,7 +100,7 @@ export interface BatchOrdersUpdateParams {
 export type ExpireOrdersBatchParams = BatchOrdersUpdateParams
 export type CancelOrdersBatchParams = BatchOrdersUpdateParams
 
-export const addOrUpdateOrdersBatch = createAction<AddOrUpdateOrdersBatchParams>('order/addOrUpdateOrdersBatch')
+export const addOrUpdateOrders = createAction<AddOrUpdateOrdersParams>('order/addOrUpdateOrders')
 
 export const fulfillOrdersBatch = createAction<FulfillOrdersBatchParams>('order/fullfillOrdersBatch')
 

--- a/src/custom/state/orders/hooks.ts
+++ b/src/custom/state/orders/hooks.ts
@@ -20,8 +20,8 @@ import {
   Order,
   setIsOrderUnfillable,
   SetIsOrderUnfillableParams,
-  AddOrUpdateOrdersBatchParams,
-  addOrUpdateOrdersBatch,
+  AddOrUpdateOrdersParams,
+  addOrUpdateOrders,
 } from './actions'
 import { OrderObject, OrdersState, PartialOrdersMap, V2OrderObject } from './reducer'
 import { isTruthy } from 'utils/misc'
@@ -29,7 +29,7 @@ import { OrderID } from 'api/gnosisProtocol'
 import { ContractDeploymentBlocks } from './consts'
 import { deserializeToken, serializeToken } from '@src/state/user/hooks'
 
-export interface AddOrUpdateUnserialisedOrdersBatchParams extends Omit<AddOrUpdateOrdersBatchParams, 'orders'> {
+export interface AddOrUpdateUnserialisedOrdersParams extends Omit<AddOrUpdateOrdersParams, 'orders'> {
   orders: Order[]
 }
 
@@ -67,7 +67,7 @@ interface UpdateLastCheckedBlockParams extends ClearOrdersParams {
   lastCheckedBlock: number
 }
 
-type AddOrUpdateOrdersCallback = (params: AddOrUpdateUnserialisedOrdersBatchParams) => void
+type AddOrUpdateOrdersCallback = (params: AddOrUpdateUnserialisedOrdersParams) => void
 type AddOrderCallback = (addOrderParams: AddUnserialisedPendingOrderParams) => void
 type RemoveOrderCallback = (removeOrderParams: GetRemoveOrderParams) => void
 type FulfillOrderCallback = (fulfillOrderParams: FulfillOrderParams) => void
@@ -236,16 +236,16 @@ export const useCancelledOrders = ({ chainId }: GetOrdersParams): Order[] => {
   }, [state])
 }
 
-export const useAddOrUpdateOrdersBatch = (): AddOrUpdateOrdersCallback => {
+export const useAddOrUpdateOrders = (): AddOrUpdateOrdersCallback => {
   const dispatch = useDispatch<AppDispatch>()
   return useCallback(
-    (params: AddOrUpdateUnserialisedOrdersBatchParams) => {
+    (params: AddOrUpdateUnserialisedOrdersParams) => {
       const orders = params.orders.map((order) => ({
         ...order,
         inputToken: serializeToken(order.inputToken),
         outputToken: serializeToken(order.outputToken),
       }))
-      dispatch(addOrUpdateOrdersBatch({ ...params, orders }))
+      dispatch(addOrUpdateOrders({ ...params, orders }))
     },
     [dispatch]
   )

--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -2,21 +2,21 @@ import { createReducer, PayloadAction } from '@reduxjs/toolkit'
 import { OrderID } from 'api/gnosisProtocol'
 import { SupportedChainId as ChainId } from 'constants/chains'
 import {
+  addOrUpdateOrdersBatch,
   addPendingOrder,
-  removeOrder,
-  clearOrders,
-  fulfillOrder,
-  OrderStatus,
-  updateLastCheckedBlock,
-  expireOrder,
-  fulfillOrdersBatch,
-  expireOrdersBatch,
   cancelOrder,
   cancelOrdersBatch,
+  clearOrders,
+  expireOrder,
+  expireOrdersBatch,
+  fulfillOrder,
+  fulfillOrdersBatch,
+  OrderStatus,
+  removeOrder,
   requestOrderCancellation,
   SerializedOrder,
   setIsOrderUnfillable,
-  addOrUpdateOrdersBatch,
+  updateLastCheckedBlock,
 } from './actions'
 import { ContractDeploymentBlocks } from './consts'
 import { Writable } from 'types'
@@ -91,6 +91,14 @@ function prefillState(
   }
 }
 
+function popOrder(state: OrdersState, chainId: ChainId, status: OrderStatus, id: string): OrderObject | undefined {
+  const orderObj = state?.[chainId]?.[status]?.[id]
+  if (orderObj) {
+    delete state?.[chainId]?.[status]?.[id]
+  }
+  return orderObj
+}
+
 const initialState: OrdersState = {}
 
 export default createReducer(initialState, (builder) =>
@@ -112,33 +120,24 @@ export default createReducer(initialState, (builder) =>
     .addCase(addOrUpdateOrdersBatch, (state, action) => {
       prefillState(state, action)
       const { chainId, orders } = action.payload
-      const pending = state[chainId].pending
-      const fulfilled = state[chainId].fulfilled
-      const expired = state[chainId].expired
-      const cancelled = state[chainId].cancelled
 
       orders.forEach((newOrder) => {
-        const { id } = newOrder
+        const { id, status } = newOrder
 
-        // does the order exist already in the state?
-        // if so, get it, and remove from state
-        let orderObj
-        if (pending[id]) {
-          orderObj = pending[id]
-          delete pending[id]
-        } else if (fulfilled[id]) {
-          orderObj = fulfilled[id]
-          delete fulfilled[id]
-        } else if (expired[id]) {
-          orderObj = expired[id]
-          delete expired[id]
-        } else if (cancelled[id]) {
-          orderObj = cancelled[id]
-          delete cancelled[id]
+        // sanity check, is the status set?
+        if (!status) {
+          console.error(`addOrUpdateOrdersBatch:: Status not set for order ${id}`)
+          return
         }
 
-        const status = newOrder.status
+        // fetch order from state, if any
+        const orderObj =
+          popOrder(state, chainId, OrderStatus.FULFILLED, id) ||
+          popOrder(state, chainId, OrderStatus.EXPIRED, id) ||
+          popOrder(state, chainId, OrderStatus.CANCELLED, id) ||
+          popOrder(state, chainId, OrderStatus.PENDING, id)
 
+        // merge existing and new order objects
         const order = orderObj
           ? {
               ...orderObj.order,
@@ -148,25 +147,8 @@ export default createReducer(initialState, (builder) =>
             }
           : newOrder
 
-        // what's the status now?
         // add order to respective state
-        switch (status) {
-          case 'pending':
-            pending[id] = { order, id }
-            break
-          case 'cancelled':
-            cancelled[id] = { order, id }
-            break
-          case 'expired':
-            expired[id] = { order, id }
-            break
-          case 'fulfilled':
-            fulfilled[id] = { order, id }
-            break
-          default:
-            // TODO: add it regardless?
-            console.warn(`Unknown state '${state}' for order`, id, newOrder)
-        }
+        state[chainId][status][id] = { order, id }
       })
     })
     .addCase(fulfillOrder, (state, action) => {

--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -16,6 +16,7 @@ import {
   requestOrderCancellation,
   SerializedOrder,
   setIsOrderUnfillable,
+  addOrUpdateOrdersBatch,
 } from './actions'
 import { ContractDeploymentBlocks } from './consts'
 import { Writable } from 'types'
@@ -107,6 +108,59 @@ export default createReducer(initialState, (builder) =>
       delete state[chainId].fulfilled[id]
       delete state[chainId].expired[id]
       delete state[chainId].cancelled[id]
+    })
+    .addCase(addOrUpdateOrdersBatch, (state, action) => {
+      prefillState(state, action)
+      const { chainId, orders } = action.payload
+      const pending = state[chainId].pending
+      const fulfilled = state[chainId].fulfilled
+      const expired = state[chainId].expired
+      const cancelled = state[chainId].cancelled
+
+      orders.forEach((newOrder) => {
+        const { id } = newOrder
+
+        // does the order exist already in the state?
+        // if so, get it, and remove from state
+        let orderObj
+        if (pending[id]) {
+          orderObj = pending[id]
+          delete pending[id]
+        } else if (fulfilled[id]) {
+          orderObj = fulfilled[id]
+          delete fulfilled[id]
+        } else if (expired[id]) {
+          orderObj = expired[id]
+          delete expired[id]
+        } else if (cancelled[id]) {
+          orderObj = cancelled[id]
+          delete cancelled[id]
+        }
+
+        const status = newOrder.status
+
+        const order = orderObj ? { ...orderObj.order, apiAdditionalInfo: newOrder.apiAdditionalInfo, status } : newOrder
+
+        // what's the status now?
+        // add order to respective state
+        switch (status) {
+          case 'pending':
+            pending[id] = { order, id }
+            break
+          case 'cancelled':
+            cancelled[id] = { order, id }
+            break
+          case 'expired':
+            expired[id] = { order, id }
+            break
+          case 'fulfilled':
+            fulfilled[id] = { order, id }
+            break
+          default:
+            // TODO: add it regardless?
+            console.warn(`Unknown state '${state}' for order`, id, newOrder)
+        }
+      })
     })
     .addCase(fulfillOrder, (state, action) => {
       prefillState(state, action)

--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -2,7 +2,7 @@ import { createReducer, PayloadAction } from '@reduxjs/toolkit'
 import { OrderID } from 'api/gnosisProtocol'
 import { SupportedChainId as ChainId } from 'constants/chains'
 import {
-  addOrUpdateOrdersBatch,
+  addOrUpdateOrders,
   addPendingOrder,
   cancelOrder,
   cancelOrdersBatch,
@@ -117,7 +117,7 @@ export default createReducer(initialState, (builder) =>
       delete state[chainId].expired[id]
       delete state[chainId].cancelled[id]
     })
-    .addCase(addOrUpdateOrdersBatch, (state, action) => {
+    .addCase(addOrUpdateOrders, (state, action) => {
       prefillState(state, action)
       const { chainId, orders } = action.payload
 
@@ -126,7 +126,7 @@ export default createReducer(initialState, (builder) =>
 
         // sanity check, is the status set?
         if (!status) {
-          console.error(`addOrUpdateOrdersBatch:: Status not set for order ${id}`)
+          console.error(`addOrUpdateOrders:: Status not set for order ${id}`)
           return
         }
 

--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -139,7 +139,14 @@ export default createReducer(initialState, (builder) =>
 
         const status = newOrder.status
 
-        const order = orderObj ? { ...orderObj.order, apiAdditionalInfo: newOrder.apiAdditionalInfo, status } : newOrder
+        const order = orderObj
+          ? {
+              ...orderObj.order,
+              apiAdditionalInfo: newOrder.apiAdditionalInfo,
+              isCancelling: newOrder.isCancelling,
+              status,
+            }
+          : newOrder
 
         // what's the status now?
         // add order to respective state

--- a/src/custom/state/orders/updaters/APIOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/APIOrdersUpdater.ts
@@ -11,6 +11,7 @@ import { Order, OrderStatus } from 'state/orders/actions'
 import { NATIVE_CURRENCY_BUY_ADDRESS, NATIVE_CURRENCY_BUY_TOKEN } from 'constants/index'
 import { ChainId } from 'state/lists/actions'
 import { ApiOrderStatus, classifyOrder } from 'state/orders/utils'
+import { computeOrderSummary } from 'state/orders/updaters/utils'
 
 function getToken(address: string, chainId: ChainId, tokens: { [p: string]: Token }): Token | undefined {
   if (address.toLowerCase() === NATIVE_CURRENCY_BUY_ADDRESS.toLowerCase()) {
@@ -54,17 +55,22 @@ function transformApiOrderToStoreOrder(
   }
 
   if (inputToken && outputToken) {
-    return {
+    const storeOrder: Order = {
       ...order,
       inputToken,
       outputToken,
       id,
       creationTime,
-      summary: 'TODO: loaded from API',
+      summary: '',
       status,
       receiver,
       apiAdditionalInfo: order,
     }
+    // The function to compute the summary needs the Order instance to exist already
+    // That's why it's not used before and an empty string is set instead
+    storeOrder.summary = computeOrderSummary({ orderFromStore: storeOrder, orderFromApi: order }) || ''
+
+    return storeOrder
   } else {
     console.warn(
       `APIOrdersUpdater::Tokens not found for order ${id}: sellToken ${!inputToken ? sellToken : 'found'} - buyToken ${

--- a/src/custom/state/orders/updaters/APIOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/APIOrdersUpdater.ts
@@ -1,0 +1,95 @@
+import { useEffect } from 'react'
+
+import { getAddress } from '@ethersproject/address'
+import { Token } from '@uniswap/sdk-core'
+
+import { useActiveWeb3React } from 'hooks/web3'
+import { useAddOrUpdateOrdersBatch } from 'state/orders/hooks'
+import { getOrders } from 'api/gnosisProtocol/api'
+import { useAllTokens } from 'hooks/Tokens'
+import { Order, OrderStatus } from 'state/orders/actions'
+import { NATIVE_CURRENCY_BUY_ADDRESS, NATIVE_CURRENCY_BUY_TOKEN } from 'constants/index'
+import { ChainId } from 'state/lists/actions'
+import { ApiOrderStatus, classifyOrder } from 'state/orders/utils'
+
+function getToken(address: string, chainId: ChainId, tokens: { [p: string]: Token }): Token | undefined {
+  if (address.toLowerCase() === NATIVE_CURRENCY_BUY_ADDRESS.toLowerCase()) {
+    return NATIVE_CURRENCY_BUY_TOKEN[chainId]
+  }
+  return tokens[getAddress(address)]
+}
+
+function classifyLocalStatus(status: ApiOrderStatus): OrderStatus | undefined {
+  switch (status) {
+    case 'cancelled':
+      return OrderStatus.CANCELLED
+    case 'expired':
+      return OrderStatus.EXPIRED
+    case 'pending':
+      return OrderStatus.PENDING
+    case 'fulfilled':
+      return OrderStatus.FULFILLED
+    default:
+      return undefined
+  }
+}
+
+export function APIOrdersUpdater(): null {
+  const { account, chainId } = useActiveWeb3React()
+  const allTokens = useAllTokens()
+  const addOrUpdateOrdersBatch = useAddOrUpdateOrdersBatch()
+
+  useEffect(() => {
+    if (account && chainId && Object.keys(allTokens).length > 0) {
+      getOrders(chainId, account, 100)
+        .then((_orders) => {
+          console.log(`APIOrdersUpdater::Fetched ${_orders.length} orders for account ${account} on chain ${chainId}`)
+
+          // Transform API orders into internal order objects
+          const orders = _orders.reduce<Order[]>((acc, order) => {
+            const { uid: id, sellToken, buyToken, creationDate: creationTime, receiver } = order
+
+            // TODO: load tokens from network when not found on local state
+            const inputToken = getToken(sellToken, chainId, allTokens)
+            const outputToken = getToken(buyToken, chainId, allTokens)
+
+            const apiStatus = classifyOrder(order)
+            const status = classifyLocalStatus(apiStatus)
+            if (!status) {
+              console.warn(`APIOrdersUpdater::Order ${id} in unknown internal state: ${apiStatus}`)
+              return acc
+            }
+
+            if (inputToken && outputToken) {
+              acc.push({
+                ...order,
+                inputToken,
+                outputToken,
+                id,
+                creationTime,
+                summary: 'TODO: loaded from API',
+                status,
+                receiver,
+                apiAdditionalInfo: order,
+              })
+            } else {
+              console.warn(
+                `APIOrdersUpdater::Tokens not found for order ${id}: sellToken ${
+                  !inputToken ? sellToken : 'found'
+                } - buyToken ${!outputToken ? buyToken : 'found'}`
+              )
+            }
+            return acc
+          }, [])
+
+          // Add to redux state
+          addOrUpdateOrdersBatch({ orders, chainId })
+        })
+        .catch((e) => {
+          console.error(`APIOrdersUpdater::Failed to fetch orders`, e)
+        })
+    }
+  }, [account, addOrUpdateOrdersBatch, allTokens, chainId])
+
+  return null
+}

--- a/src/custom/state/orders/updaters/APIOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/APIOrdersUpdater.ts
@@ -65,6 +65,7 @@ function transformApiOrderToStoreOrder(
       status,
       receiver,
       apiAdditionalInfo: order,
+      isCancelling: apiStatus === 'pending' && order.invalidated, // already cancelled in the API, not yet in the UI
     }
     // The function to compute the summary needs the Order instance to exist already
     // That's why it's not used before and an empty string is set instead

--- a/src/custom/state/orders/updaters/APIOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/APIOrdersUpdater.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 
 import { getAddress } from '@ethersproject/address'
 import { Token } from '@uniswap/sdk-core'
@@ -37,10 +37,11 @@ function classifyLocalStatus(status: ApiOrderStatus): OrderStatus | undefined {
 export function APIOrdersUpdater(): null {
   const { account, chainId } = useActiveWeb3React()
   const allTokens = useAllTokens()
+  const tokenAreLoaded = useMemo(() => Object.keys(allTokens).length > 0, [allTokens])
   const addOrUpdateOrdersBatch = useAddOrUpdateOrdersBatch()
 
   useEffect(() => {
-    if (account && chainId && Object.keys(allTokens).length > 0) {
+    if (account && chainId && tokenAreLoaded) {
       getOrders(chainId, account, 100)
         .then((_orders) => {
           console.log(`APIOrdersUpdater::Fetched ${_orders.length} orders for account ${account} on chain ${chainId}`)
@@ -89,7 +90,7 @@ export function APIOrdersUpdater(): null {
           console.error(`APIOrdersUpdater::Failed to fetch orders`, e)
         })
     }
-  }, [account, addOrUpdateOrdersBatch, allTokens, chainId])
+  }, [account, addOrUpdateOrdersBatch, allTokens, chainId, tokenAreLoaded])
 
   return null
 }

--- a/src/custom/state/orders/updaters/APIOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/APIOrdersUpdater.ts
@@ -84,11 +84,11 @@ export function APIOrdersUpdater(): null {
   useEffect(() => {
     if (account && chainId && tokenAreLoaded) {
       getOrders(chainId, account, 100)
-        .then((_orders) => {
-          console.log(`APIOrdersUpdater::Fetched ${_orders.length} orders for account ${account} on chain ${chainId}`)
+        .then((apiOrders) => {
+          console.log(`APIOrdersUpdater::Fetched ${apiOrders.length} orders for account ${account} on chain ${chainId}`)
 
           // Transform API orders into internal order objects and filter out orders that are not in a known state
-          const orders = _orders.reduce<Order[]>((acc, order) => {
+          const orders = apiOrders.reduce<Order[]>((acc, order) => {
             const storeOrder = transformApiOrderToStoreOrder(order, chainId, allTokens)
             if (storeOrder) {
               acc.push(storeOrder)

--- a/src/custom/state/orders/updaters/ApiOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/ApiOrdersUpdater.ts
@@ -82,7 +82,7 @@ function transformApiOrderToStoreOrder(
   }
 }
 
-export function APIOrdersUpdater(): null {
+export function ApiOrdersUpdater(): null {
   const { account, chainId } = useActiveWeb3React()
   const allTokens = useAllTokens()
   const tokenAreLoaded = useMemo(() => Object.keys(allTokens).length > 0, [allTokens])

--- a/src/custom/state/orders/updaters/ApiOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/ApiOrdersUpdater.ts
@@ -8,7 +8,7 @@ import { useAddOrUpdateOrdersBatch } from 'state/orders/hooks'
 import { getOrders, OrderMetaData } from 'api/gnosisProtocol/api'
 import { useAllTokens } from 'hooks/Tokens'
 import { Order, OrderStatus } from 'state/orders/actions'
-import { NATIVE_CURRENCY_BUY_ADDRESS, NATIVE_CURRENCY_BUY_TOKEN } from 'constants/index'
+import { AMOUNT_OF_ORDERS_TO_FETCH, NATIVE_CURRENCY_BUY_ADDRESS, NATIVE_CURRENCY_BUY_TOKEN } from 'constants/index'
 import { ChainId } from 'state/lists/actions'
 import { ApiOrderStatus, classifyOrder } from 'state/orders/utils'
 import { computeOrderSummary } from 'state/orders/updaters/utils'
@@ -90,7 +90,7 @@ export function ApiOrdersUpdater(): null {
 
   useEffect(() => {
     if (account && chainId && tokenAreLoaded) {
-      getOrders(chainId, account, 100)
+      getOrders(chainId, account, AMOUNT_OF_ORDERS_TO_FETCH)
         .then((apiOrders) => {
           console.log(`APIOrdersUpdater::Fetched ${apiOrders.length} orders for account ${account} on chain ${chainId}`)
 

--- a/src/custom/state/orders/updaters/ApiOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/ApiOrdersUpdater.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useCallback, useMemo, useRef } from 'react'
 
 import { getAddress } from '@ethersproject/address'
 import { Token } from '@uniswap/sdk-core'
@@ -12,12 +12,18 @@ import { AMOUNT_OF_ORDERS_TO_FETCH, NATIVE_CURRENCY_BUY_ADDRESS, NATIVE_CURRENCY
 import { ChainId } from 'state/lists/actions'
 import { ApiOrderStatus, classifyOrder } from 'state/orders/utils'
 import { computeOrderSummary } from 'state/orders/updaters/utils'
+import { useTokensLazy } from 'hooks/useTokensLazy'
 
-function getToken(address: string, chainId: ChainId, tokens: { [p: string]: Token }): Token | undefined {
+function getTokenFromMapping(
+  address: string,
+  chainId: ChainId,
+  tokens: { [p: string]: Token | null }
+): Token | undefined | null {
   if (address.toLowerCase() === NATIVE_CURRENCY_BUY_ADDRESS.toLowerCase()) {
     return NATIVE_CURRENCY_BUY_TOKEN[chainId]
   }
-  return tokens[getAddress(address)]
+  // Some tokens are checksummed, some are not. Search both ways
+  return tokens[getAddress(address)] || tokens[address]
 }
 
 const statusMapping: Record<ApiOrderStatus, OrderStatus | undefined> = {
@@ -31,13 +37,12 @@ const statusMapping: Record<ApiOrderStatus, OrderStatus | undefined> = {
 function transformApiOrderToStoreOrder(
   order: OrderMetaData,
   chainId: ChainId,
-  allTokens: { [address: string]: Token }
+  allTokens: { [address: string]: Token | null }
 ): Order | undefined {
   const { uid: id, sellToken, buyToken, creationDate: creationTime, receiver } = order
 
-  // TODO: load tokens from network when not found on local state
-  const inputToken = getToken(sellToken, chainId, allTokens)
-  const outputToken = getToken(buyToken, chainId, allTokens)
+  const inputToken = getTokenFromMapping(sellToken, chainId, allTokens)
+  const outputToken = getTokenFromMapping(buyToken, chainId, allTokens)
 
   const apiStatus = classifyOrder(order)
   const status = statusMapping[apiStatus]
@@ -77,32 +82,70 @@ function transformApiOrderToStoreOrder(
 export function ApiOrdersUpdater(): null {
   const { account, chainId } = useActiveWeb3React()
   const allTokens = useAllTokens()
-  const tokenAreLoaded = useMemo(() => Object.keys(allTokens).length > 0, [allTokens])
+  const tokensAreLoaded = useMemo(() => Object.keys(allTokens).length > 0, [allTokens])
   const addOrUpdateOrders = useAddOrUpdateOrders()
+  const getTokensFromChain = useTokensLazy()
+
+  // Using a ref to store allTokens to avoid re-fetching when new tokens are added
+  // but still use the latest whenever the callback is invoked
+  const allTokensRef = useRef(allTokens)
+  // Updated on every change
+  allTokensRef.current = allTokens
+
+  const updateOrders = useCallback(
+    async (chainId: ChainId, account: string): Promise<void> => {
+      const tokens = allTokensRef.current
+      console.log(
+        `ApiOrdersUpdater:: updating orders. Network ${chainId}, account ${account}, loaded tokens count ${
+          Object.keys(tokens).length
+        }`
+      )
+      try {
+        // Fetch latest orders from API
+        const apiOrders = await getOrders(chainId, account, AMOUNT_OF_ORDERS_TO_FETCH)
+
+        const tokensToFetch = new Set<string>()
+
+        // Find out which tokens are not yet loaded in the UI
+        apiOrders.forEach(({ sellToken, buyToken }) => {
+          if (!getTokenFromMapping(sellToken, chainId, tokens)) tokensToFetch.add(sellToken)
+          if (!getTokenFromMapping(buyToken, chainId, tokens)) tokensToFetch.add(buyToken)
+        })
+
+        let fetchedTokens
+
+        if (tokensToFetch.size > 0) {
+          // Fetch them from the chain, only if we have to
+          fetchedTokens = await getTokensFromChain(Array.from(tokensToFetch))
+        }
+
+        // Merge fetched tokens with what's currently loaded
+        const reallyAllTokens = fetchedTokens ? { ...tokens, ...fetchedTokens } : tokens
+
+        // Build store order objects, for all orders which we found both input/output tokens
+        // Don't add order for those we didn't
+        const orders = apiOrders.reduce<Order[]>((acc, order) => {
+          const storeOrder = transformApiOrderToStoreOrder(order, chainId, reallyAllTokens)
+          if (storeOrder) {
+            acc.push(storeOrder)
+          }
+          return acc
+        }, [])
+
+        // Add orders to redux state
+        addOrUpdateOrders({ orders, chainId })
+      } catch (e) {
+        console.error(`ApiOrdersUpdater::Failed to fetch orders`, e)
+      }
+    },
+    [addOrUpdateOrders, getTokensFromChain]
+  )
 
   useEffect(() => {
-    if (account && chainId && tokenAreLoaded) {
-      getOrders(chainId, account, AMOUNT_OF_ORDERS_TO_FETCH)
-        .then((apiOrders) => {
-          console.log(`ApiOrdersUpdater::Fetched ${apiOrders.length} orders for account ${account} on chain ${chainId}`)
-
-          // Transform API orders into internal order objects and filter out orders that are not in a known state
-          const orders = apiOrders.reduce<Order[]>((acc, order) => {
-            const storeOrder = transformApiOrderToStoreOrder(order, chainId, allTokens)
-            if (storeOrder) {
-              acc.push(storeOrder)
-            }
-            return acc
-          }, [])
-
-          // Add to redux state
-          addOrUpdateOrders({ orders, chainId })
-        })
-        .catch((e) => {
-          console.error(`ApiOrdersUpdater::Failed to fetch orders`, e)
-        })
+    if (account && chainId && tokensAreLoaded) {
+      updateOrders(chainId, account)
     }
-  }, [account, addOrUpdateOrders, allTokens, chainId, tokenAreLoaded])
+  }, [account, chainId, tokensAreLoaded, updateOrders])
 
   return null
 }

--- a/src/custom/state/orders/updaters/ApiOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/ApiOrdersUpdater.ts
@@ -4,7 +4,7 @@ import { getAddress } from '@ethersproject/address'
 import { Token } from '@uniswap/sdk-core'
 
 import { useActiveWeb3React } from 'hooks/web3'
-import { useAddOrUpdateOrdersBatch } from 'state/orders/hooks'
+import { useAddOrUpdateOrders } from 'state/orders/hooks'
 import { getOrders, OrderMetaData } from 'api/gnosisProtocol/api'
 import { useAllTokens } from 'hooks/Tokens'
 import { Order, OrderStatus } from 'state/orders/actions'
@@ -79,7 +79,7 @@ export function ApiOrdersUpdater(): null {
   const { account, chainId } = useActiveWeb3React()
   const allTokens = useAllTokens()
   const tokenAreLoaded = useMemo(() => Object.keys(allTokens).length > 0, [allTokens])
-  const addOrUpdateOrdersBatch = useAddOrUpdateOrdersBatch()
+  const addOrUpdateOrders = useAddOrUpdateOrders()
 
   useEffect(() => {
     if (account && chainId && tokenAreLoaded) {
@@ -97,13 +97,13 @@ export function ApiOrdersUpdater(): null {
           }, [])
 
           // Add to redux state
-          addOrUpdateOrdersBatch({ orders, chainId })
+          addOrUpdateOrders({ orders, chainId })
         })
         .catch((e) => {
           console.error(`APIOrdersUpdater::Failed to fetch orders`, e)
         })
     }
-  }, [account, addOrUpdateOrdersBatch, allTokens, chainId, tokenAreLoaded])
+  }, [account, addOrUpdateOrders, allTokens, chainId, tokenAreLoaded])
 
   return null
 }

--- a/src/custom/state/orders/updaters/ApiOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/ApiOrdersUpdater.ts
@@ -20,19 +20,12 @@ function getToken(address: string, chainId: ChainId, tokens: { [p: string]: Toke
   return tokens[getAddress(address)]
 }
 
-function classifyLocalStatus(status: ApiOrderStatus): OrderStatus | undefined {
-  switch (status) {
-    case 'cancelled':
-      return OrderStatus.CANCELLED
-    case 'expired':
-      return OrderStatus.EXPIRED
-    case 'pending':
-      return OrderStatus.PENDING
-    case 'fulfilled':
-      return OrderStatus.FULFILLED
-    default:
-      return undefined
-  }
+const statusMapping: Record<ApiOrderStatus, OrderStatus | undefined> = {
+  cancelled: OrderStatus.CANCELLED,
+  expired: OrderStatus.EXPIRED,
+  fulfilled: OrderStatus.FULFILLED,
+  pending: OrderStatus.PENDING,
+  unknown: undefined,
 }
 
 function transformApiOrderToStoreOrder(
@@ -47,7 +40,7 @@ function transformApiOrderToStoreOrder(
   const outputToken = getToken(buyToken, chainId, allTokens)
 
   const apiStatus = classifyOrder(order)
-  const status = classifyLocalStatus(apiStatus)
+  const status = statusMapping[apiStatus]
 
   if (!status) {
     console.warn(`APIOrdersUpdater::Order ${id} in unknown internal state: ${apiStatus}`)

--- a/src/custom/state/orders/updaters/index.ts
+++ b/src/custom/state/orders/updaters/index.ts
@@ -1,4 +1,4 @@
 export { PendingOrdersUpdater } from './PendingOrdersUpdater'
 export { CancelledOrdersUpdater } from './CancelledOrdersUpdater'
 export { UnfillableOrdersUpdater } from './UnfillableOrdersUpdater'
-export { APIOrdersUpdater } from './APIOrdersUpdater'
+export { ApiOrdersUpdater } from './ApiOrdersUpdater'

--- a/src/custom/state/orders/updaters/index.ts
+++ b/src/custom/state/orders/updaters/index.ts
@@ -1,3 +1,4 @@
 export { PendingOrdersUpdater } from './PendingOrdersUpdater'
 export { CancelledOrdersUpdater } from './CancelledOrdersUpdater'
 export { UnfillableOrdersUpdater } from './UnfillableOrdersUpdater'
+export { APIOrdersUpdater } from './APIOrdersUpdater'

--- a/src/custom/state/orders/updaters/utils.ts
+++ b/src/custom/state/orders/updaters/utils.ts
@@ -1,4 +1,4 @@
-import { Order, OrderFulfillmentData } from 'state/orders/actions'
+import { Order, OrderFulfillmentData, OrderKind, OrderStatus } from 'state/orders/actions'
 import { getOrder, OrderID, OrderMetaData } from 'api/gnosisProtocol'
 import { stringToCurrency } from 'state/swap/extension'
 import { formatSmart } from 'utils/format'
@@ -8,7 +8,7 @@ import { SupportedChainId as ChainId } from 'constants/chains'
 
 export type OrderLogPopupMixData = OrderFulfillmentData | OrderID
 
-function _computeFulfilledSummary({
+export function computeOrderSummary({
   orderFromStore,
   orderFromApi,
 }: {
@@ -21,18 +21,22 @@ function _computeFulfilledSummary({
   // if we can find the order from the API
   // and our specific order exists in our state, let's use that
   if (orderFromApi) {
-    const { buyToken, sellToken, executedBuyAmount, executedSellAmount } = orderFromApi
+    const { buyToken, sellToken, sellAmount, buyAmount, executedBuyAmount, executedSellAmount } = orderFromApi
 
     if (orderFromStore) {
-      const { inputToken, outputToken } = orderFromStore
-      // don't show amounts in atoms
-      const inputAmount = stringToCurrency(executedSellAmount, inputToken)
-      const outputAmount = stringToCurrency(executedBuyAmount, outputToken)
+      const { inputToken, outputToken, status, kind } = orderFromStore
+      const isFulfilled = status === OrderStatus.FULFILLED
 
-      summary = `Swap ${formatSmart(inputAmount, AMOUNT_PRECISION)} ${inputAmount.currency.symbol} for ${formatSmart(
-        outputAmount,
-        AMOUNT_PRECISION
-      )} ${outputAmount.currency.symbol}`
+      // don't show amounts in atoms
+      const inputAmount = stringToCurrency(isFulfilled ? executedSellAmount : sellAmount, inputToken)
+      const outputAmount = stringToCurrency(isFulfilled ? executedBuyAmount : buyAmount, outputToken)
+
+      const inputPrefix = !isFulfilled && kind === OrderKind.BUY ? 'at most ' : ''
+      const outputPrefix = !isFulfilled && kind === OrderKind.SELL ? 'at least ' : ''
+
+      summary = `Swap ${inputPrefix}${formatSmart(inputAmount, AMOUNT_PRECISION)} ${
+        inputAmount.currency.symbol
+      } for ${outputPrefix}${formatSmart(outputAmount, AMOUNT_PRECISION)} ${outputAmount.currency.symbol}`
     } else {
       // We only have the API order info, let's at least use that
       summary = `Swap ${sellToken} for ${buyToken}`
@@ -62,7 +66,7 @@ export async function fetchOrderPopupData(orderFromStore: Order, chainId: ChainI
         id: orderFromStore.id,
         fulfillmentTime: new Date().toISOString(),
         transactionHash: '', // there's no need  for a txHash as we'll link the notification to the Explorer
-        summary: _computeFulfilledSummary({ orderFromStore, orderFromApi }),
+        summary: computeOrderSummary({ orderFromStore, orderFromApi }),
         apiAdditionalInfo: orderFromApi
           ? {
               ...orderFromApi,

--- a/src/custom/state/orders/utils.ts
+++ b/src/custom/state/orders/utils.ts
@@ -16,7 +16,7 @@ export type ApiOrderStatus = 'unknown' | 'fulfilled' | 'expired' | 'cancelled' |
  *
  * We assume the order is `fillOrKill`
  */
-function isOrderFulfilled(order: OrderMetaData): boolean {
+function isOrderFulfilled(order: Pick<OrderMetaData, 'executedBuyAmount' | 'executedSellAmount'>): boolean {
   return Number(order.executedBuyAmount) > 0 && Number(order.executedSellAmount) > 0
 }
 
@@ -28,7 +28,7 @@ function isOrderFulfilled(order: OrderMetaData): boolean {
  *
  * We assume the order is not fulfilled.
  */
-function isOrderCancelled(order: OrderMetaData): boolean {
+function isOrderCancelled(order: Pick<OrderMetaData, 'creationDate' | 'invalidated'>): boolean {
   const creationTime = new Date(order.creationDate).getTime()
   return order.invalidated && Date.now() - creationTime > PENDING_ORDERS_BUFFER
 }
@@ -38,12 +38,17 @@ function isOrderCancelled(order: OrderMetaData): boolean {
  * The buffer is used to take into account race conditions where a solver might
  * execute a transaction after the backend changed the order status.
  */
-function isOrderExpired(order: OrderMetaData): boolean {
+function isOrderExpired(order: Pick<OrderMetaData, 'validTo'>): boolean {
   const validToTime = order.validTo * 1000 // validTo is in seconds
   return Date.now() - validToTime > PENDING_ORDERS_BUFFER
 }
 
-export function classifyOrder(order: OrderMetaData | null): ApiOrderStatus {
+export function classifyOrder(
+  order: Pick<
+    OrderMetaData,
+    'uid' | 'validTo' | 'creationDate' | 'invalidated' | 'executedBuyAmount' | 'executedSellAmount'
+  > | null
+): ApiOrderStatus {
   if (!order) {
     console.debug(`[state::orders::classifyOrder] unknown order`)
     return 'unknown'

--- a/src/custom/utils/explorer.ts
+++ b/src/custom/utils/explorer.ts
@@ -37,3 +37,9 @@ export function getExplorerOrderLink(chainId: ChainId, orderId: OrderID): string
 
   return baseUrl + `/orders/${orderId}`
 }
+
+export function getExplorerAddressLink(chainId: ChainId, address: string): string {
+  const baseUrl = _getExplorerBaseUrl(chainId)
+
+  return baseUrl + `/address/${address}`
+}

--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -113,7 +113,11 @@ export function useIsUserAddedToken(currency: Currency | undefined | null): bool
 // parse a name or symbol from a token response
 const BYTES32_REGEX = /^0x[a-fA-F0-9]{64}$/
 
-function parseStringOrBytes32(str: string | undefined, bytes32: string | undefined, defaultValue: string): string {
+export function parseStringOrBytes32(
+  str: string | undefined,
+  bytes32: string | undefined,
+  defaultValue: string
+): string {
   return str && str.length > 0
     ? str
     : // need to check for proper bytes string and valid terminator

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,7 +21,12 @@ import EnhancedTransactionUpdater from 'state/enhancedTransactions/updater'
 import UserUpdater from './state/user/updater'
 import FeesUpdater from 'state/price/updater'
 import GasUpdater from 'state/gas/updater'
-import { CancelledOrdersUpdater, PendingOrdersUpdater, UnfillableOrdersUpdater } from 'state/orders/updaters'
+import {
+  APIOrdersUpdater,
+  CancelledOrdersUpdater,
+  PendingOrdersUpdater,
+  UnfillableOrdersUpdater,
+} from 'state/orders/updaters'
 // import { EventUpdater } from 'state/orders/mocks'
 import ThemeProvider, { FixedGlobalStyle, ThemedGlobalStyle } from 'theme'
 import getLibrary from './utils/getLibrary'
@@ -71,6 +76,7 @@ function Updaters() {
       <CancelledOrdersUpdater />
       <FeesUpdater />
       <UnfillableOrdersUpdater />
+      <APIOrdersUpdater />
       <GasUpdater />
     </>
   )

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,7 +22,7 @@ import UserUpdater from './state/user/updater'
 import FeesUpdater from 'state/price/updater'
 import GasUpdater from 'state/gas/updater'
 import {
-  APIOrdersUpdater,
+  ApiOrdersUpdater,
   CancelledOrdersUpdater,
   PendingOrdersUpdater,
   UnfillableOrdersUpdater,
@@ -76,7 +76,7 @@ function Updaters() {
       <CancelledOrdersUpdater />
       <FeesUpdater />
       <UnfillableOrdersUpdater />
-      <APIOrdersUpdater />
+      <ApiOrdersUpdater />
       <GasUpdater />
     </>
   )

--- a/src/state/multicall/hooks.ts
+++ b/src/state/multicall/hooks.ts
@@ -27,20 +27,20 @@ function isMethodArg(x: unknown): x is MethodArg {
   return BigNumber.isBigNumber(x) || ['string', 'number'].indexOf(typeof x) !== -1
 }
 
-function isValidMethodArgs(x: unknown): x is MethodArgs | undefined {
+export function isValidMethodArgs(x: unknown): x is MethodArgs | undefined {
   return (
     x === undefined ||
     (Array.isArray(x) && x.every((xi) => isMethodArg(xi) || (Array.isArray(xi) && xi.every(isMethodArg))))
   )
 }
 
-interface CallResult {
+export interface CallResult {
   readonly valid: boolean
   readonly data: string | undefined
   readonly blockNumber: number | undefined
 }
 
-const INVALID_RESULT: CallResult = { valid: false, blockNumber: undefined, data: undefined }
+export const INVALID_RESULT: CallResult = { valid: false, blockNumber: undefined, data: undefined }
 
 // use this options object
 export const NEVER_RELOAD: ListenerOptions = {
@@ -120,7 +120,7 @@ export interface CallState {
 const INVALID_CALL_STATE: CallState = { valid: false, result: undefined, loading: false, syncing: false, error: false }
 const LOADING_CALL_STATE: CallState = { valid: true, result: undefined, loading: true, syncing: true, error: false }
 
-function toCallState(
+export function toCallState(
   callResult: CallResult | undefined,
   contractInterface: Interface | undefined,
   fragment: FunctionFragment | undefined,

--- a/src/state/multicall/updater.tsx
+++ b/src/state/multicall/updater.tsx
@@ -22,7 +22,7 @@ import { useAppDispatch, useAppSelector } from 'state/hooks'
  * @param chunk chunk of calls to make
  * @param minBlockNumber minimum block number of the result set
  */
-async function fetchChunk(
+export async function fetchChunk(
   multicall2Contract: Multicall2,
   chunk: Call[],
   minBlockNumber: number

--- a/src/theme/components.tsx
+++ b/src/theme/components.tsx
@@ -116,7 +116,7 @@ export const StyledInternalLink = styled(Link)`
   }
 `
 
-const StyledLink = styled.a`
+export const StyledLink = styled.a`
   text-decoration: none;
   cursor: pointer;
   color: ${({ theme }) => theme.primary1};


### PR DESCRIPTION
# Summary

Activity orders from API: "Your orders, wherever you are"

Main changes:
- At start/network/account change, fetches orders from API
- Shows only orders for connected account/network
- Shows only txs for connected account/network
- Displays at most 10 regulars orders, and as many pending as there are
- Shows orders sorted by creation date, descending
- Replaced `Clear activity` with `View all orders` ~(Pending CSS work)~
- Added a `View all orders` at the bottom of activity list

# To Test

1. Connect a wallet with existing orders
2. Open Account Activities sidebar
* There should be 10 orders or less, doesn't matter how old they are (There might be more if you have more than 10 pending orders)
* There should be a link on top right that takes you to the Explorer to see all of your orders
![screenshot_2021-09-27_16-24-30](https://user-images.githubusercontent.com/43217/134998360-3c0616ab-59b0-42f5-9d2d-896e3cf663db.png)

3. Change account AND/OR network
* Orders should be updated to match the selected account/network
4. Place an order
5. While it's pending, open the same page in another browser / device (:warning: important to test in a different browser otherwise the same local storage will be used)
* The pending order should be visible as pending in the new browser / device


# *NOT* part of this PR

- Load txs the same way as orders
- Refresh pending orders in the background - right now they are updated only on account/network change
- Show orders that have Tokens not yet loaded in the current UI

