### PR TITLE
use verySmall (500) for tiny icon

### DIFF
--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -164,9 +164,13 @@ export const LogoImage = styled.div`
   margin: 0 32px 0 0;
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
+    width: 160px;
+  `}
+
+  ${({ theme }) => theme.mediaWidth.upToVerySmall`
     background: ${({ theme }) => `url(${theme.logo.srcIcon}) no-repeat left/contain`};
     height: 34px;
-  `};
+  `}
 
   > svg {
     width: 100%;


### PR DESCRIPTION
Tiny adjustment to make logo a bit smaller on 750px and make it the clipped version on 500px

Maintains the full logo until 500px: (only minor width adjustment necessary)
![image](https://user-images.githubusercontent.com/21335563/137909809-abc89686-f1cb-4b6a-b1cf-b0ed9fb51650.png)

Under 500px = smol:
![image](https://user-images.githubusercontent.com/21335563/137909870-781c28e3-7b5e-4886-a847-1c631bf98558.png)
