### PR TITLE
Make REACT_APP_BLOCKNATIVE_API_KEY available on CI scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ env:
   PR_NUMBER: ${{ github.event.number }}
   REACT_APP_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   REACT_APP_SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+  REACT_APP_BLOCKNATIVE_API_KEY: ${{ secrets.REACT_APP_BLOCKNATIVE_API_KEY }}
 
 jobs:
   setup:

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -54,6 +54,7 @@ jobs:
           REACT_APP_ADDITIONAL_SERVICES_API_URL_XDAI: https://ido-api-xdai.gnosis.io/
           REACT_APP_NETWORK_URL_MAINNET: https://mainnet.infura.io/v3/${{ secrets.INFURA_PROJECT_KEY }}
           REACT_APP_ADDITIONAL_SERVICES_API_URL_MAINNET: https://ido-api-mainnet.gnosis.io/
+          REACT_APP_BLOCKNATIVE_API_KEY: ${{ secrets.REACT_APP_BLOCKNATIVE_API_KEY }}
 
       - name: "Deploy to IPFS with infura"
         run: yarn ipfs:publish


### PR DESCRIPTION
# Summary

Follow up to https://github.com/gnosis/cowswap/pull/1524#issuecomment-937968117

Tested on https://cowswap.dev.gnosisdev.com/#/swap and blocknative no longer works.

That's because I forgot to include the env var onto CI scrips...

# To Test

Need to merge and deploy to dev first
