### PR TITLE
Revert paraswap

### DIFF
--- a/src/custom/api/paraswap/index.ts
+++ b/src/custom/api/paraswap/index.ts
@@ -63,45 +63,44 @@ function getPriceQuoteFromError(error: APIError): ParaSwapPriceQuote | null {
 }
 
 export async function getPriceQuote(params: PriceQuoteParams): Promise<ParaSwapPriceQuote | null> {
-  return null
-  // const { baseToken, quoteToken, fromDecimals, toDecimals, amount, kind, chainId } = getValidParams(params)
+  const { baseToken, quoteToken, fromDecimals, toDecimals, amount, kind, chainId } = getValidParams(params)
 
-  // let paraSwap = paraSwapLibs.get(chainId)
-  // if (!paraSwap) {
-  //   const networkId = getParaswapChainId(chainId)
-  //   if (networkId == null) {
-  //     // Unsupported network
-  //     return null
-  //   }
-  //   paraSwap = new ParaSwap(networkId, API_URL)
-  //   paraSwapLibs.set(chainId, paraSwap)
-  // }
+  let paraSwap = paraSwapLibs.get(chainId)
+  if (!paraSwap) {
+    const networkId = getParaswapChainId(chainId)
+    if (networkId == null) {
+      // Unsupported network
+      return null
+    }
+    paraSwap = new ParaSwap(networkId, API_URL)
+    paraSwapLibs.set(chainId, paraSwap)
+  }
 
-  // console.log(`[pricesApi:${API_NAME}] Get price from Paraswap`, params)
+  console.log(`[pricesApi:${API_NAME}] Get price from Paraswap`, params)
 
-  // // Buy/sell token and side (sell/buy)
-  // const { sellToken, buyToken } = getTokensFromMarket({ baseToken, quoteToken, kind })
-  // const swapSide = kind === OrderKind.BUY ? SwapSide.BUY : SwapSide.SELL
+  // Buy/sell token and side (sell/buy)
+  const { sellToken, buyToken } = getTokensFromMarket({ baseToken, quoteToken, kind })
+  const swapSide = kind === OrderKind.BUY ? SwapSide.BUY : SwapSide.SELL
 
-  // // https://developers.paraswap.network/api/get-rate-for-a-token-pair
-  // const options: RateOptions | undefined = {
-  //   maxImpact: 100,
-  //   excludeDEXS: 'ParaSwapPool4',
-  // }
+  // https://developers.paraswap.network/api/get-rate-for-a-token-pair
+  const options: RateOptions | undefined = {
+    maxImpact: 100,
+    excludeDEXS: 'ParaSwapPool4',
+  }
 
-  // // Get price
-  // const rateResult = await paraSwap.getRate(sellToken, buyToken, amount, swapSide, options, fromDecimals, toDecimals)
+  // Get price
+  const rateResult = await paraSwap.getRate(sellToken, buyToken, amount, swapSide, options, fromDecimals, toDecimals)
 
-  // if (isGetRateSuccess(rateResult)) {
-  //   // Success getting the price
-  //   return rateResult
-  // } else {
-  //   // Error getting the price
-  //   const priceQuote = getPriceQuoteFromError(rateResult)
-  //   if (priceQuote) {
-  //     return priceQuote
-  //   } else {
-  //     throw rateResult
-  //   }
-  // }
+  if (isGetRateSuccess(rateResult)) {
+    // Success getting the price
+    return rateResult
+  } else {
+    // Error getting the price
+    const priceQuote = getPriceQuoteFromError(rateResult)
+    if (priceQuote) {
+      return priceQuote
+    } else {
+      throw rateResult
+    }
+  }
 }

--- a/src/custom/api/paraswap/index.ts
+++ b/src/custom/api/paraswap/index.ts
@@ -1,74 +1,67 @@
-// import { OrderKind } from '@gnosis.pm/gp-v2-contracts'
+import { OrderKind } from '@gnosis.pm/gp-v2-contracts'
 
-import { PriceInformation, PriceQuoteParams } from 'utils/price'
-import { OptimalRatesWithPartnerFees } from 'paraswap/build/types'
-
-// import { ParaSwap, SwapSide, NetworkID } from 'paraswap'
-// import { OptimalRatesWithPartnerFees, APIError, RateOptions } from 'paraswap/build/types'
-// import { SupportedChainId as ChainId } from 'constants/chains'
-// import { getTokensFromMarket } from 'utils/misc'
-// import { getValidParams, PriceInformation, PriceQuoteParams } from 'utils/price'
+import { ParaSwap, SwapSide, NetworkID } from 'paraswap'
+import { OptimalRatesWithPartnerFees, APIError, RateOptions } from 'paraswap/build/types'
+import { SupportedChainId as ChainId } from 'constants/chains'
+import { getTokensFromMarket } from 'utils/misc'
+import { getValidParams, PriceInformation, PriceQuoteParams } from 'utils/price'
 
 type ParaSwapPriceQuote = OptimalRatesWithPartnerFees
 
-// const API_NAME = 'ParaSwap'
-// // Provided manually just to make sure it matches what GPv2 backend is using, although the value used  is the current SDK default
-// const API_URL = 'https://apiv4.paraswap.io/v2'
+const API_NAME = 'ParaSwap'
+// Provided manually just to make sure it matches what GPv2 backend is using, although the value used  is the current SDK default
+const API_URL = 'https://apiv4.paraswap.io/v2'
 
-// const paraSwapLibs: Map<ChainId, ParaSwap> = new Map()
+const paraSwapLibs: Map<ChainId, ParaSwap> = new Map()
 
