### PR TITLE
Presign/enhanced safe transactions styles 4 grouping activities

### DIFF
--- a/src/components/AccountDetails/index.tsx
+++ b/src/components/AccountDetails/index.tsx
@@ -6,7 +6,7 @@ import { shortenAddress } from 'utils'
 import { ExplorerDataType, getExplorerLink } from 'utils/getExplorerLink'
 import { AutoRow } from '../Row'
 import Copy from 'components/Copy'
-import Transaction from './Transaction'
+import Transaction from '@src/components/AccountDetails/Transaction'
 
 import { SUPPORTED_WALLETS } from 'constants/index'
 import { ReactComponent as Close } from '../../assets/images/x.svg'

--- a/src/components/AccountDetails/index.tsx
+++ b/src/components/AccountDetails/index.tsx
@@ -6,7 +6,7 @@ import { shortenAddress } from 'utils'
 import { ExplorerDataType, getExplorerLink } from 'utils/getExplorerLink'
 import { AutoRow } from '../Row'
 import Copy from 'components/Copy'
-import Transaction from 'components/AccountDetails/Transaction'
+import Transaction from './Transaction'
 
 import { SUPPORTED_WALLETS } from 'constants/index'
 import { ReactComponent as Close } from '../../assets/images/x.svg'

--- a/src/custom/components/AccountDetails/AccountDetailsMod.tsx
+++ b/src/custom/components/AccountDetails/AccountDetailsMod.tsx
@@ -6,7 +6,7 @@ import styled /* , { ThemeContext } */ from 'styled-components'
 // import { ExplorerDataType, getExplorerLink } from 'utils/getExplorerLink'
 // import { AutoRow } from 'components/Row'
 // import Copy from 'components/AccountDetails/Copy'
-import Transaction from 'components/AccountDetails/Transaction'
+import Activity from 'components/AccountDetails/Transaction'
 
 // import { SUPPORTED_WALLETS } from 'constants/index'
 import { ReactComponent as Close } from 'assets/images/x.svg'
@@ -20,6 +20,7 @@ import { ReactComponent as Close } from 'assets/images/x.svg'
 import { ButtonSecondary } from 'components/Button'
 // import { ExternalLink as LinkIcon } from 'react-feather'
 import { ExternalLink /* , LinkStyledButton, TYPE */ } from 'theme'
+import { ActivityDescriptors } from 'hooks/useRecentActivity'
 // import { Trans } from '@lingui/macro'
 // import { useAppDispatch } from 'state/hooks'
 
@@ -206,11 +207,11 @@ export const MainWalletAction = styled(WalletAction)`
   color: ${({ theme }) => theme.primary1};
 `
 
