### PR TITLE
Pinata keys on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ env:
   REPO_NAME_SLUG: gpswapui
   PR_NUMBER: ${{ github.event.number }}
   REACT_APP_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+  REACT_APP_PINATA_API_KEY: ${{ secrets.REACT_APP_PINATA_API_KEY }}
+  REACT_APP_PINATA_SECRET_API_KEY: ${{ secrets.REACT_APP_PINATA_SECRET_API_KEY }}
 
 jobs:
   setup:

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -6,6 +6,8 @@ on:
 
 env:
   REPO_NAME_SLUG: gpswapui
+  REACT_APP_PINATA_API_KEY: ${{ secrets.REACT_APP_PINATA_API_KEY }}
+  REACT_APP_PINATA_SECRET_API_KEY: ${{ secrets.REACT_APP_PINATA_SECRET_API_KEY }}
 
 jobs:
   ipfs:


### PR DESCRIPTION
# Summary

Pinata API keys currently not available on CI builds:

`Error: No pinataApiKey provided! Please provide your pinata api key as an argument when you start this script`

Already on the repo secrets, exposing them as env vars.

Built on top of https://github.com/gnosis/cowswap/pull/1405. Necessary to test the whole flow.

  # To Test

1. Load and affiliate url, such as: `#/swap?referral=0x5B0ABE214aB7875562ADeE331dEfF0Fe1912FE42`
2. Connect wallet to mainnet
* IPFS upload should not fail
* You should see the following banner on top
![screenshot_2021-09-23_12-00-47](https://user-images.githubusercontent.com/43217/134567573-26be19d3-9f7c-44a4-a33f-3a4b8ab09c50.png)

  # Background

*Optional: Give background information for changes you've made, that might be difficult to explain via comments*

