### PR TITLE
[profile] Fix connect button in profile page

### DIFF
--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -14,7 +14,7 @@ import { useActiveWeb3React } from '@src/hooks/web3'
 import Copy from 'components/Copy/CopyMod'
 import { AccountDetailsProps } from 'components/AccountDetails'
 import { HelpCircle, RefreshCcw } from 'react-feather'
-import Web3Status from '@src/components/Web3Status'
+import Web3Status from 'components/Web3Status'
 
 export default function Profile({ ENSName }: AccountDetailsProps) {
   const today = new Date()
@@ -116,7 +116,7 @@ export default function Profile({ ENSName }: AccountDetailsProps) {
         </GridWrap>
         {!account && (
           <FlexWrap>
-            <Web3Status />
+            <Web3Status openOrdersPanel={(): void => console.log('TODO: Implement open orders panel')} />
           </FlexWrap>
         )}
       </GridWrap>


### PR DESCRIPTION
# Summary

This PR is to fix the connect button in profile page.

Before this PR:
![image](https://user-images.githubusercontent.com/2352112/134903061-fc27ff95-2f41-4b51-966c-577d4bfca43b.png)

After this PR: 
![image](https://user-images.githubusercontent.com/2352112/134904155-947caba2-bcf4-46ad-932a-edcc0d966c68.png)

See context:
https://github.com/gnosis/cowswap/pull/1376#pullrequestreview-764160417

Basically the issue is that we are not using the modified version of this component.

## Implementation notes
anxo: I just started the PR to point out the issue. However, this PR is not finished, and would love if someone in protofire could help. 

If you see the changes, you will see what needs to be done. Basically, we've made our modified version of Web3Status to receive a on open callback that is used [here]([isOrdersPanelOpen](https://github.com/gnosis/gp-swap-ui/blob/421ddfff71b47e51b16dae91b4453eea091d941f/src/custom/components/Header/index.tsx#L154-L154)) to add some class to the body

In this PR i believe we should remove this side effect from the header, and istead add  some global state for flagging when a modal is open, so we can add the `noScroll` class in a more central place.

Then the parameter with the callback won't be required anymore to use our modified `<Web3Status />`


# To Test
