### PR TITLE
[HOTFIX] 1.3.3 - Fix Cypress aka little green dots everywhere

### DIFF
--- a/cypress-custom/integration/fee.test.ts
+++ b/cypress-custom/integration/fee.test.ts
@@ -1,4 +1,3 @@
-import { SupportedChainId as ChainId } from '../../src/custom/constants/chains'
 import { WETH9 as WETH } from '@uniswap/sdk-core'
 import { OrderKind } from '@gnosis.pm/gp-v2-contracts'
 import { FeeQuoteParams, FeeInformation } from '../../src/custom/utils/price'
@@ -6,7 +5,7 @@ import { parseUnits } from 'ethers/lib/utils'
 
 const DAI = '0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735'
 const FOUR_HOURS = 3600 * 4 * 1000
-const DEFAULT_SELL_TOKEN = WETH[ChainId.RINKEBY]
+const DEFAULT_SELL_TOKEN = WETH[4]
 
 const getFeeQuery = ({ sellToken, buyToken, amount, kind }: Omit<FeeQuoteParams, 'chainId'>) =>
   `https://protocol-rinkeby.dev.gnosisdev.com/api/v1/fee?sellToken=${sellToken}&buyToken=${buyToken}&amount=${amount}&kind=${kind}`

--- a/cypress-custom/support/events.js
+++ b/cypress-custom/support/events.js
@@ -1,7 +1,7 @@
 const ETHERS_EXPECTED_ERROR = 'could not detect network (event="noNetwork"'
 
 Cypress.on('uncaught:exception', (err) => {
-  // we expect a 3rd party library error with message 'list not defined'
+  // we expect an ethers library error with message 'could not detect network ...' we're always testing rinkeby anyways
   // and don't want to fail the test so we return false
   if (err.message.includes(ETHERS_EXPECTED_ERROR)) {
     return false

--- a/cypress-custom/support/events.js
+++ b/cypress-custom/support/events.js
@@ -1,0 +1,11 @@
+const ETHERS_EXPECTED_ERROR = 'could not detect network (event="noNetwork"'
+
+Cypress.on('uncaught:exception', (err) => {
+  // we expect a 3rd party library error with message 'list not defined'
+  // and don't want to fail the test so we return false
+  if (err.message.includes(ETHERS_EXPECTED_ERROR)) {
+    return false
+  }
+  // we still want to ensure there are no other unexpected
+  // errors, so we let them fail the test
+})

--- a/cypress-custom/support/index.js
+++ b/cypress-custom/support/index.js
@@ -10,3 +10,6 @@ import '../../cypress/support/commands'
 
 // Import commands.ts using ES2015 syntax:
 import './commands'
+
+// Import events.ts using ES2015 syntax:
+import './events'


### PR DESCRIPTION
Fixes Cypress failing tests finally. It's a _bit_ hacky in the sense that it doesn't fix the underlying import paths problems 
(e.g `import thing from '@src/components/utils'` fails as aliased paths aren't recognised.)

In the future we can look into this but tbh the cypress tests shoulldn't need to import anything, they should be self contained.

Proof in the pudding:
![image](https://user-images.githubusercontent.com/21335563/138289919-37a6d28e-a419-46f4-a7ab-e51b67f72918.png)
