### PR TITLE
[1436] Divide by zero fix

### DIFF
--- a/src/custom/api/gnosisProtocol/errors/QuoteError.ts
+++ b/src/custom/api/gnosisProtocol/errors/QuoteError.ts
@@ -11,6 +11,7 @@ export enum GpQuoteErrorCodes {
   UnsupportedToken = 'UnsupportedToken',
   InsufficientLiquidity = 'InsufficientLiquidity',
   FeeExceedsFrom = 'FeeExceedsFrom',
+  ZeroPrice = 'ZeroPrice',
   UNHANDLED_ERROR = 'UNHANDLED_ERROR',
 }
 
@@ -18,6 +19,7 @@ export enum GpQuoteErrorDetails {
   UnsupportedToken = 'One of the tokens you are trading is unsupported. Please read the FAQ for more info.',
   InsufficientLiquidity = 'Token pair selected has insufficient liquidity',
   FeeExceedsFrom = 'Current fee exceeds entered "from" amount',
+  ZeroPrice = 'Quoted price is zero. This is likely due to a significant price difference between the two tokens. Please try increasing amounts.',
   UNHANDLED_ERROR = 'Quote fetch failed. This may be due to a server or network connectivity issue. Please try again later.',
 }
 

--- a/src/custom/hooks/useRefetchPriceCallback.tsx
+++ b/src/custom/hooks/useRefetchPriceCallback.tsx
@@ -2,7 +2,11 @@ import { useCallback } from 'react'
 
 import { FeeQuoteParams, getBestQuote, QuoteParams, QuoteResult } from 'utils/price'
 import { isValidOperatorError, ApiErrorCodes } from 'api/gnosisProtocol/errors/OperatorError'
-import { GpQuoteErrorCodes, isValidQuoteError } from 'api/gnosisProtocol/errors/QuoteError'
+import GpQuoteError, {
+  GpQuoteErrorCodes,
+  GpQuoteErrorDetails,
+  isValidQuoteError,
+} from 'api/gnosisProtocol/errors/QuoteError'
 import { registerOnWindow, getPromiseFulfilledValue, isPromiseFulfilled } from 'utils/misc'
 
 import { isOnline } from 'hooks/useIsOnline'
@@ -56,6 +60,10 @@ export function handleQuoteError({ quoteData, error, addUnsupportedToken }: Hand
       // e.g Insufficient Liquidity or Fee exceeds Price
       case GpQuoteErrorCodes.FeeExceedsFrom: {
         return 'fee-exceeds-sell-amount'
+      }
+
+      case GpQuoteErrorCodes.ZeroPrice: {
+        return 'zero-price'
       }
 
       case GpQuoteErrorCodes.InsufficientLiquidity: {
@@ -156,6 +164,14 @@ export function useRefetchQuoteCallback() {
         } else if (!isPromiseFulfilled(price)) {
           throw price.reason
         }
+
+        // we need to check if returned price is 0 - this is rare but can occur e.g DAI <> WBTC where price diff is huge
+        // TODO: check if this should be handled differently by backend - maybe we return a new error like "ZERO_PRICE"
+        if (price.value.amount === '0')
+          throw new GpQuoteError({
+            errorType: GpQuoteErrorCodes.ZeroPrice,
+            description: GpQuoteErrorDetails.ZeroPrice,
+          })
 
         const previouslyUnsupportedToken = isUnsupportedTokenGp(sellToken) || isUnsupportedTokenGp(buyToken)
         // can be a previously unsupported token which is now valid

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -743,6 +743,13 @@ export default function Swap({
                 </TYPE.main>
                 {/* {singleHopOnly && <TYPE.main mb="4px">Try enabling multi-hop trades.</TYPE.main>} */}
               </GreyCard>
+            ) : quote?.error === 'zero-price' ? (
+              <GreyCard style={{ textAlign: 'center' }}>
+                <TYPE.main mb="4px">
+                  <Trans>Invalid price. Try increasing input/output amount.</Trans>
+                </TYPE.main>
+                {/* {singleHopOnly && <TYPE.main mb="4px">Try enabling multi-hop trades.</TYPE.main>} */}
+              </GreyCard>
             ) : quote?.error === 'fetch-quote-error' ? (
               <GreyCard style={{ textAlign: 'center' }}>
                 <TYPE.main mb="4px">

--- a/src/custom/state/price/actions.ts
+++ b/src/custom/state/price/actions.ts
@@ -19,6 +19,7 @@ export type QuoteError =
   | 'fee-exceeds-sell-amount'
   | 'unsupported-token'
   | 'offline-browser'
+  | 'zero-price'
 
 export type SetQuoteErrorParams = UpdateQuoteParams & { error?: QuoteError }
 


### PR DESCRIPTION
# Summary

Closes #1436 - Fixes app not handling 0 price

*High-level description of what your changes are accomplishing*
GP backend sometimes returns a 0 price for pairs. In our case it's Rinkeby DAI <> WBTC when quoting an amount slightly higher than the fee.

With new error and message
![image](https://user-images.githubusercontent.com/21335563/134350182-247e7714-de07-44d1-b2fe-c883403d52ec.png)


  # To Test
1. select DAI as FROM
2. select WBTC as TO
3. RInkeby
4. input amt slightly higher than the fee
5. Should see the new error message and networks tab should show 0 price returned from backend request
6. increase amount and see it go away and check that price from networks tab isn't zero

