### PR TITLE
Hotfix :fire:  - 1.1.3 [revert default slippage to 0.5%]

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -6,7 +6,7 @@ import { WalletInfo, SUPPORTED_WALLETS as SUPPORTED_WALLETS_UNISWAP } from 'cons
 import { SupportedChainId as ChainId } from 'constants/chains'
 import { getAppDataHash } from './appDataHash'
 
-export const INITIAL_ALLOWED_SLIPPAGE_PERCENT = new Percent('1', '100') // 1%
+export const INITIAL_ALLOWED_SLIPPAGE_PERCENT = new Percent('5', '1000') // 0.5%
 export const RADIX_DECIMAL = 10
 export const RADIX_HEX = 16
 


### PR DESCRIPTION
Hotfix 1.1.3

- revert default slippage percent to 0.5

  # To Test
- the default slippage value in the settings popup should be 0.5%
![Screenshot from 2021-09-09 18-24-35](https://user-images.githubusercontent.com/34926005/132724936-d62f4821-6b70-44de-9252-31d811a6c578.png)
