### PR TITLE
[presign] confirmation: cleanup logic and determined if the wallet is EOA/Gnosis safe / EOA

### DIFF
--- a/src/custom/components/TransactionConfirmationModal/index.tsx
+++ b/src/custom/components/TransactionConfirmationModal/index.tsx
@@ -8,7 +8,7 @@ import {
   CloseIcon,
   // CustomLightSpinner
 } from 'theme'
-import { Trans } from '@lingui/macro'
+import { t, Trans } from '@lingui/macro'
 import { ExternalLink } from 'theme'
 import { RowBetween, RowFixed } from 'components/Row'
 import MetaMaskLogo from 'assets/images/metamask.png'
@@ -347,10 +347,52 @@ enum walletTypes {
   EOA,
 }
 
-enum orderTypes {
-  CANCEL,
-  APPROVAL,
-  ORDER,
+enum OperationType {
+  WRAP_ETHER,
+  UNWRAP_WETH,
+  APPROVE_TOKEN,
+  ORDER_SIGN,
+  ORDER_CANCEL,
+}
+
+function getOperationMessage(operationType: OperationType): string {
+  switch (operationType) {
+    case OperationType.WRAP_ETHER:
+      return 'Wrap Ether.'
+    case OperationType.UNWRAP_WETH:
+      return 'Wrap Ether.'
+    case OperationType.APPROVE_TOKEN:
+      return 'Approve the token.'
+    case OperationType.ORDER_CANCEL:
+      return 'Soft cancel your order.'
+
+    default:
+      return 'Almost there!'
+  }
+}
+
+function getOperationLabel(operationType: OperationType): string {
+  switch (operationType) {
+    case OperationType.WRAP_ETHER:
+      return t`wrapping`
+    case OperationType.UNWRAP_WETH:
+      return t`unwrapping`
+    case OperationType.APPROVE_TOKEN:
+      return t`token approval`
+    case OperationType.ORDER_SIGN:
+      return t`order`
+    case OperationType.ORDER_CANCEL:
+      return t`cancellation`
+  }
+}
+
+function getSubmittedMessage(operationLabel: string, operationType: OperationType): string {
+  switch (operationType) {
+    case OperationType.ORDER_SIGN:
+      return t`The order is submitted and ready to be settled.`
+    default:
+      return t`The ${operationLabel} is submitted.`
+  }
 }
 
 export function ConfirmationPendingContent({
@@ -377,7 +419,11 @@ export function ConfirmationPendingContent({
 
   const WalletNameLabel =
     walletType === walletTypes.SAFE ? 'Gnosis Safe' : walletType === walletTypes.SC ? 'smart contract wallet' : 'wallet'
-  const orderType = orderTypes.ORDER as orderTypes
+  const operationType = OperationType.ORDER_SIGN
+
+  const operationMessage = getOperationMessage(operationType)
+  const operationLabel = getOperationLabel(operationType)
+  const operationSubmittedMessage = getSubmittedMessage(operationLabel, operationType)
 
   return (
     <Wrapper>
@@ -393,20 +439,10 @@ export function ConfirmationPendingContent({
 
       <LowerSection>
         <h3>
-          <Trans>
-            {orderType === orderTypes.CANCEL ? (
-              <>
-                <span>Soft cancel your order.</span>
-              </>
-            ) : orderType === orderTypes.APPROVAL ? (
-              <>
-                <span>Approve the token.</span>
-              </>
-            ) : (
-              <span>Almost there!</span>
-            )}
-            <span>Follow these steps:</span>
-          </Trans>
+          <span>{operationMessage} </span>
+          <span>
+            <Trans>Follow these steps:</Trans>
+          </span>
         </h3>
 
         <StepsWrapper>
@@ -416,13 +452,8 @@ export function ConfirmationPendingContent({
             </StepsIconWrapper>
             <p>
               <Trans>
-                Sign the{' '}
-                {orderType === orderTypes.CANCEL
-                  ? 'cancellation'
-                  : orderType === orderTypes.APPROVAL
-                  ? 'token approval'
-                  : 'order'}{' '}
-                with your {WalletNameLabel} {account && <span>({ensName || shortenAddress(account)})</span>}
+                Sign the {operationLabel} with your {WalletNameLabel}{' '}
+                {account && <span>({ensName || shortenAddress(account)})</span>}
               </Trans>
             </p>
           </div>
@@ -431,15 +462,7 @@ export function ConfirmationPendingContent({
             <StepsIconWrapper>
               <CheckCircle />
             </StepsIconWrapper>
-            <p>
-              <Trans>
-                {orderType === orderTypes.CANCEL
-                  ? 'The cancellation request is submitted.'
-                  : orderType === orderTypes.APPROVAL
-                  ? 'The token approval is submitted.'
-                  : 'The order is submitted and ready to be settled.'}
-              </Trans>
-            </p>
+            <p>{operationSubmittedMessage}</p>
           </div>
         </StepsWrapper>
       </LowerSection>


### PR DESCRIPTION
# Summary

confirmation: cleanup logic and determined if the wallet is EOA/Gnosis safe / EOA

It will show a slightly different message on it's case.

A follow up PR will receive the enum as a parameter. This is just some intermediate step I wanted for the demo