### PR TITLE
[release/1.2] change profile to about link

### DIFF
--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -171,7 +171,7 @@ export default function Header() {
         </Title>
         <HeaderLinks>
           <StyledNavLink to="/swap">Swap</StyledNavLink>
-          <StyledNavLink to="/profile">Profile</StyledNavLink>
+          <StyledNavLink to="/about">About</StyledNavLink>
         </HeaderLinks>
       </HeaderRow>
       <HeaderControls>

--- a/src/custom/components/Menu/index.tsx
+++ b/src/custom/components/Menu/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Code, MessageCircle, HelpCircle, FileText, BookOpen, PieChart } from 'react-feather'
+import { Code, MessageCircle, HelpCircle, BookOpen, PieChart } from 'react-feather'
 
 import MenuMod, { MenuItem, InternalMenuItem, MenuFlyout as MenuFlyoutUni } from './MenuMod'
 import { useCloseModals } from 'state/application/hooks'
@@ -147,12 +147,6 @@ export function Menu() {
     <StyledMenu>
       <MenuFlyout>
         <CloseMenu onClick={close} />
-        <InternalMenuItem to="/about" onClick={close}>
-          <span aria-hidden="true" onClick={close} onKeyDown={close}>
-            <FileText size={14} />
-            About
-          </span>
-        </InternalMenuItem>
         <InternalMenuItem to="/faq" onClick={close}>
           <HelpCircle size={14} />
           FAQ


### PR DESCRIPTION
# Summary

Fixes #1427

Changes profile link to about link in header as it is in production currently

![Screenshot from 2021-09-22 14-39-41](https://user-images.githubusercontent.com/34926005/134345175-97343b8a-74d5-43b3-a13c-18feeaa165ae.png)

  # To Test

1. Go to generated link
2. Check if there is about link instead of profile link


