### PR TITLE
Avoid instantiating blocknative sdk when API key not set

### DIFF
--- a/src/custom/state/enhancedTransactions/updater.tsx
+++ b/src/custom/state/enhancedTransactions/updater.tsx
@@ -13,9 +13,16 @@ export default function Updater(): null {
   useEffect(() => {
     if (!chainId || !library) return
 
+    const blocknativeSdk = sdk[chainId]
+
+    if (!blocknativeSdk) {
+      console.warn(`TransactionUpdater::BlocknativeSdk not available`)
+      return
+    }
+
     for (const hash of pendingHashes) {
       try {
-        const { emitter } = sdk[chainId].transaction(hash)
+        const { emitter } = blocknativeSdk.transaction(hash)
         const currentHash = hash
         let isSpeedup = false
 
@@ -40,7 +47,7 @@ export default function Updater(): null {
     return () => {
       for (const hash of pendingHashes) {
         try {
-          sdk[chainId].unsubscribe(hash)
+          blocknativeSdk.unsubscribe(hash)
         } catch (error) {
           console.error('Failed to unsubscribe', hash)
         }

--- a/src/custom/utils/blocknative.ts
+++ b/src/custom/utils/blocknative.ts
@@ -2,19 +2,25 @@ import BlocknativeSdk from 'bnc-sdk'
 import { SDKError } from 'bnc-sdk/dist/types/src/interfaces'
 import { getSupportedChainIds } from 'connectors'
 
-export const sdk = getSupportedChainIds().reduce<Record<number, BlocknativeSdk>>((acc, networkId) => {
-  try {
-    acc[networkId] = new BlocknativeSdk({
-      dappId: process.env.REACT_APP_BLOCKNATIVE_API_KEY || '',
-      networkId,
-      name: 'bnc_' + networkId,
-      onerror: (error: SDKError) => {
-        console.log(error)
-      },
-    })
-  } catch (error) {
-    console.error('Instantiating BlocknativeSdk failed', error)
-  }
+const BLOCKNATIVE_API_KEY = process.env.REACT_APP_BLOCKNATIVE_API_KEY
 
-  return acc
-}, {})
+export const sdk = !BLOCKNATIVE_API_KEY
+  ? {}
+  : getSupportedChainIds().reduce<Record<number, BlocknativeSdk | null>>((acc, networkId) => {
+      try {
+        acc[networkId] = new BlocknativeSdk({
+          dappId: BLOCKNATIVE_API_KEY,
+          networkId,
+          name: 'bnc_' + networkId,
+          onerror: (error: SDKError) => {
+            console.log(error)
+          },
+        })
+      } catch (error) {
+        console.error('Instantiating BlocknativeSdk failed', error)
+      }
+
+      console.info(`BlocknativeSdk initialized on chain ${networkId}`)
+
+      return acc
+    }, {})


### PR DESCRIPTION
# Summary

Follow up to https://github.com/gnosis/cowswap/pull/1524 and #1534 

Simply to reduce console log clutter when API key is not set

  # To Test

1. Open the console and search for BlockNative
* When API key is set, you should see
![screenshot_2021-10-08_14-41-15](https://user-images.githubusercontent.com/43217/136627995-da9cd413-f53f-43fc-9eda-04a8301587ce.png)
* When API key is not set, you should see
![screenshot_2021-10-08_14-41-33](https://user-images.githubusercontent.com/43217/136628017-a4ad98b8-13b7-46ce-beda-c8c5ee41432a.png)

On this PR and local, you should see the later, on any other environment (dev, prod, bar, staging) you should see the former