### PR TITLE
Re-enable Argent wallet

### DIFF
--- a/src/custom/hooks/useApproveCallback/useApproveCallbackMod.ts
+++ b/src/custom/hooks/useApproveCallback/useApproveCallbackMod.ts
@@ -37,12 +37,13 @@ export function useApproveCallback(
     // we might not have enough data to know whether or not we need to approve
     if (!currentAllowance) return ApprovalState.UNKNOWN
 
-    // amountToApprove will be defined if currentAllowance is
-    return currentAllowance.lessThan(amountToApprove)
-      ? pendingApproval
-        ? ApprovalState.PENDING
-        : ApprovalState.NOT_APPROVED
-      : ApprovalState.APPROVED
+    // Return approval state
+    if (currentAllowance.lessThan(amountToApprove)) {
+      return pendingApproval ? ApprovalState.PENDING : ApprovalState.NOT_APPROVED
+    } else {
+      // Enough allowance
+      return ApprovalState.APPROVED
+    }
   }, [amountToApprove, currentAllowance, pendingApproval, spender])
 
   const tokenContract = useTokenContract(token?.address)
@@ -120,6 +121,7 @@ export function useApproveCallbackFromTrade(
 ) {
   const { chainId } = useActiveWeb3React()
   const v3SwapRouterAddress = chainId ? SWAP_ROUTER_ADDRESSES[chainId] : undefined
+
   const amountToApprove = useMemo(
     () => (trade && trade.inputAmount.currency.isToken ? trade.maximumAmountIn(allowedSlippage) : undefined),
     [trade, allowedSlippage]

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -40,7 +40,6 @@ import { ApprovalState, useApproveCallbackFromTrade } from 'hooks/useApproveCall
 // import { V3TradeState } from '../../hooks/useBestV3Trade'
 import useENSAddress from 'hooks/useENSAddress'
 import { useERC20PermitFromTrade, UseERC20PermitState } from 'hooks/useERC20Permit'
-import useIsArgentWallet from 'hooks/useIsArgentWallet'
 import { useIsSwapUnsupported } from 'hooks/useIsSwapUnsupported'
 import { useSwapCallback } from 'hooks/useSwapCallback'
 import { /* useToggledVersion, */ Version } from 'hooks/useToggledVersion'
@@ -443,13 +442,9 @@ export default function Swap({
   //   )
   // }, [priceImpact, trade])
 
-  const isArgentWallet = useIsArgentWallet()
-
   // show approve flow when: no error on inputs, not approved or pending, or approved in current session
   // never show if price impact is above threshold in non expert mode
   const showApproveFlow =
-    // TODO: review this
-    !isArgentWallet &&
     !swapInputError &&
     (approvalState === ApprovalState.NOT_APPROVED ||
       approvalState === ApprovalState.PENDING ||
@@ -506,9 +501,6 @@ export default function Swap({
       amountBeforeFees = formatSmart(trade.inputAmountWithoutFee, AMOUNT_PRECISION)
     }
   }
-
-  console.log('{isNativeIn && onWrap', { isNativeIn, onWrap })
-
   return (
     <>
       <TokenWarningModal


### PR DESCRIPTION
# Summary
Re-enables Argent, it just works with the new code and pre-sign

## Doesn't include
Handle the rejection, same as Gnosis Safe

## Funny stories in this PR
When I tried to trade in Argent, I was getting an error from the API. They said I didn't have balance, but i did!

Then I suspected I didn't have the approval, I was unsure if I had that already some time ago. I didn't! I checked in the contract and my allowance was 0.

However the button was not visible. I started to debug from the useApproveCallback hook, adding console.log, in a super slow process of going back and back and back to the root of the problem. 

When I arrive to the flag that enables the button, and I see a TODO with if `!argentWallet` I face-palmed with force! 😂

# To Test

1. Wrap/Unwrap/Swap with Argent

TIP: If you don't want to approve with your guardiags every tx, you can "open trusted session": https://support.argent.xyz/hc/en-us/articles/360018626137-Transactions-with-a-Trusted-Session
