### PR TITLE
1334/do not refetch when token added

### DIFF
--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -16,8 +16,8 @@ import AddressInputPanel from 'components/AddressInputPanel'
 import {
   ButtonConfirmed,
   /* ButtonError,
-  ButtonGray, 
-  ButtonLight, 
+  ButtonGray,
+  ButtonLight,
   ButtonPrimary */
 } from 'components/Button'
 import Card, { GreyCard } from 'components/Card'
@@ -506,8 +506,6 @@ export default function Swap({
     }
   }
 
-  console.log('{isNativeIn && onWrap', { isNativeIn, onWrap })
-
   return (
     <>
       <TokenWarningModal
@@ -572,7 +570,7 @@ export default function Swap({
                 id="swap-currency-input"
               />
               {/* UNI ARROW SWITCHER */}
-              {/* 
+              {/*
               <ArrowWrapper clickable>
                 <ArrowDown
                   size="16"


### PR DESCRIPTION
# Summary

Waterfalls into https://github.com/gnosis/cowswap/pull/1504

Addressing comment on https://github.com/gnosis/cowswap/pull/1395

No longer re-fetching orders when a token is added to the local list

# To Test

1. Trade with a token not part of the token list. Eg.: ZRX or BAT on rinkeby
2. Open the console and filter by `ApiOrdersUpdater`
3. Remove the custom added token
* There should not be any new log entry like
![screenshot_2021-10-07_15-54-59](https://user-images.githubusercontent.com/43217/136473168-49a304a9-6b4b-4e97-bffa-bc3e17a0cd46.png)
4. Refresh the page
* There should be only 1 log entry like the above after the refresh
* The removed token should be back at the list of user tokens