-// function getParaswapChainId(chainId: ChainId): NetworkID | null {
-//   switch (chainId) {
-//     // Only Mainnnet and Ropsten supported
-//     //  See https://developers.paraswap.network/api/list-all-tokens
-//     case ChainId.MAINNET:
-//     case ChainId.ROPSTEN:
-//       return chainId
+function getParaswapChainId(chainId: ChainId): NetworkID | null {
+  switch (chainId) {
+    // Only Mainnnet and Ropsten supported
+    //  See https://developers.paraswap.network/api/list-all-tokens
+    case ChainId.MAINNET:
+    case ChainId.ROPSTEN:
+      return chainId
 
-//     default:
-//       // Unsupported network
-//       return null
-//   }
-// }
-
-// eslint-disable-next-line
-export function toPriceInformation(priceRaw: ParaSwapPriceQuote | null): PriceInformation | null {
-  return null
+    default:
+      // Unsupported network
+      return null
+  }
 }
-//   if (!priceRaw || !priceRaw.details) {
-//     return null
-//   }
 
-//   const { destAmount, srcAmount, details, side } = priceRaw
-//   if (side === SwapSide.SELL) {
-//     return {
-//       amount: destAmount,
-//       token: details.tokenTo,
-//     }
-//   } else {
-//     return {
-//       amount: srcAmount,
-//       token: details.tokenFrom,
-//     }
-//   }
-// }
+export function toPriceInformation(priceRaw: ParaSwapPriceQuote | null): PriceInformation | null {
+  if (!priceRaw || !priceRaw.details) {
+    return null
+  }
 
-// function isGetRateSuccess(
-//   rateResult: OptimalRatesWithPartnerFees | APIError
-// ): rateResult is OptimalRatesWithPartnerFees {
-//   return !!(rateResult as OptimalRatesWithPartnerFees).destAmount
-// }
+  const { destAmount, srcAmount, details, side } = priceRaw
+  if (side === SwapSide.SELL) {
+    return {
+      amount: destAmount,
+      token: details.tokenTo,
+    }
+  } else {
+    return {
+      amount: srcAmount,
+      token: details.tokenFrom,
+    }
+  }
+}
 
-// function getPriceQuoteFromError(error: APIError): ParaSwapPriceQuote | null {
-//   if (error.message === 'ESTIMATED_LOSS_GREATER_THAN_MAX_IMPACT' && error.data && error.data.priceRoute) {
-//     // If the price impact is too big, it still give you the estimation
-//     return error.data.priceRoute
-//   } else {
-//     return null
-//   }
-// }
+function isGetRateSuccess(
+  rateResult: OptimalRatesWithPartnerFees | APIError
+): rateResult is OptimalRatesWithPartnerFees {
+  return !!(rateResult as OptimalRatesWithPartnerFees).destAmount
+}
 
-// eslint-disable-next-line
+function getPriceQuoteFromError(error: APIError): ParaSwapPriceQuote | null {
+  if (error.message === 'ESTIMATED_LOSS_GREATER_THAN_MAX_IMPACT' && error.data && error.data.priceRoute) {
+    // If the price impact is too big, it still give you the estimation
+    return error.data.priceRoute
+  } else {
+    return null
+  }
+}
+
 export async function getPriceQuote(params: PriceQuoteParams): Promise<ParaSwapPriceQuote | null> {
   return null
   // const { baseToken, quoteToken, fromDecimals, toDecimals, amount, kind, chainId } = getValidParams(params)

--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -106,12 +106,11 @@ export type QuoteResult = [PromiseSettledResult<PriceInformation>, PromiseSettle
 export async function getAllPrices(params: PriceQuoteParams) {
   // Get price from all API: Gpv2, Paraswap, Matcha (0x)
   const pricePromise = withTimeout(getPriceQuoteGp(params), PRICE_API_TIMEOUT_MS, 'GPv2: Get Price API')
-  // Hotfix to disable Paraswap price estimation
-  // const paraSwapPricePromise = withTimeout(
-  //   getPriceQuoteParaswap(params),
-  //   PRICE_API_TIMEOUT_MS,
-  //   'Paraswap: Get Price API'
-  // )
+  const paraSwapPricePromise = withTimeout(
+    getPriceQuoteParaswap(params),
+    PRICE_API_TIMEOUT_MS,
+    'Paraswap: Get Price API'
+  )
   const matchaPricePromise = withTimeout(getPriceQuoteMatcha(params), PRICE_API_TIMEOUT_MS, 'Matcha(0x): Get Price API')
 
   // Get results from API queries

--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -106,11 +106,12 @@ export type QuoteResult = [PromiseSettledResult<PriceInformation>, PromiseSettle
 export async function getAllPrices(params: PriceQuoteParams) {
   // Get price from all API: Gpv2, Paraswap, Matcha (0x)
   const pricePromise = withTimeout(getPriceQuoteGp(params), PRICE_API_TIMEOUT_MS, 'GPv2: Get Price API')
-  const paraSwapPricePromise = withTimeout(
-    getPriceQuoteParaswap(params),
-    PRICE_API_TIMEOUT_MS,
-    'Paraswap: Get Price API'
-  )
+  // Hotfix to disable Paraswap price estimation
+  // const paraSwapPricePromise = withTimeout(
+  //   getPriceQuoteParaswap(params),
+  //   PRICE_API_TIMEOUT_MS,
+  //   'Paraswap: Get Price API'
+  // )
   const matchaPricePromise = withTimeout(getPriceQuoteMatcha(params), PRICE_API_TIMEOUT_MS, 'Matcha(0x): Get Price API')
 
   // Get results from API queries


### PR DESCRIPTION
# Summary

Reverts @fleupold hotfix to remove paraswap

This PR is preparation of next ones:
- Add Paraswap v5
- Provide an easy way to disable price feeds temporarily 

# To Test

1. Test app is back to the way was before: Paraswap4 price should be queried
 