### PR TITLE
Improve banner styles.

### DIFF
--- a/src/custom/components/Header/URLWarning/URLWarningMod.tsx
+++ b/src/custom/components/Header/URLWarning/URLWarningMod.tsx
@@ -5,7 +5,7 @@ import { AlertTriangle, X } from 'react-feather'
 import { useURLWarningToggle, useURLWarningVisible } from 'state/user/hooks'
 import { isMobile } from 'react-device-detect'
 
-const PhishAlert = styled.div<{ isActive: any }>`
+export const PhishAlert = styled.div<{ isActive: any }>`
   width: 100%;
   padding: 6px 6px;
   background-color: ${({ theme }) => theme.blue1};

--- a/src/custom/components/Header/URLWarning/index.tsx
+++ b/src/custom/components/Header/URLWarning/index.tsx
@@ -7,17 +7,24 @@ import { useAnnouncementVisible, useCloseAnnouncement } from 'state/profile/hook
 import { hashCode } from 'utils/misc'
 import useFetchFile from 'hooks/useFetchFile'
 import { Markdown } from 'components/Markdown'
+import { useActiveWeb3React } from '@src/hooks/web3'
+import { ChainId } from '@uniswap/sdk'
 
 export * from './URLWarningMod'
 
 // Announcement content: Modify this file to edit the announcement
 //  https://github.com/gnosis/cowswap/blob/announcements/docs/announcements.md
-const ANNOUNCEMENTS_MARKDOWN_URL =
-  'https://raw.githubusercontent.com/gnosis/cowswap/announcements/docs/announcements.md'
+const ANNOUNCEMENTS_MARKDOWN_BASE_URL = 'https://raw.githubusercontent.com/gnosis/cowswap/announcements/docs'
+
+function getAnnouncementUrl(chainId: number) {
+  return `${ANNOUNCEMENTS_MARKDOWN_BASE_URL}/announcements-${chainId}.md`
+}
 
 export default function URLWarning() {
+  const { chainId = ChainId.MAINNET } = useActiveWeb3React()
+
   // Ger announcement if there's one
-  const { file, error } = useFetchFile(ANNOUNCEMENTS_MARKDOWN_URL)
+  const { file, error } = useFetchFile(getAnnouncementUrl(chainId))
   const announcementText = error ? undefined : file?.trim()
   const contentHash = announcementText ? hashCode(announcementText).toString() : undefined
 

--- a/src/custom/components/Header/URLWarning/index.tsx
+++ b/src/custom/components/Header/URLWarning/index.tsx
@@ -17,7 +17,6 @@ const Wrapper = styled.div`
   width: 100%;
 
   ${PhishAlert} {
-    display: flex;
     justify-content: center;
     font-size: 12px;
     padding: 8px;

--- a/src/custom/components/Header/URLWarning/index.tsx
+++ b/src/custom/components/Header/URLWarning/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
+import styled from 'styled-components'
 
 import { PRODUCTION_URL } from 'constants/index'
 import { AlertTriangle } from 'react-feather'
-import URLWarningUni, { StyledClose } from './URLWarningMod'
+import URLWarningUni, { PhishAlert, StyledClose } from './URLWarningMod'
 import { useAnnouncementVisible, useCloseAnnouncement } from 'state/profile/hooks'
 import { hashCode } from 'utils/misc'
 import useFetchFile from 'hooks/useFetchFile'
@@ -11,6 +12,42 @@ import { useActiveWeb3React } from '@src/hooks/web3'
 import { ChainId } from '@uniswap/sdk'
 
 export * from './URLWarningMod'
+
+const Wrapper = styled.div`
+  width: 100%;
+
+  ${PhishAlert} {
+    display: flex;
+    justify-content: center;
+    font-size: 12px;
+    padding: 8px;
+    background-color: ${({ theme }) => theme.primary1};
+    color: ${({ theme }) => theme.text2};
+
+    > div {
+      align-items: center;
+      width: 100%;
+    }
+
+    > div > svg {
+      min-width: 24px;
+    }
+
+    > div > p {
+      padding: 0 12px;
+
+      ${({ theme }) => theme.mediaWidth.upToSmall`
+        padding: 12px;
+      `};
+    }
+  }
+
+  ${StyledClose} {
+    height: 100%;
+    width: 24px;
+    margin: 0;
+  }
+`
 
 // Announcement content: Modify this file to edit the announcement
 //  https://github.com/gnosis/cowswap/blob/announcements/docs/announcements.md
@@ -39,11 +76,15 @@ export default function URLWarning() {
   const announcement = announcementVisible && announcementText && (
     <>
       <div style={{ display: 'flex' }}>
-        <AlertTriangle style={{ marginRight: 6 }} size={12} /> <Markdown>{announcementText}</Markdown>
+        <AlertTriangle /> <Markdown>{announcementText}</Markdown>
       </div>
       <StyledClose size={12} onClick={() => closeAnnouncement(contentHash)} />
     </>
   )
 
-  return <URLWarningUni url={PRODUCTION_URL} announcement={announcement} />
+  return (
+    <Wrapper>
+      <URLWarningUni url={PRODUCTION_URL} announcement={announcement} />
+    </Wrapper>
+  )
 }


### PR DESCRIPTION
# Summary

Proposal to improve banner styles to increase visibility/urgency:

**original PR:**

<img width="813" alt="Screen Shot 2021-09-21 at 13 36 22" src="https://user-images.githubusercontent.com/31534717/134163728-0a8251d3-9044-4987-9d6c-2dc819a3eff5.png">

**New proposal:**

<img width="1284" alt="Screen Shot 2021-09-21 at 13 34 33" src="https://user-images.githubusercontent.com/31534717/134163645-bf818420-f7b4-4cb7-a550-4e9287f5e1a3.png">
<img width="1283" alt="Screen Shot 2021-09-21 at 13 34 20" src="https://user-images.githubusercontent.com/31534717/134163652-eb9d5303-6ba4-4cef-ba47-41a94c59ad4b.png">
<img width="401" alt="Screen Shot 2021-09-21 at 13 34 06" src="https://user-images.githubusercontent.com/31534717/134163653-38023ccf-2524-429e-95b7-2375366d845b.png">


