### PR TITLE
[Release 1.3.0] XDAI Weth contract (WXDAI) bug fix

### DIFF
--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -165,14 +165,13 @@ export default function Swap({
 
   // Checks if either currency is native ETH
   // MOD: adds this hook
-  const { isNativeIn, isWrappedOut, native, wrappedToken } = useDetectNativeToken(
+  const { isNativeIn, native, wrappedToken } = useDetectNativeToken(
     { currency: currencies.INPUT, address: INPUT.currencyId },
     { currency: currencies.OUTPUT, address: OUTPUT.currencyId },
     chainId
   )
-
   // Is user swapping Eth as From token and not wrapping to WETH?
-  const isNativeInSwap = isNativeIn && !isWrappedOut
+  const isNativeInSwap = isNativeIn
 
   // Is fee greater than input?
   const { isFeeGreater, fee } = useIsFeeGreaterThanInput({

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -450,10 +450,7 @@ export function useDetectNativeToken(input?: CurrencyWithAddress, output?: Curre
 
     const native = ETHER.onChain(chainId || DEFAULT_NETWORK_FOR_LISTS)
 
-    const [isNativeIn, isNativeOut] = [
-      input?.currency && native.equals(input.currency),
-      output?.currency && native.equals(output.currency),
-    ]
+    const [isNativeIn, isNativeOut] = [input?.currency?.isNative, output?.currency?.isNative]
     const [isWrappedIn, isWrappedOut] = [input?.currency?.equals(wrappedToken), output?.currency?.equals(wrappedToken)]
 
     return {

--- a/src/custom/utils/supportedChainId.ts
+++ b/src/custom/utils/supportedChainId.ts
@@ -1,4 +1,4 @@
-import { SupportedChainId } from '../constants/chains'
+import { SupportedChainId } from 'constants/chains'
 
 export function isSupportedChain(chainId?: number): chainId is SupportedChainId {
   if (!chainId) return false

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -37,7 +37,7 @@ import { Quoter, NonfungiblePositionManager, UniswapInterfaceMulticall } from 't
 import { V3Migrator } from 'types/v3/V3Migrator'
 import { getContract } from 'utils'
 import { Erc20, ArgentWalletDetector, EnsPublicResolver, EnsRegistrar, Weth } from '../abis/types'
-import { UNI, WETH9_EXTENDED } from '../constants/tokens'
+import { UNI, WETH9_EXTENDED } from 'constants/tokens'
 import { useActiveWeb3React } from './web3'
 
 // returns null on errors


### PR DESCRIPTION
There was an import path issue in useContract > useWethContract importing the default WethContract map which didn't have XDAI causing XDAI bug:

- trade WXDAI <> XDAI (or inverse)
- input amount anywhere
- shows SWAP instead of WRAP/UNWRAP

This is now fixed (above broken code can be tested in #1594) 