### PR TITLE
[presign] Enhanced safe transactions

### DIFF
--- a/src/custom/api/gnosisSafe/index.ts
+++ b/src/custom/api/gnosisSafe/index.ts
@@ -8,6 +8,13 @@ const SAFE_TRANSACTION_SERVICE_URL: Partial<Record<number, string>> = {
   [ChainId.XDAI]: 'https://safe-transaction.xdai.gnosis.io',
 }
 
+const SAFE_WEB_URL: Partial<Record<number, string>> = {
+  [ChainId.MAINNET]: 'https://gnosis-safe.io',
+  [ChainId.RINKEBY]: 'https://rinkeby.gnosis-safe.io',
+  [ChainId.XDAI]: 'https://xdai.gnosis-safe.io',
+}
+//
+
 const SAFE_TRANSACTION_SERVICE_CACHE: Partial<Record<number, SafeServiceClient | null>> = {}
 
 function _getClient(chainId: number): SafeServiceClient | null {
@@ -34,6 +41,16 @@ function _getClientOrThrow(chainId: number): SafeServiceClient {
   }
 
   return client
+}
+
+export function getSafeWebUrl(chaindId: number, safeAddress: string): string | null {
+  const safeWebUrl = SAFE_WEB_URL[chaindId]
+
+  if (!safeWebUrl) {
+    return null
+  }
+
+  return `${safeWebUrl}/app/#/safes/${safeAddress}/transactions`
 }
 
 export function getSafeTransaction(chainId: number, safeTxHash: string): Promise<SafeMultisigTransactionResponse> {

--- a/src/custom/api/gnosisSafe/index.ts
+++ b/src/custom/api/gnosisSafe/index.ts
@@ -13,7 +13,6 @@ const SAFE_WEB_URL: Partial<Record<number, string>> = {
   [ChainId.RINKEBY]: 'https://rinkeby.gnosis-safe.io',
   [ChainId.XDAI]: 'https://xdai.gnosis-safe.io',
 }
-//
 
 const SAFE_TRANSACTION_SERVICE_CACHE: Partial<Record<number, SafeServiceClient | null>> = {}
 

--- a/src/custom/components/AccountDetails/Transaction/ActivityDetails.tsx
+++ b/src/custom/components/AccountDetails/Transaction/ActivityDetails.tsx
@@ -68,7 +68,7 @@ interface OrderSummaryType {
 
 export function ActivityDetails(props: { chainId: number; activityDerivedState: ActivityDerivedState }) {
   const { activityDerivedState } = props
-  const { id, isOrder, summary, order, enhancedTransaction, isCancelled, isExpired, isUnfillable } =
+  const { id, isOrder, summary, order, enhancedTransaction, isCancelled, isExpired, isUnfillable, gnosisSafeInfo } =
     activityDerivedState
 
   if (!order && !enhancedTransaction) return null
@@ -175,8 +175,11 @@ export function ActivityDetails(props: { chainId: number; activityDerivedState: 
           summary ?? id
         )}
         {/* TODO: Load gnosisSafeThreshold (not default!) */}
-        {enhancedTransaction && enhancedTransaction.safeTransaction && (
-          <GnosisSafeTxDetails enhancedTransaction={enhancedTransaction} gnosisSafeThreshold={2} />
+        {gnosisSafeInfo && enhancedTransaction && enhancedTransaction.safeTransaction && (
+          <GnosisSafeTxDetails
+            enhancedTransaction={enhancedTransaction}
+            gnosisSafeThreshold={gnosisSafeInfo.threshold}
+          />
         )}
       </SummaryInner>
     </Summary>

--- a/src/custom/components/AccountDetails/Transaction/ActivityDetails.tsx
+++ b/src/custom/components/AccountDetails/Transaction/ActivityDetails.tsx
@@ -1,0 +1,184 @@
+import React from 'react'
+import { CurrencyAmount } from '@uniswap/sdk-core'
+
+import { OrderStatus } from 'state/orders/actions'
+import { EnhancedTransactionDetails } from 'state/enhancedTransactions/reducer'
+
+import { formatSmart } from 'utils/format'
+import { Summary, SummaryInner, SummaryInnerRow, TransactionAlertMessage } from './styled'
+import { getLimitPrice, getExecutionPrice } from 'state/orders/utils'
+import { DEFAULT_PRECISION } from 'constants/index'
+import { ActivityDerivedState } from './index'
+
+const DEFAULT_ORDER_SUMMARY = {
+  from: '',
+  to: '',
+  limitPrice: '',
+  validTo: '',
+}
+
+function unfillableAlert(): JSX.Element {
+  return (
+    <>
+      <TransactionAlertMessage>
+        <p>
+          <span role="img" aria-label="alert">
+            🚨
+          </span>{' '}
+          Limit price out of range. Wait for a matching price or cancel your order.
+        </p>
+      </TransactionAlertMessage>
+    </>
+  )
+}
+
+function GnosisSafeTxDetails(props: {
+  enhancedTransaction: EnhancedTransactionDetails | null
+  gnosisSafeThreshold: number
+}): JSX.Element | null {
+  const { enhancedTransaction, gnosisSafeThreshold } = props
+
+  if (!enhancedTransaction || !enhancedTransaction.safeTransaction) {
+    return null
+  }
+
+  const { confirmations, nonce } = enhancedTransaction.safeTransaction
+  const numConfirmations = confirmations?.length ?? 0
+  const pendingSignatures = gnosisSafeThreshold - numConfirmations
+
+  return (
+    <>
+      <div>
+        Gnosis Safe transaction. Nonce: <strong>{nonce}</strong>
+      </div>
+      {pendingSignatures > 0 && <div>{pendingSignatures} more signatures are required</div>}
+    </>
+  )
+}
+
+interface OrderSummaryType {
+  from: string | undefined
+  to: string | undefined
+  limitPrice: string | undefined
+  executionPrice?: string | undefined
+  validTo: string | undefined
+  fulfillmentTime?: string | undefined
+  kind?: string
+}
+
+export function ActivityDetails(props: { chainId: number; activityDerivedState: ActivityDerivedState }) {
+  const { activityDerivedState } = props
+  const { id, isOrder, summary, order, enhancedTransaction, isCancelled, isExpired, isUnfillable } =
+    activityDerivedState
+
+  if (!order && !enhancedTransaction) return null
+
+  // Order Summary default object
+  let orderSummary: OrderSummaryType
+  if (order) {
+    const { inputToken, sellAmount, feeAmount, outputToken, buyAmount, validTo, kind, fulfillmentTime } = order
+
+    const sellAmt = CurrencyAmount.fromRawAmount(inputToken, sellAmount.toString())
+    const feeAmt = CurrencyAmount.fromRawAmount(inputToken, feeAmount.toString())
+    const outputAmount = CurrencyAmount.fromRawAmount(outputToken, buyAmount.toString())
+    const sellTokenDecimals = order?.inputToken?.decimals ?? DEFAULT_PRECISION
+    const buyTokenDecimals = order?.outputToken?.decimals ?? DEFAULT_PRECISION
+
+    const limitPrice = formatSmart(
+      getLimitPrice({
+        buyAmount: order.buyAmount.toString(),
+        sellAmount: order.sellAmount.toString(),
+        buyTokenDecimals,
+        sellTokenDecimals,
+        inverted: true, // TODO: handle invert price
+      })
+    )
+
+    let executionPrice: string | undefined
+    if (order.apiAdditionalInfo && order.status === OrderStatus.FULFILLED) {
+      const { executedSellAmountBeforeFees, executedBuyAmount } = order.apiAdditionalInfo
+      executionPrice = formatSmart(
+        getExecutionPrice({
+          executedSellAmountBeforeFees,
+          executedBuyAmount,
+          buyTokenDecimals,
+          sellTokenDecimals,
+          inverted: true, // TODO: Handle invert price
+        })
+      )
+    }
+
+    const getPriceFormat = (price: string): string => {
+      return `${price} ${sellAmt.currency.symbol} per ${outputAmount.currency.symbol}`
+    }
+
+    orderSummary = {
+      ...DEFAULT_ORDER_SUMMARY,
+      from: `${formatSmart(sellAmt.add(feeAmt))} ${sellAmt.currency.symbol}`,
+      to: `${formatSmart(outputAmount)} ${outputAmount.currency.symbol}`,
+      limitPrice: limitPrice && getPriceFormat(limitPrice),
+      executionPrice: executionPrice && getPriceFormat(executionPrice),
+      validTo: new Date((validTo as number) * 1000).toLocaleString(),
+      fulfillmentTime: fulfillmentTime ? new Date(fulfillmentTime).toLocaleString() : undefined,
+      kind: kind.toString(),
+    }
+  } else {
+    orderSummary = DEFAULT_ORDER_SUMMARY
+  }
+
+  const { kind, from, to, executionPrice, limitPrice, fulfillmentTime, validTo } = orderSummary
+  return (
+    <Summary>
+      <b>{isOrder ? `${kind} order` : 'Transaction'} ↗</b>
+      <SummaryInner>
+        {isOrder ? (
+          <>
+            <SummaryInnerRow>
+              <b>From{kind === 'buy' && ' at most'}</b>
+              <i>{from}</i>
+            </SummaryInnerRow>
+            <SummaryInnerRow>
+              <b>To{kind === 'sell' && ' at least'}</b>
+              <i>{to}</i>
+            </SummaryInnerRow>
+            <SummaryInnerRow>
+              {executionPrice ? (
+                <>
+                  {' '}
+                  <b>Exec. price</b>
+                  <i>{executionPrice}</i>
+                </>
+              ) : (
+                <>
+                  {' '}
+                  <b>Limit price</b>
+                  <i>{limitPrice}</i>
+                </>
+              )}
+            </SummaryInnerRow>
+            {isUnfillable && unfillableAlert()}
+            <SummaryInnerRow isCancelled={isCancelled} isExpired={isExpired}>
+              {fulfillmentTime ? (
+                <>
+                  <b>Filled on</b>
+                  <i>{fulfillmentTime}</i>
+                </>
+              ) : (
+                <>
+                  <b>Valid to</b>
+                  <i>{validTo}</i>
+                </>
+              )}
+            </SummaryInnerRow>
+          </>
+        ) : (
+          summary ?? id
+        )}
+        {/* TODO: Load gnosisSafeThreshold (not default!) */}
+        {enhancedTransaction && enhancedTransaction.safeTransaction && (
+          <GnosisSafeTxDetails enhancedTransaction={enhancedTransaction} gnosisSafeThreshold={2} />
+        )}
+      </SummaryInner>
+    </Summary>
+  )
+}

--- a/src/custom/components/AccountDetails/Transaction/CancelationModal.tsx
+++ b/src/custom/components/AccountDetails/Transaction/CancelationModal.tsx
@@ -1,0 +1,110 @@
+import React, { useCallback, useEffect, useState } from 'react'
+
+import { LinkStyledButton } from 'theme'
+
+import { useCancelOrder } from 'hooks/useCancelOrder'
+import { ButtonPrimary } from 'components/Button'
+import { GpModal as Modal } from 'components/Modal'
+import {
+  ConfirmationModalContent,
+  ConfirmationPendingContent,
+  TransactionErrorContent,
+} from 'components/TransactionConfirmationModal'
+import { CancellationSummary } from './styled'
+
+import { shortenOrderId } from 'utils'
+
+type RequestCancellationModalProps = {
+  onDismiss: () => void
+  onClick: () => void
+  summary?: string
+  shortId: string
+}
+
+function RequestCancellationModal(props: RequestCancellationModalProps): JSX.Element {
+  const { onDismiss, onClick, summary, shortId } = props
+
+  const [showMore, setShowMore] = useState(false)
+
+  const toggleShowMore = () => setShowMore((showMore) => !showMore)
+
+  return (
+    <ConfirmationModalContent
+      title={`Cancel order ${shortId}`}
+      onDismiss={onDismiss}
+      topContent={() => (
+        <>
+          <p>
+            Are you sure you want to cancel order <strong>{shortId}</strong>?
+          </p>
+          <CancellationSummary>{summary}</CancellationSummary>
+          <p>
+            Keep in mind this is a soft cancellation{' '}
+            <LinkStyledButton onClick={toggleShowMore}>[{showMore ? '- less' : '+ more'}]</LinkStyledButton>
+          </p>
+          {showMore && (
+            <>
+              <p>
+                This means that a solver might already have included the order in a solution even if this cancellation
+                is successful. Read more in the{' '}
+                <a target="_blank" href="/#/faq#can-i-cancel-an-order">
+                  FAQ
+                </a>
+                .
+              </p>
+            </>
+          )}
+        </>
+      )}
+      bottomContent={() => <ButtonPrimary onClick={onClick}>Request cancellation</ButtonPrimary>}
+    />
+  )
+}
+
+export type CancellationModalProps = {
+  onDismiss: () => void
+  isOpen: boolean
+  orderId: string
+  summary: string | undefined
+}
+
+export function CancellationModal(props: CancellationModalProps): JSX.Element | null {
+  const { orderId, isOpen, onDismiss, summary } = props
+  const shortId = shortenOrderId(orderId)
+
+  const [isWaitingSignature, setIsWaitingSignature] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const cancelOrder = useCancelOrder()
+
+  useEffect(() => {
+    // Reset status every time orderId changes to avoid race conditions
+    setIsWaitingSignature(false)
+    setError(null)
+  }, [orderId])
+
+  const onClick = useCallback(() => {
+    setIsWaitingSignature(true)
+    setError(null)
+
+    cancelOrder(orderId)
+      .then(onDismiss)
+      .catch((e) => {
+        setError(e.message)
+      })
+  }, [cancelOrder, onDismiss, orderId])
+
+  return (
+    <Modal isOpen={isOpen} onDismiss={onDismiss}>
+      {error !== null ? (
+        <TransactionErrorContent onDismiss={onDismiss} message={error || 'Failed to cancel order'} />
+      ) : isWaitingSignature ? (
+        <ConfirmationPendingContent
+          onDismiss={onDismiss}
+          pendingText={`Soft cancelling order with id ${shortId}\n\n${summary}`}
+        />
+      ) : (
+        <RequestCancellationModal onDismiss={onDismiss} onClick={onClick} summary={summary} shortId={shortId} />
+      )}
+    </Modal>
+  )
+}

--- a/src/custom/components/AccountDetails/Transaction/StateIcon.tsx
+++ b/src/custom/components/AccountDetails/Transaction/StateIcon.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+
+import Loader from 'components/Loader'
+import { IconWrapper } from '../TransactionMod'
+
+import SVG from 'react-inlinesvg'
+import TxArrowsImage from 'assets/cow-swap/transaction-arrows.svg'
+import TxCheckImage from 'assets/cow-swap/transaction-confirmed.svg'
+
+import { IconType } from './styled'
+import { ActivityDerivedState, determinePillColour } from '.'
+
+export function StateIcon(props: { activityDerivedState: ActivityDerivedState }) {
+  const { status, type, isPending, isCancelling, isConfirmed, isExpired, isCancelled, isPresignaturePending } =
+    props.activityDerivedState
+
+  return (
+    <IconType color={determinePillColour(status, type)}>
+      <IconWrapper pending={isPending || isCancelling} success={isConfirmed || isCancelled}>
+        {isPending || isPresignaturePending || isCancelling ? (
+          <Loader />
+        ) : isConfirmed ? (
+          <SVG src={TxCheckImage} description="Order Filled" />
+        ) : isExpired ? (
+          <SVG src={TxArrowsImage} description="Order Expired" />
+        ) : isCancelled ? (
+          <SVG src={TxArrowsImage} description="Order Cancelled" />
+        ) : (
+          <SVG src={TxArrowsImage} description="Order Open" />
+        )}
+      </IconWrapper>
+    </IconType>
+  )
+}

--- a/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
+++ b/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react'
+import { PenTool as PresignaturePendingImage } from 'react-feather'
+import SVG from 'react-inlinesvg'
+import { LinkStyledButton, ExternalLink } from 'theme'
+
+import OrderCheckImage from 'assets/cow-swap/order-check.svg'
+import OrderExpiredImage from 'assets/cow-swap/order-expired.svg'
+import OrderCancelledImage from 'assets/cow-swap/order-cancelled.svg'
+
+// import PresignaturePendingImage from 'assets/cow-swap/order-presignature-pending.svg'
+import OrderOpenImage from 'assets/cow-swap/order-open.svg'
+
+import { StatusLabel, StatusLabelWrapper, StatusLabelBelow } from './styled'
+import { ActivityDerivedState, determinePillColour } from './index'
+import { CancellationModal } from './CancelationModal'
+import { EnhancedTransactionDetails } from 'state/enhancedTransactions/reducer'
+import { getSafeWebUrl } from 'api/gnosisSafe'
+
+function GnosisSafeLink(props: {
+  chainId: number
+  enhancedTransaction: EnhancedTransactionDetails | null
+  gnosisSafeThreshold: number
+}): JSX.Element | null {
+  const { chainId, enhancedTransaction } = props
+
+  if (!enhancedTransaction || !enhancedTransaction.safeTransaction) {
+    return null
+  }
+
+  const { safe } = enhancedTransaction.safeTransaction
+  const safeUrl = getSafeWebUrl(chainId, safe)
+
+  if (safeUrl === null) {
+    return null
+  }
+
+  return <ExternalLink href={safeUrl}>View Gnosis Safe</ExternalLink>
+}
+
+export function StatusDetails(props: { chainId: number; activityDerivedState: ActivityDerivedState }) {
+  const { chainId, activityDerivedState } = props
+
+  const {
+    id,
+    status,
+    type,
+    summary,
+    enhancedTransaction,
+    isPending,
+    isCancelling,
+    isPresignaturePending,
+    isConfirmed,
+    isExpired,
+    isTransaction,
+    isCancelled,
+    isCancellable,
+  } = activityDerivedState
+
+  const [showCancelModal, setShowCancelModal] = useState(false)
+
+  const onCancelClick = () => setShowCancelModal(true)
+  const onDismiss = () => setShowCancelModal(false)
+
+  return (
+    <StatusLabelWrapper>
+      <StatusLabel
+        color={determinePillColour(status, type)}
+        isPending={isPending}
+        isCancelling={isCancelling}
+        isPresignaturePending={isPresignaturePending}
+      >
+        {isConfirmed && isTransaction ? (
+          <SVG src={OrderCheckImage} description="Transaction Confirmed" />
+        ) : isConfirmed ? (
+          <SVG src={OrderCheckImage} description="Order Filled" />
+        ) : isExpired && isTransaction ? (
+          <SVG src={OrderCancelledImage} description="Transaction Failed" />
+        ) : isExpired ? (
+          <SVG src={OrderExpiredImage} description="Order Expired" />
+        ) : isCancelled ? (
+          <SVG src={OrderCancelledImage} description="Order Cancelled" />
+        ) : isPresignaturePending ? (
+          // <SVG src={PresignaturePendingImage} description="Pending pre-signature" />
+          <PresignaturePendingImage size={16} />
+        ) : isCancelling ? null : (
+          <SVG src={OrderOpenImage} description="Order Open" />
+        )}
+        {isPending
+          ? 'Open'
+          : isConfirmed && isTransaction
+          ? 'Approved'
+          : isConfirmed
+          ? 'Filled'
+          : isExpired && isTransaction
+          ? 'Failed'
+          : isExpired
+          ? 'Expired'
+          : isCancelling
+          ? 'Cancelling...'
+          : isPresignaturePending
+          ? 'Pre-signing...'
+          : isCancelled
+          ? 'Cancelled'
+          : 'Open'}
+      </StatusLabel>
+
+      {/* Gnosis Safe Web Link (only shown when the transaction has been mined) */}
+      {enhancedTransaction && enhancedTransaction.safeTransaction && (
+        <StatusLabelBelow>
+          {/* View in: Gnosis Safe */}
+          {/* TODO: Load gnosisSafeThreshold (not default!) */}
+          <GnosisSafeLink chainId={chainId} enhancedTransaction={enhancedTransaction} gnosisSafeThreshold={2} />
+        </StatusLabelBelow>
+      )}
+
+      {isCancellable && (
+        <StatusLabelBelow>
+          {/* Cancel order */}
+          <LinkStyledButton onClick={onCancelClick}>Cancel order</LinkStyledButton>
+          {showCancelModal && (
+            <CancellationModal orderId={id} summary={summary} isOpen={showCancelModal} onDismiss={onDismiss} />
+          )}
+        </StatusLabelBelow>
+      )}
+    </StatusLabelWrapper>
+  )
+}

--- a/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
+++ b/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
@@ -56,6 +56,7 @@ export function StatusDetails(props: { chainId: number; activityDerivedState: Ac
     isTransaction,
     isCancelled,
     isCancellable,
+    gnosisSafeInfo,
   } = activityDerivedState
 
   const [showCancelModal, setShowCancelModal] = useState(false)
@@ -82,6 +83,7 @@ export function StatusDetails(props: { chainId: number; activityDerivedState: Ac
         ) : isCancelled ? (
           <SVG src={OrderCancelledImage} description="Order Cancelled" />
         ) : isPresignaturePending ? (
+          // TODO: Michel, is this image alright?
           // <SVG src={PresignaturePendingImage} description="Pending pre-signature" />
           <PresignaturePendingImage size={16} />
         ) : isCancelling ? null : (
@@ -107,11 +109,14 @@ export function StatusDetails(props: { chainId: number; activityDerivedState: Ac
       </StatusLabel>
 
       {/* Gnosis Safe Web Link (only shown when the transaction has been mined) */}
-      {enhancedTransaction && enhancedTransaction.safeTransaction && (
+      {gnosisSafeInfo && enhancedTransaction && enhancedTransaction.safeTransaction && (
         <StatusLabelBelow>
           {/* View in: Gnosis Safe */}
-          {/* TODO: Load gnosisSafeThreshold (not default!) */}
-          <GnosisSafeLink chainId={chainId} enhancedTransaction={enhancedTransaction} gnosisSafeThreshold={2} />
+          <GnosisSafeLink
+            chainId={chainId}
+            enhancedTransaction={enhancedTransaction}
+            gnosisSafeThreshold={gnosisSafeInfo.threshold}
+          />
         </StatusLabelBelow>
       )}
 

--- a/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
+++ b/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
@@ -27,10 +27,12 @@ function GnosisSafeLink(props: {
     return null
   }
 
-  const { safe } = enhancedTransaction.safeTransaction
+  const { safe, transactionHash } = enhancedTransaction.safeTransaction
   const safeUrl = getSafeWebUrl(chainId, safe)
 
-  if (safeUrl === null) {
+  // Only show the link to the safe, if we have the "safeUrl" and the Ethereum transaction is not available
+  // The reason we don't show it when the tx is not available, is because the main link will point to the Gnosis Safe already
+  if (safeUrl === null || !transactionHash) {
     return null
   }
 

--- a/src/custom/components/AccountDetails/Transaction/index.tsx
+++ b/src/custom/components/AccountDetails/Transaction/index.tsx
@@ -20,6 +20,7 @@ import { ActivityDetails } from './ActivityDetails'
 import { StatusDetails } from './StatusDetails'
 import { StateIcon } from './StateIcon'
 import { Order } from 'state/orders/actions'
+import { SafeInfoResponse } from '@gnosis.pm/safe-service-client'
 
 const PILL_COLOUR_MAP = {
   CONFIRMED: '#3B7848',
@@ -74,6 +75,9 @@ export interface ActivityDerivedState {
   // Possible activity types
   enhancedTransaction?: EnhancedTransactionDetails
   order?: Order
+
+  // Gnosis Safe
+  gnosisSafeInfo?: SafeInfoResponse
 }
 
 function getActivityLinkUrl(params: {
@@ -108,8 +112,9 @@ function getActivityDerivedState(props: {
   id: string
   activityData: ActivityDescriptors | null
   allowsOffchainSigning: boolean
+  gnosisSafeInfo?: SafeInfoResponse
 }): ActivityDerivedState | null {
-  const { chainId, id, activityData, allowsOffchainSigning } = props
+  const { chainId, id, activityData, allowsOffchainSigning, gnosisSafeInfo } = props
   if (activityData === null || chainId === undefined) {
     return null
   }
@@ -148,20 +153,23 @@ function getActivityDerivedState(props: {
     // Convenient casting
     order,
     enhancedTransaction,
+
+    // Gnosis Safe
+    gnosisSafeInfo,
   }
 }
 
 export default function Transaction({ hash: id }: { hash: string }) {
   const { chainId } = useActiveWeb3React()
-  const { allowsOffchainSigning } = useWalletInfo()
+  const { allowsOffchainSigning, gnosisSafeInfo } = useWalletInfo()
   // Return info necessary for rendering order/transaction info from the incoming id
   //    - activity data can be either EnhancedTransactionDetails or Order
   const activityData = useActivityDescriptors({ id, chainId })
 
   // Get some derived information about the activity. It helps to simplify the rendering of the sub-components
   const activityDerivedState = useMemo(
-    () => getActivityDerivedState({ chainId, id, activityData, allowsOffchainSigning }),
-    [chainId, id, activityData, allowsOffchainSigning]
+    () => getActivityDerivedState({ chainId, id, activityData, allowsOffchainSigning, gnosisSafeInfo }),
+    [chainId, id, activityData, allowsOffchainSigning, gnosisSafeInfo]
   )
 
   if (!activityDerivedState || !chainId) return null

--- a/src/custom/components/AccountDetails/Transaction/index.tsx
+++ b/src/custom/components/AccountDetails/Transaction/index.tsx
@@ -1,63 +1,25 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { CurrencyAmount } from '@uniswap/sdk-core'
+import React, { useMemo } from 'react'
 
 import { useActiveWeb3React } from 'hooks/web3'
-import { getEtherscanLink, shortenOrderId } from 'utils'
+import { getEtherscanLink } from 'utils'
 import { RowFixed } from 'components/Row'
-import Loader from 'components/Loader'
-import { IconWrapper } from '../TransactionMod'
-import {
-  ConfirmationModalContent,
-  ConfirmationPendingContent,
-  TransactionErrorContent,
-} from 'components/TransactionConfirmationModal'
 
-import { ActivityDescriptors, ActivityStatus, ActivityType, useActivityDescriptors } from 'hooks/useRecentActivity'
-import { useCancelOrder } from 'hooks/useCancelOrder'
-import { ExternalLink, LinkStyledButton } from 'theme'
-import { ButtonPrimary } from 'components/Button'
-import { GpModal as Modal } from 'components/Modal'
-import { Order, OrderStatus } from 'state/orders/actions'
-
-import SVG from 'react-inlinesvg'
-import TxArrowsImage from 'assets/cow-swap/transaction-arrows.svg'
-import TxCheckImage from 'assets/cow-swap/transaction-confirmed.svg'
-import OrderCheckImage from 'assets/cow-swap/order-check.svg'
-import OrderExpiredImage from 'assets/cow-swap/order-expired.svg'
-import OrderCancelledImage from 'assets/cow-swap/order-cancelled.svg'
-import { PenTool as PresignaturePendingImage } from 'react-feather'
-// import PresignaturePendingImage from 'assets/cow-swap/order-presignature-pending.svg'
-import OrderOpenImage from 'assets/cow-swap/order-open.svg'
-
-import { formatSmart } from 'utils/format'
 import {
   Wrapper,
-  Summary,
-  SummaryInner,
-  SummaryInnerRow,
   TransactionWrapper,
-  TransactionAlertMessage,
   TransactionStatusText as ActivityDetailsText,
-  StatusLabel,
-  StatusLabelWrapper,
-  StatusLabelBelow,
   TransactionState as ActivityLink,
-  CancellationSummary,
-  IconType,
 } from './styled'
-import { getLimitPrice, getExecutionPrice } from 'state/orders/utils'
-import { DEFAULT_PRECISION } from 'constants/index'
 import { useWalletInfo } from 'hooks/useWalletInfo'
 import { EnhancedTransactionDetails } from 'state/enhancedTransactions/reducer'
 import { getSafeWebUrl } from 'api/gnosisSafe'
 import { getExplorerOrderLink } from 'utils/explorer'
+import { useActivityDescriptors, ActivityStatus, ActivityType, ActivityDescriptors } from 'hooks/useRecentActivity'
 
-const DEFAULT_ORDER_SUMMARY = {
-  from: '',
-  to: '',
-  limitPrice: '',
-  validTo: '',
-}
+import { ActivityDetails } from './ActivityDetails'
+import { StatusDetails } from './StatusDetails'
+import { StateIcon } from './StateIcon'
+import { Order } from 'state/orders/actions'
 
 const PILL_COLOUR_MAP = {
   CONFIRMED: '#3B7848',
@@ -69,7 +31,7 @@ const PILL_COLOUR_MAP = {
   CANCELLING_ORDER: '#ED673A',
 }
 
-function determinePillColour(status: ActivityStatus, type: ActivityType) {
+export function determinePillColour(status: ActivityStatus, type: ActivityType) {
   const isOrder = type === ActivityType.ORDER
   switch (status) {
     case ActivityStatus.PENDING:
@@ -87,297 +49,15 @@ function determinePillColour(status: ActivityStatus, type: ActivityType) {
   }
 }
 
-interface OrderSummaryType {
-  from: string | undefined
-  to: string | undefined
-  limitPrice: string | undefined
-  executionPrice?: string | undefined
-  validTo: string | undefined
-  fulfillmentTime?: string | undefined
-  kind?: string
-}
-
-function ActivityDetails(props: { chainId: number; activityDerivedState: ActivityDerivedState }) {
-  const { activityDerivedState } = props
-  const { id, isOrder, summary, order, enhancedTransaction, isCancelled, isExpired, isUnfillable } =
-    activityDerivedState
-
-  if (!order && !enhancedTransaction) return null
-
-  // Order Summary default object
-  let orderSummary: OrderSummaryType
-  if (order) {
-    const { inputToken, sellAmount, feeAmount, outputToken, buyAmount, validTo, kind, fulfillmentTime } = order
-
-    const sellAmt = CurrencyAmount.fromRawAmount(inputToken, sellAmount.toString())
-    const feeAmt = CurrencyAmount.fromRawAmount(inputToken, feeAmount.toString())
-    const outputAmount = CurrencyAmount.fromRawAmount(outputToken, buyAmount.toString())
-    const sellTokenDecimals = order?.inputToken?.decimals ?? DEFAULT_PRECISION
-    const buyTokenDecimals = order?.outputToken?.decimals ?? DEFAULT_PRECISION
-
-    const limitPrice = formatSmart(
-      getLimitPrice({
-        buyAmount: order.buyAmount.toString(),
-        sellAmount: order.sellAmount.toString(),
-        buyTokenDecimals,
-        sellTokenDecimals,
-        inverted: true, // TODO: handle invert price
-      })
-    )
-
-    let executionPrice: string | undefined
-    if (order.apiAdditionalInfo && order.status === OrderStatus.FULFILLED) {
-      const { executedSellAmountBeforeFees, executedBuyAmount } = order.apiAdditionalInfo
-      executionPrice = formatSmart(
-        getExecutionPrice({
-          executedSellAmountBeforeFees,
-          executedBuyAmount,
-          buyTokenDecimals,
-          sellTokenDecimals,
-          inverted: true, // TODO: Handle invert price
-        })
-      )
-    }
-
-    const getPriceFormat = (price: string): string => {
-      return `${price} ${sellAmt.currency.symbol} per ${outputAmount.currency.symbol}`
-    }
-
-    orderSummary = {
-      ...DEFAULT_ORDER_SUMMARY,
-      from: `${formatSmart(sellAmt.add(feeAmt))} ${sellAmt.currency.symbol}`,
-      to: `${formatSmart(outputAmount)} ${outputAmount.currency.symbol}`,
-      limitPrice: limitPrice && getPriceFormat(limitPrice),
-      executionPrice: executionPrice && getPriceFormat(executionPrice),
-      validTo: new Date((validTo as number) * 1000).toLocaleString(),
-      fulfillmentTime: fulfillmentTime ? new Date(fulfillmentTime).toLocaleString() : undefined,
-      kind: kind.toString(),
-    }
-  } else {
-    orderSummary = DEFAULT_ORDER_SUMMARY
-  }
-
-  const { kind, from, to, executionPrice, limitPrice, fulfillmentTime, validTo } = orderSummary
-  return (
-    <Summary>
-      <b>{isOrder ? `${kind} order` : 'Transaction'} ↗</b>
-      <SummaryInner>
-        {isOrder ? (
-          <>
-            <SummaryInnerRow>
-              <b>From{kind === 'buy' && ' at most'}</b>
-              <i>{from}</i>
-            </SummaryInnerRow>
-            <SummaryInnerRow>
-              <b>To{kind === 'sell' && ' at least'}</b>
-              <i>{to}</i>
-            </SummaryInnerRow>
-            <SummaryInnerRow>
-              {executionPrice ? (
-                <>
-                  {' '}
-                  <b>Exec. price</b>
-                  <i>{executionPrice}</i>
-                </>
-              ) : (
-                <>
-                  {' '}
-                  <b>Limit price</b>
-                  <i>{limitPrice}</i>
-                </>
-              )}
-            </SummaryInnerRow>
-            {isUnfillable && unfillableAlert()}
-            <SummaryInnerRow isCancelled={isCancelled} isExpired={isExpired}>
-              {fulfillmentTime ? (
-                <>
-                  <b>Filled on</b>
-                  <i>{fulfillmentTime}</i>
-                </>
-              ) : (
-                <>
-                  <b>Valid to</b>
-                  <i>{validTo}</i>
-                </>
-              )}
-            </SummaryInnerRow>
-          </>
-        ) : (
-          summary ?? id
-        )}
-        {/* TODO: Load gnosisSafeThreshold (not default!) */}
-        {enhancedTransaction && enhancedTransaction.safeTransaction && (
-          <GnosisSafeTxDetails enhancedTransaction={enhancedTransaction} gnosisSafeThreshold={2} />
-        )}
-      </SummaryInner>
-    </Summary>
-  )
-}
-
-type RequestCancellationModalProps = {
-  onDismiss: () => void
-  onClick: () => void
-  summary?: string
-  shortId: string
-}
-
-function RequestCancellationModal(props: RequestCancellationModalProps): JSX.Element {
-  const { onDismiss, onClick, summary, shortId } = props
-
-  const [showMore, setShowMore] = useState(false)
-
-  const toggleShowMore = () => setShowMore((showMore) => !showMore)
-
-  return (
-    <ConfirmationModalContent
-      title={`Cancel order ${shortId}`}
-      onDismiss={onDismiss}
-      topContent={() => (
-        <>
-          <p>
-            Are you sure you want to cancel order <strong>{shortId}</strong>?
-          </p>
-          <CancellationSummary>{summary}</CancellationSummary>
-          <p>
-            Keep in mind this is a soft cancellation{' '}
-            <LinkStyledButton onClick={toggleShowMore}>[{showMore ? '- less' : '+ more'}]</LinkStyledButton>
-          </p>
-          {showMore && (
-            <>
-              <p>
-                This means that a solver might already have included the order in a solution even if this cancellation
-                is successful. Read more in the{' '}
-                <a target="_blank" href="/#/faq#can-i-cancel-an-order">
-                  FAQ
-                </a>
-                .
-              </p>
-            </>
-          )}
-        </>
-      )}
-      bottomContent={() => <ButtonPrimary onClick={onClick}>Request cancellation</ButtonPrimary>}
-    />
-  )
-}
-
-type CancellationModalProps = {
-  onDismiss: () => void
-  isOpen: boolean
-  orderId: string
-  summary: string | undefined
-}
-
-function CancellationModal(props: CancellationModalProps): JSX.Element | null {
-  const { orderId, isOpen, onDismiss, summary } = props
-  const shortId = shortenOrderId(orderId)
-
-  const [isWaitingSignature, setIsWaitingSignature] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const cancelOrder = useCancelOrder()
-
-  useEffect(() => {
-    // Reset status every time orderId changes to avoid race conditions
-    setIsWaitingSignature(false)
-    setError(null)
-  }, [orderId])
-
-  const onClick = useCallback(() => {
-    setIsWaitingSignature(true)
-    setError(null)
-
-    cancelOrder(orderId)
-      .then(onDismiss)
-      .catch((e) => {
-        setError(e.message)
-      })
-  }, [cancelOrder, onDismiss, orderId])
-
-  return (
-    <Modal isOpen={isOpen} onDismiss={onDismiss}>
-      {error !== null ? (
-        <TransactionErrorContent onDismiss={onDismiss} message={error || 'Failed to cancel order'} />
-      ) : isWaitingSignature ? (
-        <ConfirmationPendingContent
-          onDismiss={onDismiss}
-          pendingText={`Soft cancelling order with id ${shortId}\n\n${summary}`}
-        />
-      ) : (
-        <RequestCancellationModal onDismiss={onDismiss} onClick={onClick} summary={summary} shortId={shortId} />
-      )}
-    </Modal>
-  )
-}
-
-function unfillableAlert(): JSX.Element {
-  return (
-    <>
-      <TransactionAlertMessage>
-        <p>
-          <span role="img" aria-label="alert">
-            🚨
-          </span>{' '}
-          Limit price out of range. Wait for a matching price or cancel your order.
-        </p>
-      </TransactionAlertMessage>
-    </>
-  )
-}
-
-function GnosisSafeTxDetails(props: {
-  enhancedTransaction: EnhancedTransactionDetails | null
-  gnosisSafeThreshold: number
-}): JSX.Element | null {
-  const { enhancedTransaction, gnosisSafeThreshold } = props
-
-  if (!enhancedTransaction || !enhancedTransaction.safeTransaction) {
-    return null
-  }
-
-  const { confirmations, nonce } = enhancedTransaction.safeTransaction
-  const numConfirmations = confirmations?.length ?? 0
-  const pendingSignatures = gnosisSafeThreshold - numConfirmations
-
-  return (
-    <>
-      <div>
-        Gnosis Safe transaction. Nonce: <strong>{nonce}</strong>
-      </div>
-      {pendingSignatures > 0 && <div>{pendingSignatures} more signatures are required</div>}
-    </>
-  )
-}
-
-function GnosisSafeLink(props: {
-  chainId: number
-  enhancedTransaction: EnhancedTransactionDetails | null
-  gnosisSafeThreshold: number
-}): JSX.Element | null {
-  const { chainId, enhancedTransaction } = props
-
-  if (!enhancedTransaction || !enhancedTransaction.safeTransaction) {
-    return null
-  }
-
-  const { safe } = enhancedTransaction.safeTransaction
-  const safeUrl = getSafeWebUrl(chainId, safe)
-
-  if (safeUrl === null) {
-    return null
-  }
-
-  return <ExternalLink href={safeUrl}>View Gnosis Safe</ExternalLink>
-}
-
 /**
  * Object derived from the activity state
  */
-interface ActivityDerivedState {
+export interface ActivityDerivedState {
   id: string
   status: ActivityStatus
   type: ActivityType
   summary?: string
-  activityLink?: string
+  activityLinkUrl?: string
 
   // Convenient flags
   isTransaction: boolean
@@ -396,119 +76,7 @@ interface ActivityDerivedState {
   order?: Order
 }
 
-function StateIcon(props: { activityDerivedState: ActivityDerivedState }) {
-  const { status, type, isPending, isCancelling, isConfirmed, isExpired, isCancelled, isPresignaturePending } =
-    props.activityDerivedState
-
-  return (
-    <IconType color={determinePillColour(status, type)}>
-      <IconWrapper pending={isPending || isCancelling} success={isConfirmed || isCancelled}>
-        {isPending || isPresignaturePending || isCancelling ? (
-          <Loader />
-        ) : isConfirmed ? (
-          <SVG src={TxCheckImage} description="Order Filled" />
-        ) : isExpired ? (
-          <SVG src={TxArrowsImage} description="Order Expired" />
-        ) : isCancelled ? (
-          <SVG src={TxArrowsImage} description="Order Cancelled" />
-        ) : (
-          <SVG src={TxArrowsImage} description="Order Open" />
-        )}
-      </IconWrapper>
-    </IconType>
-  )
-}
-
-function StatusDetails(props: { chainId: number; activityDerivedState: ActivityDerivedState }) {
-  const { chainId, activityDerivedState } = props
-
-  const {
-    id,
-    status,
-    type,
-    summary,
-    enhancedTransaction,
-    isPending,
-    isCancelling,
-    isPresignaturePending,
-    isConfirmed,
-    isExpired,
-    isTransaction,
-    isCancelled,
-    isCancellable,
-  } = activityDerivedState
-
-  const [showCancelModal, setShowCancelModal] = useState(false)
-
-  const onCancelClick = () => setShowCancelModal(true)
-  const onDismiss = () => setShowCancelModal(false)
-
-  return (
-    <StatusLabelWrapper>
-      <StatusLabel
-        color={determinePillColour(status, type)}
-        isPending={isPending}
-        isCancelling={isCancelling}
-        isPresignaturePending={isPresignaturePending}
-      >
-        {isConfirmed && isTransaction ? (
-          <SVG src={OrderCheckImage} description="Transaction Confirmed" />
-        ) : isConfirmed ? (
-          <SVG src={OrderCheckImage} description="Order Filled" />
-        ) : isExpired && isTransaction ? (
-          <SVG src={OrderCancelledImage} description="Transaction Failed" />
-        ) : isExpired ? (
-          <SVG src={OrderExpiredImage} description="Order Expired" />
-        ) : isCancelled ? (
-          <SVG src={OrderCancelledImage} description="Order Cancelled" />
-        ) : isPresignaturePending ? (
-          // <SVG src={PresignaturePendingImage} description="Pending pre-signature" />
-          <PresignaturePendingImage size={16} />
-        ) : isCancelling ? null : (
-          <SVG src={OrderOpenImage} description="Order Open" />
-        )}
-        {isPending
-          ? 'Open'
-          : isConfirmed && isTransaction
-          ? 'Approved'
-          : isConfirmed
-          ? 'Filled'
-          : isExpired && isTransaction
-          ? 'Failed'
-          : isExpired
-          ? 'Expired'
-          : isCancelling
-          ? 'Cancelling...'
-          : isPresignaturePending
-          ? 'Pre-signing...'
-          : isCancelled
-          ? 'Cancelled'
-          : 'Open'}
-      </StatusLabel>
-
-      {/* Gnosis Safe Web Link (only shown when the transaction has been mined) */}
-      {enhancedTransaction && enhancedTransaction.safeTransaction && (
-        <StatusLabelBelow>
-          {/* View in: Gnosis Safe */}
-          {/* TODO: Load gnosisSafeThreshold (not default!) */}
-          <GnosisSafeLink chainId={chainId} enhancedTransaction={enhancedTransaction} gnosisSafeThreshold={2} />
-        </StatusLabelBelow>
-      )}
-
-      {isCancellable && (
-        <StatusLabelBelow>
-          {/* Cancel order */}
-          <LinkStyledButton onClick={onCancelClick}>Cancel order</LinkStyledButton>
-          {showCancelModal && (
-            <CancellationModal orderId={id} summary={summary} isOpen={showCancelModal} onDismiss={onDismiss} />
-          )}
-        </StatusLabelBelow>
-      )}
-    </StatusLabelWrapper>
-  )
-}
-
-function getActivityLink(params: {
+function getActivityLinkUrl(params: {
   chainId: number
   id: string
   enhancedTransaction?: EnhancedTransactionDetails
@@ -556,14 +124,14 @@ function getActivityDerivedState(props: {
   const isPending = status === ActivityStatus.PENDING
   const isCancellable = allowsOffchainSigning && isPending && isOrder
 
-  const activityLink = getActivityLink({ id, chainId, enhancedTransaction, order })
+  const activityLinkUrl = getActivityLinkUrl({ id, chainId, enhancedTransaction, order })
 
   return {
     id,
     status,
     type,
     summary,
-    activityLink,
+    activityLinkUrl,
 
     // Convenient flags
     isTransaction,
@@ -596,16 +164,14 @@ export default function Transaction({ hash: id }: { hash: string }) {
     [chainId, id, activityData, allowsOffchainSigning]
   )
 
-  console.log('activityDerivedState', activityDerivedState)
-
   if (!activityDerivedState || !chainId) return null
-  const { activityLink } = activityDerivedState
-  const hasLink = activityLink !== null
+  const { activityLinkUrl } = activityDerivedState
+  const hasLink = activityLinkUrl !== null
 
   return (
     <Wrapper>
       <TransactionWrapper>
-        <ActivityLink href={activityLink ?? undefined} disableMouseActions={!hasLink}>
+        <ActivityLink href={activityLinkUrl ?? undefined} disableMouseActions={!hasLink}>
           <RowFixed>
             {/* Icon state: confirmed, expired, canceled, pending, ...  */}
             {activityData?.activity && <StateIcon activityDerivedState={activityDerivedState} />}

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -97,7 +97,7 @@ export default function useRecentActivity() {
   }, [recentOrdersAdjusted, recentTransactionsAdjusted])
 }
 
-interface ActivityDescriptors {
+export interface ActivityDescriptors {
   activity: EnhancedTransactionDetails | Order
   summary?: string
   status: ActivityStatus

--- a/src/custom/state/enhancedTransactions/reducer.ts
+++ b/src/custom/state/enhancedTransactions/reducer.ts
@@ -70,6 +70,7 @@ export default createReducer(initialState, (builder) =>
         const txs = transactions[chainId] ?? {}
         txs[hash] = {
           hash,
+          transactionHash: hashType === HashType.ETHEREUM_TX ? hash : undefined,
           hashType,
           addedTime: now(),
           from,
@@ -103,6 +104,7 @@ export default createReducer(initialState, (builder) =>
         return
       }
       tx.receipt = receipt
+      // tx.transactionHash = receipt.transactionHash
       tx.confirmedTime = now()
     })
 

--- a/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
+++ b/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
@@ -164,10 +164,36 @@ function checkEthereumTransactions(params: CheckEthereumTransactions): Cancel[] 
 
       return cancel
     } else if (hashType === HashType.GNOSIS_SAFE_TX) {
-      // Get receipt for transaction, and finalize if needed
-      const { promise, cancel } = getSafeInfo(hash)
-      promise
-        .then((safeTransaction) => {
+      // Get safe info and receipt
+      const { promise: safeTransactionPromise, cancel } = getSafeInfo(hash)
+
+      // Get safe info
+      safeTransactionPromise
+        .then(async (safeTransaction) => {
+          const { isExecuted, transactionHash } = safeTransaction
+
+          // If the safe transaction is executed, but we don't have a tx receipt yet
+          if (isExecuted && !receipt) {
+            // Get the ethereum tx receipt
+            console.log(
+              '[FinalizeTxUpdater] Safe transaction is executed, but we have not fetched the receipt yet. Tx: ',
+              transactionHash
+            )
+            // Get the transaction receipt
+            const { promise: receiptPromise } = getReceipt(transactionHash)
+
+            receiptPromise
+              .then((newReceipt) => finalizeEthereumTransaction(newReceipt, transaction, params))
+              .catch((error) => {
+                if (!error.isCancelledError) {
+                  console.error(
+                    `[FinalizeTxUpdater] Failed to get transaction receipt for safeTransaction: ${hash}`,
+                    error
+                  )
+                }
+              })
+          }
+
           dispatch(updateSafeTransaction({ chainId, safeTransaction, blockNumber: lastBlockNumber }))
         })
         .catch((error) => {

--- a/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
+++ b/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
@@ -103,27 +103,7 @@ function checkEthereumTransactions(params: CheckEthereumTransactions): Cancel[] 
   const promiseCancellations = transactions.map((transaction) => {
     const { hash, hashType, receipt } = transaction
 
-    if (hashType === HashType.ETHEREUM_TX) {
-      // Get receipt for transaction, and finalize if needed
-      const { promise, cancel } = getReceipt(hash)
-      promise
-        .then((receipt) => {
-          if (receipt) {
-            // If the tx is mined. We finalize it!
-            finalizeEthereumTransaction(receipt, transaction, params)
-          } else {
-            // Update the last checked blockNumber
-            dispatch(checkedTransaction({ chainId, hash, blockNumber: lastBlockNumber }))
-          }
-        })
-        .catch((error) => {
-          if (!error.isCancelledError) {
-            console.error(`[FinalizeTxUpdater] Failed to get transaction receipt for tx: ${hash}`, error)
-          }
-        })
-
-      return cancel
-    } else if (hashType === HashType.GNOSIS_SAFE_TX) {
+    if (hashType === HashType.GNOSIS_SAFE_TX) {
       // Get safe info and receipt
       const { promise: safeTransactionPromise, cancel } = getSafeInfo(hash)
 
@@ -204,7 +184,25 @@ function checkEthereumTransactions(params: CheckEthereumTransactions): Cancel[] 
 
       return cancel
     } else {
-      throw new Error('[FinalizeTxUpdater] Unknown HashType: ' + hashType)
+      // Get receipt for transaction, and finalize if needed
+      const { promise, cancel } = getReceipt(hash)
+      promise
+        .then((receipt) => {
+          if (receipt) {
+            // If the tx is mined. We finalize it!
+            finalizeEthereumTransaction(receipt, transaction, params)
+          } else {
+            // Update the last checked blockNumber
+            dispatch(checkedTransaction({ chainId, hash, blockNumber: lastBlockNumber }))
+          }
+        })
+        .catch((error) => {
+          if (!error.isCancelledError) {
+            console.error(`[FinalizeTxUpdater] Failed to get transaction receipt for tx: ${hash}`, error)
+          }
+        })
+
+      return cancel
     }
   })
 

--- a/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
+++ b/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
@@ -163,6 +163,20 @@ function checkEthereumTransactions(params: CheckEthereumTransactions): Cancel[] 
         })
 
       return cancel
+    } else if (hashType === HashType.GNOSIS_SAFE_TX) {
+      // Get receipt for transaction, and finalize if needed
+      const { promise, cancel } = getSafeInfo(hash)
+      promise
+        .then((safeTransaction) => {
+          dispatch(updateSafeTransaction({ chainId, safeTransaction, blockNumber: lastBlockNumber }))
+        })
+        .catch((error) => {
+          if (!error.isCancelledError) {
+            console.error(`[FinalizeTxUpdater] Failed to check transaction hash: ${hash}`, error)
+          }
+        })
+
+      return cancel
     } else {
       throw new Error('[FinalizeTxUpdater] Unknown HashType: ' + hashType)
     }

--- a/src/custom/state/orders/hooks.ts
+++ b/src/custom/state/orders/hooks.ts
@@ -1,5 +1,5 @@
 import { SupportedChainId as ChainId } from 'constants/chains'
-import { useCallback, useMemo, useRef } from 'react'
+import { MutableRefObject, useCallback, useMemo, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { AppDispatch, AppState } from 'state'
@@ -121,7 +121,9 @@ export const useOrder = ({ id, chainId }: Partial<GetRemoveOrderParams>): Order 
   return useSelector<AppState, Order | undefined>((state) => {
     if (!id || !chainId) return undefined
 
-    const orders = state.orders[chainId]
+    const ordersState = state.orders[chainId]
+    const orders = { ...ORDERS_LIST, ...ordersState }
+
     const serialisedOrder =
       orders?.fulfilled[id] ||
       orders?.pending[id] ||
@@ -132,6 +134,14 @@ export const useOrder = ({ id, chainId }: Partial<GetRemoveOrderParams>): Order 
     return _deserializeOrder(serialisedOrder)
   })
 }
+
+// function getDeserializedOrder(id: string, state: MutableRefObject<OrderStateNetwork>) {
+//   const orders = { ...ORDERS_LIST, ...state.current }
+
+//   const serialisedOrderObject = orders.fulfilled[id] || orders.pending[id] || orders.expired[id] || orders.cancelled[id]
+
+//   return _deserializeOrder(serialisedOrderObject)
+// }
 
 // used to extract Order.summary before showing popup
 // TODO: put the whole logic inside Popup middleware

--- a/src/custom/state/orders/hooks.ts
+++ b/src/custom/state/orders/hooks.ts
@@ -1,5 +1,5 @@
 import { SupportedChainId as ChainId } from 'constants/chains'
-import { MutableRefOct, useCallback, useMemo, useRef } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { AppDispatch, AppState } from 'state'

--- a/src/custom/state/orders/hooks.ts
+++ b/src/custom/state/orders/hooks.ts
@@ -154,13 +154,6 @@ function useOrdersStateNetwork(chainId: ChainId | undefined): OrdersStateNetwork
   })
 }
 
-// function getDeserializedOrder(id: string, state: MutableRefObject<OrderStateNetwork>) {
-//   const orders = { ...ORDERS_LIST, ...state.current }
-
-//   const serialisedOrderObject = orders.fulfilled[id] || orders.pending[id] || orders.expired[id] || orders.cancelled[id]
-
-//   return _deserializeOrder(serialisedOrderObject)
-// }
 
 // used to extract Order.summary before showing popup
 // TODO: put the whole logic inside Popup middleware

--- a/src/custom/state/orders/hooks.ts
+++ b/src/custom/state/orders/hooks.ts
@@ -198,7 +198,7 @@ export const usePendingOrders = ({ chainId }: GetOrdersParams): Order[] => {
         return
       }
 
-      return { pending: ordersState.pending, presignaturePending: ordersState.presignaturePending }
+      return { pending: ordersState.pending || {}, presignaturePending: ordersState.presignaturePending || {} }
       // return chainId && state.orders?.[chainId]?.pending
     }
   )

--- a/src/custom/state/orders/hooks.ts
+++ b/src/custom/state/orders/hooks.ts
@@ -1,5 +1,5 @@
 import { SupportedChainId as ChainId } from 'constants/chains'
-import { MutableRefObject, useCallback, useMemo, useRef } from 'react'
+import { MutableRefOct, useCallback, useMemo, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { AppDispatch, AppState } from 'state'
@@ -146,7 +146,13 @@ export const useOrder = ({ id, chainId }: Partial<GetRemoveOrderParams>): Order 
 // used to extract Order.summary before showing popup
 // TODO: put the whole logic inside Popup middleware
 export const useFindOrderById = ({ chainId }: GetOrdersParams): GetOrderByIdCallback => {
-  const state = useSelector<AppState, OrdersState[ChainId] | undefined>((state) => chainId && state.orders?.[chainId])
+  const state = useSelector<AppState, OrdersState[ChainId] | undefined>((state) => {
+    if (!chainId) {
+      return undefined
+    }
+    const ordersState = state.orders?.[chainId] || {}
+    return { ...ORDERS_LIST, ...ordersState }
+  })
 
   // stable ref, so we don't recreate the function
   const stateRef = useRef(state)

--- a/src/custom/state/orders/hooks.ts
+++ b/src/custom/state/orders/hooks.ts
@@ -22,7 +22,7 @@ import {
   SetIsOrderUnfillableParams,
   preSignOrders,
 } from './actions'
-import { OrderObject, OrdersState, PartialOrdersMap, V2OrderObject } from './reducer'
+import { OrderObject, OrdersState, ORDERS_LIST, PartialOrdersMap, V2OrderObject } from './reducer'
 import { isTruthy } from 'utils/misc'
 import { OrderID } from 'api/gnosisProtocol'
 import { ContractDeploymentBlocks } from './consts'
@@ -148,11 +148,10 @@ export const useFindOrderById = ({ chainId }: GetOrdersParams): GetOrderByIdCall
     (id: OrderID) => {
       if (!chainId || !stateRef.current) return
 
+      const orders = { ...ORDERS_LIST, ...stateRef.current }
+
       const serialisedOrderObject =
-        stateRef.current.fulfilled[id] ||
-        stateRef.current.pending[id] ||
-        stateRef.current.expired[id] ||
-        stateRef.current.cancelled[id]
+        orders.fulfilled[id] || orders.pending[id] || orders.expired[id] || orders.cancelled[id]
 
       return _deserializeOrder(serialisedOrderObject)
     },

--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -37,22 +37,27 @@ export interface OrderObject {
 type OrdersMap = Record<OrderID, OrderObject>
 export type PartialOrdersMap = Partial<OrdersMap>
 
+type OrderStateNetwork = {
+  pending: PartialOrdersMap
+  presignaturePending: PartialOrdersMap
+  fulfilled: PartialOrdersMap
+  expired: PartialOrdersMap
+  cancelled: PartialOrdersMap
+  lastCheckedBlock: number
+}
+
 export type OrdersState = {
-  readonly [chainId in ChainId]?: {
-    pending: PartialOrdersMap
-    presignaturePending: PartialOrdersMap
-    fulfilled: PartialOrdersMap
-    expired: PartialOrdersMap
-    cancelled: PartialOrdersMap
-    lastCheckedBlock: number
-  }
+  readonly [chainId in ChainId]?: OrderStateNetwork
 }
 
 export interface PrefillStateRequired {
   chainId: ChainId
 }
 
-export const ORDERS_LIST = {
+export const ORDERS_LIST: Pick<
+  OrderStateNetwork,
+  'pending' | 'presignaturePending' | 'fulfilled' | 'expired' | 'cancelled'
+> = {
   pending: {},
   presignaturePending: {},
   fulfilled: {},
@@ -79,6 +84,13 @@ function prefillState(
     }
     return
   }
+
+  // Object.keys(ORDERS_LIST).forEach((key) => {
+  //   const orderList = stateAtChainId[key]
+  //   if (!orderList) {
+  //     stateAtChainId[key] = ORDERS_LIST[key]
+  //   }
+  // })
 
   Object.assign(stateAtChainId, ORDERS_LIST)
 

--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -52,6 +52,18 @@ export interface PrefillStateRequired {
   chainId: ChainId
 }
 
+export const ORDERS_LIST = {
+  pending: {},
+  presignaturePending: {},
+  fulfilled: {},
+  expired: {},
+  cancelled: {},
+}
+
+function getDefaultLastCheckedBlock(chainId: ChainId): number {
+  return ContractDeploymentBlocks[chainId] ?? 0
+}
+
 // makes sure there's always an object at state[chainId], state[chainId].pending | .fulfilled
 function prefillState(
   state: Writable<OrdersState>,
@@ -62,38 +74,16 @@ function prefillState(
 
   if (!stateAtChainId) {
     state[chainId] = {
-      pending: {},
-      presignaturePending: {},
-      fulfilled: {},
-      expired: {},
-      cancelled: {},
-      lastCheckedBlock: ContractDeploymentBlocks[chainId] ?? 0,
+      ...ORDERS_LIST,
+      lastCheckedBlock: getDefaultLastCheckedBlock(chainId),
     }
     return
   }
 
-  if (!stateAtChainId.pending) {
-    stateAtChainId.pending = {}
-  }
-
-  if (!stateAtChainId.fulfilled) {
-    stateAtChainId.fulfilled = {}
-  }
-
-  if (!stateAtChainId.presignaturePending) {
-    stateAtChainId.presignaturePending = {}
-  }
-
-  if (!stateAtChainId.expired) {
-    stateAtChainId.expired = {}
-  }
-
-  if (!stateAtChainId.cancelled) {
-    stateAtChainId.cancelled = {}
-  }
+  Object.assign(stateAtChainId, ORDERS_LIST)
 
   if (stateAtChainId.lastCheckedBlock === undefined) {
-    stateAtChainId.lastCheckedBlock = ContractDeploymentBlocks[chainId] ?? 0
+    stateAtChainId.lastCheckedBlock = getDefaultLastCheckedBlock(chainId)
   }
 }
 
@@ -272,11 +262,7 @@ export default createReducer(initialState, (builder) =>
       const lastCheckedBlock = state[chainId]?.lastCheckedBlock
 
       state[chainId] = {
-        pending: {},
-        presignaturePending: {},
-        fulfilled: {},
-        expired: {},
-        cancelled: {},
+        ...ORDERS_LIST,
         lastCheckedBlock: lastCheckedBlock ?? ContractDeploymentBlocks[chainId] ?? 0,
       }
     })


### PR DESCRIPTION
# Summary

This PR adds some context for Gnosis Safe transactions.

* It will show when the transaction is a Gnosis Safe, it will show also the nonce so you can identify it within the safe
* While the tx has some pending signers, it will show how many signatures are left
* It includes a smart link 

The smart link is basically, that before transactions would take you always to Etherscan. Now, they will take you to:
* Etherscan for non safe tx
* Gnosis Safe Web for safe tx that are not mined
* Etherscan for safe tx that are mined

When the transaction is mined for a  Gnosis Safe tx, it will additionally show a link to Gnosis Safe Web, so the user will have the option to click in the tx to see it in Etherscan, or click in the link and see it in Gnosis Safe.

This PR applies only to transactions, not to orders.

Example of waiting for signatures safe tx:
![image](https://user-images.githubusercontent.com/2352112/135160669-d9007848-e2c6-450d-b9e2-49dbc6b1f121.png)

Example of mined gnosis safe tx:
<img width="687" alt="Screenshot at Sep 28 20-33-30" src="https://user-images.githubusercontent.com/2352112/135160704-bc49cb6a-740a-4cb4-b7b0-b7efdb6f5417.png">


Additionally, this PR does also a big refactor in the transaction component to break it into more manageable pieces.

## Not included
Please, don't focus the review on the design. @biocom will probably want to reiterate. This is basically setting the grounds so we can shape it in the future as we please.

Doesn't include any change for orders. If we do something for orders workflow, it will be in a future PR.

Doesn't solve two issues (they were already in the base branch) and will be address separatelly:
* Unwrap doesn't work: https://github.com/gnosis/cowswap/issues/1469
* Reject using Wallet Connect is not working


## Notes to the reviewer


This is a rather big PR in terms of changes, but I think with a few hints, it should be easier to review.

### Partition into components
The transaction was a monolithic component that was handling the orders and transactions that we represent in the side panel.




This PR needed to add a few elements to this representation to handle Gnosis Safe transactions, there fore, it was going to increase it's complexity. 

I took this chance to break the component into smaller parts. Basically 3 main parts:
![image](https://user-images.githubusercontent.com/2352112/135158949-ce2ef516-715b-46e5-966a-c345ff1a49c7.png)

These tree parts are easy to spot in the way smaller component that render activities:
![image](https://user-images.githubusercontent.com/2352112/135159117-262efc95-e81f-42bc-8a82-d0c5b7383d03.png)

This partition was done also into different files, so now all components are in a manageable size file:
![image](https://user-images.githubusercontent.com/2352112/135158401-774b37c7-a2ea-4a16-820c-945304f00dd3.png)

### ActivityDerivedState
This is a object that is constructed with some data related to the activity. Is derived data meant to simplify tendering all the components.

The creation of this object is done using an aux function `getActivityDerivedState` and it's result  is memoized.


# To Test

1. Create transactions (approve/wrap) using EOA
2. Create transactions (approve/wrap) using Gnosis Sage

For both cases, observe all the states the transaction transitions. Test the links.

Known issues that won't be solved in this PR: 
* Unwrap doesn't work: https://github.com/gnosis/cowswap/issues/1469
* Reject using Wallet Connect is not working
* Also be aware of the "Not Included: section