-export function renderTransactions(transactions: string[]) {
+export function renderActivities(activities: ActivityDescriptors[]) {
   return (
     <TransactionListWrapper>
-      {transactions.map((hash, i) => {
-        return <Transaction key={i} hash={hash} />
+      {activities.map((activity, i) => {
+        return <Activity key={i} activity={activity} />
       })}
     </TransactionListWrapper>
   )
@@ -224,7 +225,7 @@ export function renderTransactions(transactions: string[]) {
 //   openOptions: () => void
 // }
 
-/* 
+/*
 export default function AccountDetails({
   toggleWalletModal,
   pendingTransactions,
@@ -294,7 +295,7 @@ export default function AccountDetails({
       )
     }
     return null
-  } 
+  }
 
   const clearAllTransactionsCallback = useCallback(() => {
     if (chainId) dispatch(clearAllTransactions({ chainId }))

--- a/src/custom/components/AccountDetails/AccountDetailsMod.tsx
+++ b/src/custom/components/AccountDetails/AccountDetailsMod.tsx
@@ -210,8 +210,8 @@ export const MainWalletAction = styled(WalletAction)`
 export function renderActivities(activities: ActivityDescriptors[]) {
   return (
     <TransactionListWrapper>
-      {activities.map((activity, i) => {
-        return <Activity key={i} activity={activity} />
+      {activities.map((activity) => {
+        return <Activity key={activity.id} activity={activity} />
       })}
     </TransactionListWrapper>
   )

--- a/src/custom/components/AccountDetails/Transaction/index.tsx
+++ b/src/custom/components/AccountDetails/Transaction/index.tsx
@@ -159,9 +159,6 @@ function getActivityDerivedState(props: {
 export default function Activity({ activity: activityData }: { activity: ActivityDescriptors }) {
   const { chainId } = useActiveWeb3React()
   const { allowsOffchainSigning, gnosisSafeInfo } = useWalletInfo()
-  // Return info necessary for rendering order/transaction info from the incoming id
-  //    - activity data can be either EnhancedTransactionDetails or Order
-  // const activityData = useSingleActivityDescriptor({ id, chainId })
 
   // Get some derived information about the activity. It helps to simplify the rendering of the sub-components
   const activityDerivedState = useMemo(
@@ -181,23 +178,15 @@ export default function Activity({ activity: activityData }: { activity: Activit
     ? new Date(Date.parse(creationTimeOrder))
     : undefined
 
-  // const timeFormatOptionMDY: Intl.DateTimeFormatOptions = {
-  //   dateStyle: 'long',
-  // }
-
   const timeFormatOptionHM: Intl.DateTimeFormatOptions = {
     timeStyle: 'short',
   }
-
-  // Month Day, Year
-  // const creationTimeMDY = creationTimeFull?.toLocaleString(undefined, timeFormatOptionMDY)
 
   // Hour:Minute
   const creationTime = creationTimeFull?.toLocaleString(undefined, timeFormatOptionHM)
 
   return (
     <Wrapper>
-      {/*{creationTimeMDY && <CreationDateText>{creationTimeMDY}</CreationDateText>}*/}
       <TransactionWrapper>
         <RowFixed>
           {/* Icon state: confirmed, expired, canceled, pending, ...  */}

--- a/src/custom/components/AccountDetails/Transaction/index.tsx
+++ b/src/custom/components/AccountDetails/Transaction/index.tsx
@@ -4,12 +4,12 @@ import { useActiveWeb3React } from 'hooks/web3'
 import { getEtherscanLink } from 'utils'
 import { RowFixed } from 'components/Row'
 
-import { Wrapper, TransactionWrapper, TransactionStatusText as ActivityDetailsText, CreationDateText } from './styled'
+import { TransactionStatusText as ActivityDetailsText, TransactionWrapper, Wrapper } from './styled'
 import { useWalletInfo } from 'hooks/useWalletInfo'
 import { EnhancedTransactionDetails } from 'state/enhancedTransactions/reducer'
 import { getSafeWebUrl } from 'api/gnosisSafe'
 import { getExplorerOrderLink } from 'utils/explorer'
-import { useActivityDescriptors, ActivityStatus, ActivityType, ActivityDescriptors } from 'hooks/useRecentActivity'
+import { ActivityDescriptors, ActivityStatus, ActivityType } from 'hooks/useRecentActivity'
 
 import { ActivityDetails } from './ActivityDetails'
 
@@ -157,12 +157,16 @@ function getActivityDerivedState(props: {
   }
 }
 
-export default function Transaction({ hash: id }: { hash: string }) {
+export default function Activity({ activity: activityData }: { activity: ActivityDescriptors }) {
+  const { activity, type } = activityData
+  // TODO: this is messy, clean it up
+  const id = type === ActivityType.ORDER ? (activity as Order).id : (activity as EnhancedTransactionDetails).hash
+
   const { chainId } = useActiveWeb3React()
   const { allowsOffchainSigning, gnosisSafeInfo } = useWalletInfo()
   // Return info necessary for rendering order/transaction info from the incoming id
   //    - activity data can be either EnhancedTransactionDetails or Order
-  const activityData = useActivityDescriptors({ id, chainId })
+  // const activityData = useSingleActivityDescriptor({ id, chainId })
 
   // Get some derived information about the activity. It helps to simplify the rendering of the sub-components
   const activityDerivedState = useMemo(
@@ -182,23 +186,23 @@ export default function Transaction({ hash: id }: { hash: string }) {
     ? new Date(Date.parse(creationTimeOrder))
     : undefined
 
-  const timeFormatOptionMDY: Intl.DateTimeFormatOptions = {
-    dateStyle: 'long',
-  }
+  // const timeFormatOptionMDY: Intl.DateTimeFormatOptions = {
+  //   dateStyle: 'long',
+  // }
 
   const timeFormatOptionHM: Intl.DateTimeFormatOptions = {
     timeStyle: 'short',
   }
 
   // Month Day, Year
-  const creationTimeMDY = creationTimeFull?.toLocaleString(undefined, timeFormatOptionMDY)
+  // const creationTimeMDY = creationTimeFull?.toLocaleString(undefined, timeFormatOptionMDY)
 
   // Hour:Minute
   const creationTime = creationTimeFull?.toLocaleString(undefined, timeFormatOptionHM)
 
   return (
     <Wrapper>
-      {creationTimeMDY && <CreationDateText>{creationTimeMDY}</CreationDateText>}
+      {/*{creationTimeMDY && <CreationDateText>{creationTimeMDY}</CreationDateText>}*/}
       <TransactionWrapper>
         <RowFixed>
           {/* Icon state: confirmed, expired, canceled, pending, ...  */}

--- a/src/custom/components/AccountDetails/Transaction/index.tsx
+++ b/src/custom/components/AccountDetails/Transaction/index.tsx
@@ -107,17 +107,16 @@ function getActivityLinkUrl(params: {
 
 function getActivityDerivedState(props: {
   chainId?: number
-  id: string
   activityData: ActivityDescriptors | null
   allowsOffchainSigning: boolean
   gnosisSafeInfo?: SafeInfoResponse
 }): ActivityDerivedState | null {
-  const { chainId, id, activityData, allowsOffchainSigning, gnosisSafeInfo } = props
+  const { chainId, activityData, allowsOffchainSigning, gnosisSafeInfo } = props
   if (activityData === null || chainId === undefined) {
     return null
   }
 
-  const { activity, status, type, summary } = activityData
+  const { id, activity, status, type, summary } = activityData
   const isTransaction = type === ActivityType.TX
   const isOrder = type === ActivityType.ORDER
   const order = isOrder ? (activity as Order) : undefined
@@ -158,10 +157,6 @@ function getActivityDerivedState(props: {
 }
 
 export default function Activity({ activity: activityData }: { activity: ActivityDescriptors }) {
-  const { activity, type } = activityData
-  // TODO: this is messy, clean it up
-  const id = type === ActivityType.ORDER ? (activity as Order).id : (activity as EnhancedTransactionDetails).hash
-
   const { chainId } = useActiveWeb3React()
   const { allowsOffchainSigning, gnosisSafeInfo } = useWalletInfo()
   // Return info necessary for rendering order/transaction info from the incoming id
@@ -170,8 +165,8 @@ export default function Activity({ activity: activityData }: { activity: Activit
 
   // Get some derived information about the activity. It helps to simplify the rendering of the sub-components
   const activityDerivedState = useMemo(
-    () => getActivityDerivedState({ chainId, id, activityData, allowsOffchainSigning, gnosisSafeInfo }),
-    [chainId, id, activityData, allowsOffchainSigning, gnosisSafeInfo]
+    () => getActivityDerivedState({ chainId, activityData, allowsOffchainSigning, gnosisSafeInfo }),
+    [chainId, activityData, allowsOffchainSigning, gnosisSafeInfo]
   )
 
   if (!activityDerivedState || !chainId) return null

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, Fragment } from 'react'
 import { batch, useDispatch } from 'react-redux'
 
 import { useActiveWeb3React } from 'hooks/web3'
@@ -263,11 +263,11 @@ export default function AccountDetails({
           <div>
             {activitiesGroupedByDate.map(({ date, activities }) => {
               return (
-                <>
+                <Fragment key={date.getTime()}>
                   {/* TODO: style me! */}
                   <h3>{date.toString()}</h3>
                   {renderActivities(activities)}
-                </>
+                </Fragment>
               )
             })}
           </div>

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -138,8 +138,8 @@ interface AccountDetailsProps {
 }
 
 export default function AccountDetails({
-  pendingTransactions,
-  confirmedTransactions,
+  pendingTransactions = [],
+  confirmedTransactions = [],
   ENSName,
   toggleWalletModal,
   closeOrdersPanel,
@@ -160,11 +160,9 @@ export default function AccountDetails({
   }, [dispatch, chainId])
   const explorerLabel = chainId && account ? getExplorerLabel(chainId, account, 'address') : undefined
 
-  const activities = useMultipleActivityDescriptors({
-    chainId,
-    ids: (pendingTransactions || []).concat(confirmedTransactions || []),
-  })
-  const activitiesGroupedByDate = groupActivitiesByDay(activities || [])
+  const activities =
+    useMultipleActivityDescriptors({ chainId, ids: pendingTransactions.concat(confirmedTransactions) }) || []
+  const activitiesGroupedByDate = groupActivitiesByDay(activities)
   const activityTotalCount = activities?.length || 0
 
   const handleDisconnectClick = () => {

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -128,6 +128,34 @@ export function getStatusIcon(connector?: AbstractConnector, walletInfo?: Connec
   return null
 }
 
+type ActivitiesGroupedByDate = {
+  date: Date
+  activities: ActivityDescriptors[]
+}[]
+
+function groupActivitiesByDay(activities: ActivityDescriptors[]): ActivitiesGroupedByDate {
+  const mapByTimestamp: { [timestamp: number]: ActivityDescriptors[] } = {}
+
+  activities.forEach((activity) => {
+    const { date } = activity
+    // get timestamp of the day, drop hours, minutes and seconds
+    const timestamp = new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime()
+
+    mapByTimestamp[timestamp] = (mapByTimestamp[timestamp] || []).concat(activity)
+  })
+
+  return (
+    Object.keys(mapByTimestamp)
+      .map(Number) // Keys are always string, convert back to number
+      // .sort((a, b) => b - a) // Should be sorted already I guess, but just in case
+      .reduce<ActivitiesGroupedByDate>((acc, timestamp) => {
+        // For easier handling later, transform into a list of objects with nested lists
+        acc.push({ date: new Date(timestamp), activities: mapByTimestamp[timestamp] })
+        return acc
+      }, [])
+  )
+}
+
 interface AccountDetailsProps {
   pendingTransactions: string[]
   confirmedTransactions: string[]

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -134,13 +134,21 @@ type ActivitiesGroupedByDate = {
   activities: ActivityDescriptors[]
 }[]
 
+/**
+ * Given a Date obj, remove hours, minutes and seconds, and return the timestamp of it
+ * @param date
+ */
+function getDateTimestamp(date: Date): number {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime()
+}
+
 function groupActivitiesByDay(activities: ActivityDescriptors[]): ActivitiesGroupedByDate {
   const mapByTimestamp: { [timestamp: number]: ActivityDescriptors[] } = {}
 
   activities.forEach((activity) => {
     const { date } = activity
-    // get timestamp of the day, drop hours, minutes and seconds
-    const timestamp = new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime()
+
+    const timestamp = getDateTimestamp(date)
 
     mapByTimestamp[timestamp] = (mapByTimestamp[timestamp] || []).concat(activity)
   })

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -153,16 +153,12 @@ function groupActivitiesByDay(activities: ActivityDescriptors[]): ActivitiesGrou
     mapByTimestamp[timestamp] = (mapByTimestamp[timestamp] || []).concat(activity)
   })
 
-  return (
-    Object.keys(mapByTimestamp)
-      .map(Number) // Keys are always string, convert back to number
-      // .sort((a, b) => b - a) // Should be sorted already I guess, but just in case
-      .reduce<ActivitiesGroupedByDate>((acc, timestamp) => {
-        // For easier handling later, transform into a list of objects with nested lists
-        acc.push({ date: new Date(timestamp), activities: mapByTimestamp[timestamp] })
-        return acc
-      }, [])
-  )
+  return Object.keys(mapByTimestamp).map((strTimestamp) => {
+    // Keys are always string, convert back to number
+    const timestamp = Number(strTimestamp)
+    // For easier handling later, transform into a list of objects with nested lists
+    return { date: new Date(timestamp), activities: mapByTimestamp[timestamp] }
+  })
 }
 
 interface AccountDetailsProps {

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -231,15 +231,13 @@ export default function AccountDetails({
           </span>
 
           <div>
-            {activitiesGroupedByDate.map(({ date, activities }) => {
-              return (
-                <Fragment key={date.getTime()}>
-                  {/* TODO: style me! */}
-                  <h3>{date.toString()}</h3>
-                  {renderActivities(activities)}
-                </Fragment>
-              )
-            })}
+            {activitiesGroupedByDate.map(({ date, activities }) => (
+              <Fragment key={date.getTime()}>
+                {/* TODO: style me! */}
+                <h3>{date.toString()}</h3>
+                {renderActivities(activities)}
+              </Fragment>
+            ))}
           </div>
         </LowerSection>
       ) : (

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -43,7 +43,7 @@ import {
 import { ConnectedWalletInfo, useWalletInfo } from 'hooks/useWalletInfo'
 import { MouseoverTooltip } from 'components/Tooltip'
 import { supportedChainId } from 'utils/supportedChainId'
-import { ActivityDescriptors, useMultipleActivityDescriptors } from 'hooks/useRecentActivity'
+import { ActivityDescriptors, groupActivitiesByDay, useMultipleActivityDescriptors } from 'hooks/useRecentActivity'
 
 type AbstractConnector = Pick<ReturnType<typeof useActiveWeb3React>, 'connector'>['connector']
 
@@ -127,38 +127,6 @@ export function getStatusIcon(connector?: AbstractConnector, walletInfo?: Connec
     )
   }
   return null
-}
-
-type ActivitiesGroupedByDate = {
-  date: Date
-  activities: ActivityDescriptors[]
-}[]
-
-/**
- * Given a Date obj, remove hours, minutes and seconds, and return the timestamp of it
- * @param date
- */
-function getDateTimestamp(date: Date): number {
-  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime()
-}
-
-function groupActivitiesByDay(activities: ActivityDescriptors[]): ActivitiesGroupedByDate {
-  const mapByTimestamp: { [timestamp: number]: ActivityDescriptors[] } = {}
-
-  activities.forEach((activity) => {
-    const { date } = activity
-
-    const timestamp = getDateTimestamp(date)
-
-    mapByTimestamp[timestamp] = (mapByTimestamp[timestamp] || []).concat(activity)
-  })
-
-  return Object.keys(mapByTimestamp).map((strTimestamp) => {
-    // Keys are always string, convert back to number
-    const timestamp = Number(strTimestamp)
-    // For easier handling later, transform into a list of objects with nested lists
-    return { date: new Date(timestamp), activities: mapByTimestamp[timestamp] }
-  })
 }
 
 interface AccountDetailsProps {

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -27,7 +27,7 @@ import {
   AccountControl,
   AddressLink,
   IconWrapper,
-  renderTransactions,
+  renderActivities,
 } from './AccountDetailsMod'
 import {
   NetworkCard,
@@ -43,6 +43,7 @@ import {
 import { ConnectedWalletInfo, useWalletInfo } from 'hooks/useWalletInfo'
 import { MouseoverTooltip } from 'components/Tooltip'
 import { supportedChainId } from 'utils/supportedChainId'
+import { ActivityDescriptors, useMultipleActivityDescriptors } from 'hooks/useRecentActivity'
 
 type AbstractConnector = Pick<ReturnType<typeof useActiveWeb3React>, 'connector'>['connector']
 
@@ -186,7 +187,16 @@ export default function AccountDetails({
     }
   }, [dispatch, chainId])
   const explorerLabel = chainId && account ? getExplorerLabel(chainId, account, 'address') : undefined
-  const activityTotalCount = (pendingTransactions?.length || 0) + (confirmedTransactions?.length || 0)
+
+  // TODO: for now I'm merging both Pending and Confirmed activities
+  // TODO: if you wan to show them separately just call this hook once with each list
+  const activities = useMultipleActivityDescriptors({
+    chainId,
+    ids: (pendingTransactions || []).concat(confirmedTransactions || []),
+  })
+  // TODO: and also group them separately
+  const activitiesGroupedByDate = groupActivitiesByDay(activities || [])
+  const activityTotalCount = activities?.length || 0
 
   const handleDisconnectClick = () => {
     ;(connector as any).close()
@@ -254,8 +264,17 @@ export default function AccountDetails({
           </span>
 
           <div>
-            {renderTransactions(pendingTransactions)}
-            {renderTransactions(confirmedTransactions)}
+            {activitiesGroupedByDate.map(({ date, activities }) => {
+              return (
+                <>
+                  {/* TODO: style me! */}
+                  <h3>{date.toString()}</h3>
+                  {renderActivities(activities)}
+                </>
+              )
+            })}
+            {/*{renderTransactions(pendingTransactions)}*/}
+            {/*{renderTransactions(confirmedTransactions)}*/}
           </div>
         </LowerSection>
       ) : (

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -188,13 +188,10 @@ export default function AccountDetails({
   }, [dispatch, chainId])
   const explorerLabel = chainId && account ? getExplorerLabel(chainId, account, 'address') : undefined
 
-  // TODO: for now I'm merging both Pending and Confirmed activities
-  // TODO: if you wan to show them separately just call this hook once with each list
   const activities = useMultipleActivityDescriptors({
     chainId,
     ids: (pendingTransactions || []).concat(confirmedTransactions || []),
   })
-  // TODO: and also group them separately
   const activitiesGroupedByDate = groupActivitiesByDay(activities || [])
   const activityTotalCount = activities?.length || 0
 
@@ -273,8 +270,6 @@ export default function AccountDetails({
                 </>
               )
             })}
-            {/*{renderTransactions(pendingTransactions)}*/}
-            {/*{renderTransactions(confirmedTransactions)}*/}
           </div>
         </LowerSection>
       ) : (

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -43,7 +43,12 @@ import {
 import { ConnectedWalletInfo, useWalletInfo } from 'hooks/useWalletInfo'
 import { MouseoverTooltip } from 'components/Tooltip'
 import { supportedChainId } from 'utils/supportedChainId'
-import { ActivityDescriptors, groupActivitiesByDay, useMultipleActivityDescriptors } from 'hooks/useRecentActivity'
+import { groupActivitiesByDay, useMultipleActivityDescriptors } from 'hooks/useRecentActivity'
+import { CreationDateText } from 'components/AccountDetails/Transaction/styled'
+
+const DATE_FORMAT_OPTION: Intl.DateTimeFormatOptions = {
+  dateStyle: 'long',
+}
 
 type AbstractConnector = Pick<ReturnType<typeof useActiveWeb3React>, 'connector'>['connector']
 
@@ -234,7 +239,7 @@ export default function AccountDetails({
             {activitiesGroupedByDate.map(({ date, activities }) => (
               <Fragment key={date.getTime()}>
                 {/* TODO: style me! */}
-                <h3>{date.toString()}</h3>
+                <CreationDateText>{date.toLocaleString(undefined, DATE_FORMAT_OPTION)}</CreationDateText>
                 {renderActivities(activities)}
               </Fragment>
             ))}

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -40,7 +40,9 @@ const DAY_MS = 86_400_000
  * @param order
  */
 function isOrderRecent(order: Order): boolean {
-  return Date.now() - Date.parse(order.creationTime) < DAY_MS
+  // TODO: TEMPORARY CHANGE TO SEE HISTORY FOR 10 INSTEAD OF 1 DAY
+  // TODO: will become obsolete with the api orders stuff
+  return Date.now() - Date.parse(order.creationTime) < DAY_MS * 10
 }
 
 /**

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
-import { isTransactionRecent, useAllTransactions } from 'state/enhancedTransactions/hooks'
-import { useOrder, useOrders } from 'state/orders/hooks'
+import { isTransactionRecent, useAllTransactions, useTransactionsByHash } from 'state/enhancedTransactions/hooks'
+import { useOrder, useOrders, useOrdersById } from 'state/orders/hooks'
 import { useActiveWeb3React } from 'hooks/web3'
 import { Order, OrderStatus } from 'state/orders/actions'
 import { EnhancedTransactionDetails } from 'state/enhancedTransactions/reducer'
@@ -182,6 +182,28 @@ function createActivityDescriptor(tx?: EnhancedTransactionDetails, order?: Order
     type,
     date,
   }
+}
+
+export function useMultipleActivityDescriptors({
+  chainId,
+  ids,
+}: UseActivityDescriptionParams): ActivityDescriptors[] | null {
+  const txs = useTransactionsByHash({ hashes: ids })
+  const orders = useOrdersById({ chainId, ids })
+
+  return useMemo(() => {
+    if (!chainId) return null
+
+    console.log(`useMultipleActivityDescriptors::memo`, ids.length, Object.keys(txs).length, Object.keys(orders).length)
+
+    return ids.reduce<ActivityDescriptors[]>((acc, id) => {
+      const activity = createActivityDescriptor(txs[id], orders[id])
+      if (activity) {
+        acc.push(activity)
+      }
+      return acc
+    }, [])
+  }, [chainId, ids, orders, txs])
 }
 
 export function useSingleActivityDescriptor({

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -5,6 +5,7 @@ import { useActiveWeb3React } from 'hooks/web3'
 import { Order, OrderStatus } from 'state/orders/actions'
 import { EnhancedTransactionDetails } from 'state/enhancedTransactions/reducer'
 import { SupportedChainId as ChainId } from 'constants/chains'
+import { getDateTimestamp } from 'utils/time'
 
 export type TransactionAndOrder =
   | (Order & { addedTime: number })
@@ -227,4 +228,34 @@ export function useSingleActivityDescriptor({
     if (!chainId) return null
     return createActivityDescriptor(tx, order)
   }, [chainId, order, tx])
+}
+
+type ActivitiesGroupedByDate = {
+  date: Date
+  activities: ActivityDescriptors[]
+}[]
+
+/**
+ * Helper function that groups a list of activities by day
+ * To be used on the return of `useMultipleActivityDescriptors`
+ *
+ * @param activities
+ */
+export function groupActivitiesByDay(activities: ActivityDescriptors[]): ActivitiesGroupedByDate {
+  const mapByTimestamp: { [timestamp: number]: ActivityDescriptors[] } = {}
+
+  activities.forEach((activity) => {
+    const { date } = activity
+
+    const timestamp = getDateTimestamp(date)
+
+    mapByTimestamp[timestamp] = (mapByTimestamp[timestamp] || []).concat(activity)
+  })
+
+  return Object.keys(mapByTimestamp).map((strTimestamp) => {
+    // Keys are always string, convert back to number
+    const timestamp = Number(strTimestamp)
+    // For easier handling later, transform into a list of objects with nested lists
+    return { date: new Date(timestamp), activities: mapByTimestamp[timestamp] }
+  })
 }

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -194,7 +194,6 @@ export function useMultipleActivityDescriptors({
   return useMemo(() => {
     if (!chainId) return null
 
-
     return ids.reduce<ActivityDescriptors[]>((acc, id) => {
       const activity = createActivityDescriptor(txs[id], orders[id])
       if (activity) {

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -194,7 +194,6 @@ export function useMultipleActivityDescriptors({
   return useMemo(() => {
     if (!chainId) return null
 
-    console.log(`useMultipleActivityDescriptors::memo`, ids.length, Object.keys(txs).length, Object.keys(orders).length)
 
     return ids.reduce<ActivityDescriptors[]>((acc, id) => {
       const activity = createActivityDescriptor(txs[id], orders[id])

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -100,6 +100,7 @@ export default function useRecentActivity() {
 }
 
 export interface ActivityDescriptors {
+  id: string
   activity: EnhancedTransactionDetails | Order
   summary?: string
   status: ActivityStatus
@@ -117,7 +118,8 @@ function createActivityDescriptor(tx?: EnhancedTransactionDetails, order?: Order
 
   let activity: EnhancedTransactionDetails | Order, type: ActivityType
 
-  let isPending: boolean,
+  let id: string,
+    isPending: boolean,
     isPresignaturePending: boolean,
     isConfirmed: boolean,
     isCancelling: boolean,
@@ -127,6 +129,8 @@ function createActivityDescriptor(tx?: EnhancedTransactionDetails, order?: Order
   if (!tx && order) {
     // We're dealing with an ORDER
     // setup variables accordingly...
+    id = order.id
+
     isPending = order?.status === OrderStatus.PENDING
     isPresignaturePending = order?.status === OrderStatus.PRESIGNATURE_PENDING
     isConfirmed = !isPending && order?.status === OrderStatus.FULFILLED
@@ -140,6 +144,8 @@ function createActivityDescriptor(tx?: EnhancedTransactionDetails, order?: Order
   } else if (tx) {
     // We're dealing with a TRANSACTION
     // setup variables accordingly...
+    id = tx.hash
+
     const isReceiptConfirmed =
       tx.receipt?.status === TxReceiptStatus.CONFIRMED || typeof tx.receipt?.status === 'undefined'
     isPending = !tx.receipt
@@ -176,6 +182,7 @@ function createActivityDescriptor(tx?: EnhancedTransactionDetails, order?: Order
   const summary = activity.summary
 
   return {
+    id,
     activity,
     summary,
     status,

--- a/src/custom/state/enhancedTransactions/hooks/index.ts
+++ b/src/custom/state/enhancedTransactions/hooks/index.ts
@@ -84,3 +84,24 @@ export function useAllTransactionHashes(filter?: TransactionFilter): string[] {
 
   return useMemo(() => transactions.map((tx) => tx.hash), [transactions])
 }
+
+type EnhancedTransactionDetailsMap = {
+  [txHash: string]: EnhancedTransactionDetails
+}
+
+export function useTransactionsByHash({ hashes }: { hashes: string[] }): EnhancedTransactionDetailsMap {
+  const allTxs = useAllTransactions()
+
+  return useMemo(() => {
+    if (!allTxs || !hashes) {
+      return {}
+    }
+
+    return hashes.reduce<EnhancedTransactionDetailsMap>((acc, hash) => {
+      if (allTxs[hash]) {
+        acc[hash] = allTxs[hash]
+      }
+      return acc
+    }, {})
+  }, [allTxs, hashes])
+}

--- a/src/custom/state/orders/hooks.ts
+++ b/src/custom/state/orders/hooks.ts
@@ -54,6 +54,10 @@ interface GetRemoveOrderParams {
   id: OrderID
   chainId: ChainId
 }
+type GetOrdersByIdParams = {
+  ids: OrderID[]
+  chainId?: ChainId
+}
 
 type GetOrdersParams = Partial<Pick<GetRemoveOrderParams, 'chainId'>>
 type ClearOrdersParams = Pick<GetRemoveOrderParams, 'chainId'>
@@ -214,6 +218,28 @@ export const useAllOrders = ({ chainId }: GetOrdersParams): PartialOrdersMap => 
       ...state.cancelled,
     }
   }, [state])
+}
+
+type OrdersMap = {
+  [id: string]: Order
+}
+
+export const useOrdersById = ({ chainId, ids }: GetOrdersByIdParams): OrdersMap => {
+  const allOrders = useAllOrders({ chainId })
+
+  return useMemo(() => {
+    if (!allOrders || !ids) {
+      return {}
+    }
+
+    return ids.reduce<OrdersMap>((acc, id) => {
+      const order = _deserializeOrder(allOrders[id])
+      if (order) {
+        acc[id] = order
+      }
+      return acc
+    }, {})
+  }, [allOrders, ids])
 }
 
 export const usePendingOrders = ({ chainId }: GetOrdersParams): Order[] => {

--- a/src/custom/utils/time.ts
+++ b/src/custom/utils/time.ts
@@ -1,0 +1,7 @@
+/**
+ * Given a Date obj, remove hours, minutes and seconds, and return the timestamp of it
+ * @param date
+ */
+export function getDateTimestamp(date: Date): number {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime()
+}


### PR DESCRIPTION
# Summary

Grouping activities by day on activities list

Proof of concept, still needs some polishing

Merges onto Michel's https://github.com/gnosis/cowswap/pull/1523

  # To Test

1. With an account that has multiple orders in the last 10 days
2. Open the activities list
* Activities on the same day should be grouped
![screenshot_2021-10-07_11-55-10](https://user-images.githubusercontent.com/43217/136445596-27789af6-980d-4b84-bf24-662e1cb7d8c2.png)


  # Background

Not optimal, not styled, etc, etc

