### PR TITLE
[closes #1600] - Fix expert mode toggle switch

### DIFF
--- a/src/custom/components/Toggle/index.tsx
+++ b/src/custom/components/Toggle/index.tsx
@@ -3,8 +3,8 @@ import ToggleUni, { ToggleProps as TogglePropsUni, ToggleElement } from '@src/co
 
 export type ToggleProps = TogglePropsUni
 
-const Wrapper = styled(ToggleUni)`
-  background: ${({ theme }) => theme.bg4};
+const WrappedToggle = styled(ToggleUni)`
+  background: ${({ theme }) => theme.bg7};
 
   ${ToggleElement} {
     color: ${({ theme }) => theme.text1};
@@ -23,5 +23,5 @@ const Wrapper = styled(ToggleUni)`
 `
 
 export default function Toggle(props: ToggleProps) {
-  return <Wrapper {...props} />
+  return <WrappedToggle {...props} />
 }

--- a/src/custom/theme/baseTheme.tsx
+++ b/src/custom/theme/baseTheme.tsx
@@ -25,6 +25,10 @@ export function colors(darkMode: boolean): Colors {
     bg1: darkMode ? '#1E1F2C' : '#FFFFFF',
     bg2: darkMode ? '#2C2D3F' : '#F7F8FA',
     bg3: darkMode ? '#1E1F2C' : '#EDEEF2',
+    bg4: darkMode ? '#021E34' : '#ffffff',
+    bg5: darkMode ? '#1d4373' : '#D5E9F0',
+    bg6: darkMode ? '#163861' : '#b0dfee',
+    bg7: darkMode ? '#001e3659' : '#8080806b',
 
     // ****** specialty colors ******
     advancedBG: darkMode ? '#2B2D3F' : 'rgb(247 248 250)',


### PR DESCRIPTION
# Summary

Closes #1600 - fixes expert mode toggle

Light
![image](https://user-images.githubusercontent.com/21335563/137593186-2aacea6b-f0d4-4d47-af5f-158c8e93975e.png)

Dark
![image](https://user-images.githubusercontent.com/21335563/137593192-0dc2d840-44e8-4863-89c8-7b2a633ceea7.png)

Edits theme a bit to change bg7 (unused) and avoids having to mod Toggle component just to change one SCSSS line. Reason we would have to mod and can't just target via CSS is that the prop is not accessible inside the override inside our own `custom/components/Toggle/index.tsx` file

unless someone has a better idea! 