### PR TITLE
[presign] Detect safe wallet, and load its data

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "@gnosis.pm/cow-runner-game": "^0.2.9",
     "@gnosis.pm/dex-js": "^0.12.0",
     "@gnosis.pm/gp-v2-contracts": "^1.0.2",
+    "@gnosis.pm/safe-service-client": "^0.1.1",
     "@sentry/react": "^6.11.0",
     "@sentry/tracing": "^6.11.0",
     "@uniswap/default-token-list": "^2.0.0",

--- a/src/custom/api/gnosisSafe/index.ts
+++ b/src/custom/api/gnosisSafe/index.ts
@@ -1,0 +1,52 @@
+import SafeServiceClient, { SafeInfoResponse, SafeMultisigTransactionResponse } from '@gnosis.pm/safe-service-client'
+import { registerOnWindow } from '@src/custom/utils/misc'
+import { ChainId } from '@uniswap/sdk'
+
+const SAFE_TRANSACTION_SERVICE_URL: Partial<Record<ChainId, string>> = {
+  [ChainId.MAINNET]: 'https://safe-transaction.gnosis.io',
+  [ChainId.RINKEBY]: 'https://safe-transaction.rinkeby.gnosis.io',
+  [ChainId.XDAI]: 'https://safe-transaction.xdai.gnosis.io',
+}
+
+const SAFE_TRANSACTION_SERVICE_CACHE: Partial<Record<ChainId, SafeServiceClient | null>> = {}
+
+function _getClient(chainId: ChainId): SafeServiceClient | null {
+  let client = SAFE_TRANSACTION_SERVICE_CACHE[chainId]
+  if (client === undefined) {
+    const url = SAFE_TRANSACTION_SERVICE_URL[chainId]
+    if (!url) {
+      client = null
+    } else {
+      client = new SafeServiceClient(url)
+    }
+
+    // Add client to cache (or null if unknonw network)
+    SAFE_TRANSACTION_SERVICE_CACHE[chainId] = client
+  }
+
+  return client
+}
+
+function _getClientOrThrow(chainId: ChainId): SafeServiceClient {
+  const client = _getClient(chainId)
+  if (!client) {
+    throw new Error('Unsupported network for Gnosis Safe Transaction Service: ' + chainId)
+  }
+
+  return client
+}
+
+export function getSafeTransaction(chainId: ChainId, safeTxHash: string): Promise<SafeMultisigTransactionResponse> {
+  console.log('[api/gnosisSafe] getSafeTransaction', chainId, safeTxHash)
+  const client = _getClientOrThrow(chainId)
+  return client.getTransaction(safeTxHash)
+}
+
+export function getSafeInfo(chainId: ChainId, safeAddress: string): Promise<SafeInfoResponse> {
+  console.log('[api/gnosisSafe] getSafeInfo', chainId, safeAddress)
+  const client = _getClientOrThrow(chainId)
+
+  return client.getSafeInfo(safeAddress)
+}
+
+registerOnWindow({ getSafeTransaction, getSafeInfo })

--- a/src/custom/pages/CowGame/index.tsx
+++ b/src/custom/pages/CowGame/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import Page, { Content } from 'components/Page'
 import styled from 'styled-components'
 import { CowGame } from '@gnosis.pm/cow-runner-game'
+import { useWalletInfo } from '@src/custom/hooks/useWalletInfo'
 
 const Wrapper = styled(Page)`
   min-height: initial;
@@ -30,9 +31,11 @@ const Wrapper = styled(Page)`
 `
 
 export default function CowGamePage() {
+  const { gnosisSafeInfo } = useWalletInfo()
   return (
     <Wrapper>
       <p>
+        <pre>{JSON.stringify(gnosisSafeInfo, null, 2)}</pre>
         Run! ...and try not getting sandwiched{' '}
         <span role="img" aria-label="sandwich-icon">
           🥪

--- a/yarn.lock
+++ b/yarn.lock
@@ -1850,6 +1850,19 @@
   resolved "https://registry.yarnpkg.com/@gnosis.pm/gp-v2-contracts/-/gp-v2-contracts-1.0.2.tgz#bcc1f6a07061df6ab55298d7fe6ee93fcd1025aa"
   integrity sha512-bsWB8r8RENvpAGMRfRfENtMU7tPdfa1AtgTidUpxC9f3HREZ2FdiAvAghE3XZwy7BzJ0CQJ2lNl4ANKCZ+kj8Q==
 
+"@gnosis.pm/safe-core-sdk-types@^0.1.0":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-core-sdk-types/-/safe-core-sdk-types-0.1.1.tgz#908c394cb4660493b4e9c8e01b5a7aa36efafd30"
+  integrity sha512-PghXGDaI5Foq37nZGmI90U2OKMeGtxh5KqkDqou9aFHwGVa/nf9HRQPxG9/XUzcyfe9OlKttDlJnR3XnC3dSDw==
+
+"@gnosis.pm/safe-service-client@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-service-client/-/safe-service-client-0.1.1.tgz#4a664fc4c00634cd8f4d8138f900158ca621f3bb"
+  integrity sha512-7oQxcs1xTYdS+ZxqFPe44zlu7uzF654QNxI8XSMMnQ11sai7jgoMlom0ucRcWLp1cKATYMNA9+yUgPYYmTRgqA==
+  dependencies:
+    "@gnosis.pm/safe-core-sdk-types" "^0.1.0"
+    axios "^0.21.1"
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"


### PR DESCRIPTION
# Summary
This PR detects when the user is using Gnosis Safe through wallet connect, and tries to load the data of the wallet.

Includes the API integration for the 3 supported networks. 

**NOTE**: Just to make testing easier for the reviewers, I added the info of the wallet in the game. Of course this will be removed in a future PR.

![image](https://user-images.githubusercontent.com/2352112/132705323-59aac5ec-b147-4244-9f86-8d87ba72d9c5.png)


# To Test

1. Connect using Gnosis Safe and wallet connnect
2. Go to the cow game, and see the data for the Gnosis Safe