### PR TITLE
[CI.yml] ignore "locale" cache in lint step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,6 @@ jobs:
             src/types/v3
             src/abis/types
             src/state/data
-            src/locales
           key: ${{ runner.os }}-generatedFiles-${{ hashFiles('**/yarn.lock') }}
 
       - name: Run linters


### PR DESCRIPTION
-Lint step was loading "locale" files, including a JS file created during the compilation step. Don't load that mfer