### PR TITLE
Display `0` when there's no balance to format

### DIFF
--- a/src/custom/components/CurrencyInputPanel/CurrencyInputPanelMod.tsx
+++ b/src/custom/components/CurrencyInputPanel/CurrencyInputPanelMod.tsx
@@ -284,7 +284,7 @@ export default function CurrencyInputPanel({
                           renderBalance(selectedCurrencyBalance)
                         ) : (
                           <Trans>
-                            Balance: {formatSmart(selectedCurrencyBalance, AMOUNT_PRECISION)} {currency.symbol}
+                            Balance: {formatSmart(selectedCurrencyBalance, AMOUNT_PRECISION) || '0'} {currency.symbol}
                           </Trans>
                         )
                       ) : null}

--- a/src/custom/components/SearchModal/CurrencyList/index.tsx
+++ b/src/custom/components/SearchModal/CurrencyList/index.tsx
@@ -127,7 +127,7 @@ function TokenTags({ currency, isUnsupported }: { currency: Currency; isUnsuppor
 }
 
 export function Balance({ balance }: { balance: CurrencyAmount<Currency> }) {
-  return <StyledBalanceText title={balance.toExact()}>{formatSmart(balance, LONG_PRECISION)}</StyledBalanceText>
+  return <StyledBalanceText title={balance.toExact()}>{formatSmart(balance, LONG_PRECISION) || '0'}</StyledBalanceText>
 }
 
 export default function CurrencyList(


### PR DESCRIPTION
# Summary

Fixes #1426 

Balances with `0` amount now show `0` instead of nothing. Same for token selector.

|Before|After|
|-|-|
| ![screenshot_2021-09-21_11-42-36](https://user-images.githubusercontent.com/43217/134228810-5e40a6d6-c872-4bec-98fc-a14d49a69bb9.png) | ![screenshot_2021-09-21_11-42-00](https://user-images.githubusercontent.com/43217/134228836-58426d5a-8ca3-40ba-8dcf-ac3aa53f0559.png) |
| ![screenshot_2021-09-21_11-42-27](https://user-images.githubusercontent.com/43217/134228857-cc66c778-a35b-4670-9524-13829d4677fe.png) | ![screenshot_2021-09-21_11-38-31](https://user-images.githubusercontent.com/43217/134228894-919786dd-404d-4b69-992f-7426ab1a85eb.png) |

  # To Test

1. Connect wallet
2. Open token selector drop down
* Zero balance tokens should have `0` on the right side
3. Pick a token with zero balance
* Balance should show `0` <token symbol>

  # Background

*Optional: Give background information for changes you've made, that might be difficult to explain via comments*

