### PR TITLE
[presign] Fix pending loader not showing up

### DIFF
--- a/src/custom/components/Web3Status/index.tsx
+++ b/src/custom/components/Web3Status/index.tsx
@@ -21,7 +21,9 @@ const Wrapper = styled.div`
   }
 `
 
-const isPending = (data: TransactionAndOrder) => data.status === OrderStatus.PENDING
+const isPending = (data: TransactionAndOrder) =>
+  data.status === OrderStatus.PENDING || data.status === OrderStatus.PRESIGNATURE_PENDING
+
 const isConfirmed = (data: TransactionAndOrder) =>
   data.status === OrderStatus.FULFILLED || data.status === OrderStatus.EXPIRED || data.status === OrderStatus.CANCELLED
 


### PR DESCRIPTION
# Summary
Add the spinner for pre-sign orders. It was lost :)  

![image](https://user-images.githubusercontent.com/2352112/132691199-7a342790-d8f7-409a-9eb6-7fcdca9cff78.png)


# To Test

1. Send an order
2. See the spinner

# Background
@MareenG noticed in the PR for cancelation of orders