### PR TITLE
Only use default precision on formatMax when decimals is null|undefined

### DIFF
--- a/src/custom/utils/format.ts
+++ b/src/custom/utils/format.ts
@@ -154,7 +154,7 @@ export function formatMax(value?: Fraction, decimals?: number): string | undefin
   if (!value) {
     return
   }
-  let amount = value.toFixed(decimals || LONG_PRECISION)
+  let amount = value.toFixed(decimals ?? LONG_PRECISION)
 
   if (+amount === 0) {
     amount = value.toSignificant(1)


### PR DESCRIPTION
# Summary

Closes #1491 

Fix hard error when token has `0` decimals

# To Test

1. On mainnet, load the token `0x61CEAc48136d6782DBD83c09f51E23514D12470a` (or any token with 0 decimals)
2. Pick any other token and fill in the input
* The UI should NOT crash

# Background

Even though we can now load the token properly, there's no liquidity available for `Subs` while testing

Another 0 decimals token that has liquidity and can be tested with is `CHI` (https://etherscan.io/token/0x0000000000004946c0e9F43F4Dee607b0eF1fA1c)

