### PR TITLE
[closes #1635] - cannot connect to mainnet when disconnected

### DIFF
--- a/src/custom/components/Header/NetworkCard/NetworkCardMod.tsx
+++ b/src/custom/components/Header/NetworkCard/NetworkCardMod.tsx
@@ -299,7 +299,9 @@ export default function NetworkCard() {
             )} */}
             {/* Supported networks to change to */}
             {ALL_SUPPORTED_CHAIN_IDS.map((supportedChainId) => {
-              if (supportedChainId === chainId) {
+              const callback = () => networkCallback(supportedChainId)
+
+              if (account && supportedChainId === chainId) {
                 /*  Current selected network */
                 return (
                   <ButtonMenuItem $selected key={'selected_' + chainId}>
@@ -310,7 +312,6 @@ export default function NetworkCard() {
                 )
               }
 
-              const callback = () => networkCallback(supportedChainId)
               return (
                 <ButtonMenuItem
                   key={supportedChainId}


### PR DESCRIPTION
# Summary

Closes #1635 

When disconnected from wallet mainnet is set as default chain - but code was bugging and preventing connecting to mainnet while allowing others. Fixes this

# To Test
1. disconnect from wallet
2. open network picker
3. select/click mainnet
4. observe
5. try it in about page as is shown in issue #1635 
6. observe it also works