### PR TITLE
Use client time for updater

### DIFF
--- a/src/custom/state/gas/reducer.ts
+++ b/src/custom/state/gas/reducer.ts
@@ -13,7 +13,11 @@ export default createReducer(initialState, (builder) =>
     const { chainId, ...rest } = action.payload
 
     if (chainId) {
-      state[chainId] = rest
+      state[chainId] = {
+        ...rest,
+        // We don't use the last update of the endpoint, we use the one of the client time
+        lastUpdate: new Date().toISOString(),
+      }
     }
   })
 )


### PR DESCRIPTION
# Summary

Fix issue with infinite loop in Rikeby

![image](https://user-images.githubusercontent.com/2352112/134332718-ac7d575f-48e0-41d2-8b1b-abafce0ea6f5.png)


## Context
The issue is that the safe relay in Rinkeby fell out of sync. We were using their reported last update time in order to decide when we were re-checking.

This has two problems:
- As we saw, if the node is out of sync, we enter in an infinite loop
- The logic to decide to update compares to dates with different clocks. The server time and client time is not comparable, there could be a big difference making the loop to appear even if theres no a "out of sync" problem in the node.

This PR persist the client time instead of the server time, so then we will be comparing dates using the same clock

# To Test
- Verify all works as expected, specially there's no infinite loops!

1. <<Step one>> Open the page `about`
- [ ] <<What to expect?>> Verify it contains about information...
- [ ] Checkbox Style list of things a QA person could verify, i.e.
- [ ] Should display Text Input our storybook
- [ ] Input should not accept Numbers
2. <<Step two>> ...

  # Background

*Optional: Give background information for changes you've made, that might be difficult to explain via comments*

