### PR TITLE
[Uni merge] Set xdai provider library polling at 1ms

### DIFF
--- a/src/custom/utils/getLibrary.ts
+++ b/src/custom/utils/getLibrary.ts
@@ -1,13 +1,14 @@
 import { Web3Provider } from '@ethersproject/providers'
-// import ms from 'ms.macro'
-// import { SupportedChainId } from '../constants/chains'
+import ms from 'ms.macro'
+import { SupportedChainId } from 'constants/chains'
 
-/* const NETWORK_POLLING_INTERVALS: { [chainId: number]: number } = {
-  [SupportedChainId.ARBITRUM_ONE]: ms`1s`,
-  [SupportedChainId.ARBITRUM_RINKEBY]: ms`1s`,
-  [SupportedChainId.OPTIMISM]: ms`1s`,
-  [SupportedChainId.OPTIMISTIC_KOVAN]: ms`1s`,
-} */
+const NETWORK_POLLING_INTERVALS: { [chainId: number]: number } = {
+  // [SupportedChainId.ARBITRUM_ONE]: ms`1s`,
+  // [SupportedChainId.ARBITRUM_RINKEBY]: ms`1s`,
+  // [SupportedChainId.OPTIMISM]: ms`1s`,
+  // [SupportedChainId.OPTIMISTIC_KOVAN]: ms`1s`,
+  [SupportedChainId.XDAI]: ms`1s`,
+}
 
 export default function getLibrary(provider: any): Web3Provider {
   const library = new Web3Provider(
@@ -19,12 +20,12 @@ export default function getLibrary(provider: any): Web3Provider {
       : 'any'
   )
   library.pollingInterval = 15_000
-  /* library.detectNetwork().then((network) => {
+  library.detectNetwork().then((network) => {
     const networkPollingInterval = NETWORK_POLLING_INTERVALS[network.chainId]
     if (networkPollingInterval) {
       console.debug('Setting polling interval', networkPollingInterval)
       library.pollingInterval = networkPollingInterval
     }
-  }) */
+  })
   return library
 }


### PR DESCRIPTION
# Summary
Uni in 4.13 set a polling time for other network providers. Added Xdai to this list and is polled at 1ms. Should help with getting faster response times on switch (balances etc)

# To Test

1. go to mainnet
2. switch to xdai
3. check console for "Setting polling interval"
4. check balances loading
