### PR TITLE
1441/input copy paste error

### DIFF
--- a/src/custom/utils/format.ts
+++ b/src/custom/utils/format.ts
@@ -147,7 +147,6 @@ export function formatSmart(
  *   Token decimals: `10`; value: `412310.0014123`
  *   => `412310.0014123000`
  *
- *
  * @param value
  * @param decimals
  */
@@ -161,4 +160,16 @@ export function formatMax(value?: Fraction, decimals?: number): string | undefin
     amount = value.toSignificant(1)
   }
   return amount
+}
+
+/**
+ * Truncated given `value` on `decimals`.
+ * E.g.: value=10.001; decimals=2 => 10.00
+ *
+ * @param value
+ * @param decimals
+ */
+export function truncateOnMaxDecimals(value: string, decimals: number): string {
+  const regex = new RegExp(`(\\d*\\.\\d{${decimals}})\\d*`)
+  return value.replace(regex, '$1')
 }

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -21,6 +21,7 @@ import { Field, replaceSwapState, selectCurrency, setRecipient, switchCurrencies
 import { SwapState } from './reducer'
 import { useUserSingleHopOnly } from 'state/user/hooks'
 import { useAppDispatch, useAppSelector } from 'state/hooks'
+import { truncateOnMaxDecimals } from 'utils/format'
 
 export function useSwapState(): AppState['swap'] {
   return useAppSelector((state) => state.swap)
@@ -77,7 +78,9 @@ export function tryParseAmount<T extends Currency>(value?: string, currency?: T)
     return undefined
   }
   try {
-    const typedValueParsed = parseUnits(value, currency.decimals).toString()
+    // Here we drop everything after given token decimals to avoid parsing issues
+    const truncatedValue = truncateOnMaxDecimals(value, currency.decimals)
+    const typedValueParsed = parseUnits(truncatedValue, currency.decimals).toString()
     if (typedValueParsed !== '0') {
       return CurrencyAmount.fromRawAmount(currency, JSBI.BigInt(typedValueParsed))
     }

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -79,7 +79,7 @@ export function tryParseAmount<T extends Currency>(value?: string, currency?: T)
   }
   try {
     // Here we drop everything after given token decimals to avoid parsing issues
-    const truncatedValue = truncateOnMaxDecimals(value, currency.decimals)
+    const truncatedValue = currency.decimals ? truncateOnMaxDecimals(value, currency.decimals) : value
     const typedValueParsed = parseUnits(truncatedValue, currency.decimals).toString()
     if (typedValueParsed !== '0') {
       return CurrencyAmount.fromRawAmount(currency, JSBI.BigInt(typedValueParsed))


### PR DESCRIPTION
# Summary

Fixes #1441

Truncating input value based on max decimals of selected token

| 100 USDC | 100.0000001 USDC|
|-|-|
| ![screenshot_2021-09-21_09-56-54](https://user-images.githubusercontent.com/43217/134214333-49d2a0ee-ed63-482c-8509-06b25599d054.png) | ![screenshot_2021-09-21_09-56-46](https://user-images.githubusercontent.com/43217/134214353-d2672a8b-c2b4-4b60-bbea-e0f0b4feabe8.png) |


  # To Test

1. Pick a token pair
2. Insert one amount with more decimals precision that the token has. Example: USDC => 100.0000001
* UI should not break and give the corresponding price
3. Copy a value with more precision than the token has (you can re-use the example from `2`)
4. Clear the input contents and paste the value into it
* UI should not break and give the corresponding price

  # Background

*Optional: Give background information for changes you've made, that might be difficult to explain via comments*

