### PR TITLE
1334/only update connected wallet

### DIFF
--- a/src/custom/state/orders/updaters/CancelledOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/CancelledOrdersUpdater.ts
@@ -39,12 +39,14 @@ export function CancelledOrdersUpdater(): null {
 
   const updateOrders = useCallback(
     async (chainId: ChainId, account: string) => {
+      const lowerCaseAccount = account.toLowerCase()
       // Filter orders:
       // - Owned by the current connected account
       // - Created in the last 5 min, no further
       const pending = cancelledRef.current.filter(
-        (order) =>
-          order.owner === account && Date.now() - new Date(order.creationTime).getTime() < CANCELLED_ORDERS_PENDING_TIME
+        ({ owner, creationTime }) =>
+          owner.toLowerCase() === lowerCaseAccount &&
+          Date.now() - new Date(creationTime).getTime() < CANCELLED_ORDERS_PENDING_TIME
       )
 
       if (pending.length === 0) {

--- a/src/custom/state/orders/updaters/CancelledOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/CancelledOrdersUpdater.ts
@@ -27,7 +27,7 @@ import { fetchOrderPopupData, OrderLogPopupMixData } from 'state/orders/updaters
  * period and say it's cancelled even though in some cases it might actually be filled.
  */
 export function CancelledOrdersUpdater(): null {
-  const { chainId } = useActiveWeb3React()
+  const { chainId, account } = useActiveWeb3React()
 
   const cancelled = useCancelledOrders({ chainId })
 
@@ -38,10 +38,13 @@ export function CancelledOrdersUpdater(): null {
   const fulfillOrdersBatch = useFulfillOrdersBatch()
 
   const updateOrders = useCallback(
-    async (chainId: ChainId) => {
-      // Filter orders created in the last 5 min, no further
+    async (chainId: ChainId, account: string) => {
+      // Filter orders:
+      // - Owned by the current connected account
+      // - Created in the last 5 min, no further
       const pending = cancelledRef.current.filter(
-        (order) => Date.now() - new Date(order.creationTime).getTime() < CANCELLED_ORDERS_PENDING_TIME
+        (order) =>
+          order.owner === account && Date.now() - new Date(order.creationTime).getTime() < CANCELLED_ORDERS_PENDING_TIME
       )
 
       if (pending.length === 0) {
@@ -74,14 +77,14 @@ export function CancelledOrdersUpdater(): null {
   )
 
   useEffect(() => {
-    if (!chainId) {
+    if (!chainId || !account) {
       return
     }
 
-    const interval = setInterval(() => updateOrders(chainId), OPERATOR_API_POLL_INTERVAL)
+    const interval = setInterval(() => updateOrders(chainId, account), OPERATOR_API_POLL_INTERVAL)
 
     return () => clearInterval(interval)
-  }, [chainId, updateOrders])
+  }, [account, chainId, updateOrders])
 
   return null
 }

--- a/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
@@ -51,8 +51,9 @@ export function PendingOrdersUpdater(): null {
 
   const updateOrders = useCallback(
     async (chainId: ChainId, account: string) => {
+      const lowerCaseAccount = account.toLowerCase()
       // Only check pending orders of current connected account
-      const pending = pendingRef.current.filter((order) => order.owner === account)
+      const pending = pendingRef.current.filter(({ owner }) => owner.toLowerCase() === lowerCaseAccount)
 
       // Exit early when there are no pending orders
       if (pending.length === 0) {

--- a/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
@@ -36,7 +36,7 @@ function _getNewlyPreSignedOrders(allPendingOrders: Order[], signedOrdersIds: Or
 }
 
 export function PendingOrdersUpdater(): null {
-  const { chainId } = useActiveWeb3React()
+  const { chainId, account } = useActiveWeb3React()
 
   const pending = usePendingOrders({ chainId })
 
@@ -50,15 +50,18 @@ export function PendingOrdersUpdater(): null {
   const presignOrders = usePresignOrders()
 
   const updateOrders = useCallback(
-    async (chainId: ChainId) => {
+    async (chainId: ChainId, account: string) => {
+      // Only check pending orders of current connected account
+      const pending = pendingRef.current.filter((order) => order.owner === account)
+
       // Exit early when there are no pending orders
-      if (pendingRef.current.length === 0) {
+      if (pending.length === 0) {
         return
       }
 
       // Iterate over pending orders fetching API data
       const unfilteredOrdersData = await Promise.all(
-        pendingRef.current.map(async (orderFromStore) => fetchOrderPopupData(orderFromStore, chainId))
+        pending.map(async (orderFromStore) => fetchOrderPopupData(orderFromStore, chainId))
       )
 
       // Group resolved promises by status
@@ -76,7 +79,7 @@ export function PendingOrdersUpdater(): null {
       if (presigned.length > 0) {
         // Only mark as presigned the orders we were not aware of their new state
         const presignedOrderIds = presigned as OrderID[]
-        const ordersPresignaturePendingSigned = _getNewlyPreSignedOrders(pendingRef.current, presignedOrderIds)
+        const ordersPresignaturePendingSigned = _getNewlyPreSignedOrders(pending, presignedOrderIds)
 
         if (ordersPresignaturePendingSigned.length > 0) {
           presignOrders({
@@ -111,14 +114,14 @@ export function PendingOrdersUpdater(): null {
   )
 
   useEffect(() => {
-    if (!chainId) {
+    if (!chainId || !account) {
       return
     }
 
-    const interval = setInterval(() => updateOrders(chainId), OPERATOR_API_POLL_INTERVAL)
+    const interval = setInterval(() => updateOrders(chainId, account), OPERATOR_API_POLL_INTERVAL)
 
     return () => clearInterval(interval)
-  }, [chainId, updateOrders])
+  }, [account, chainId, updateOrders])
 
   return null
 }

--- a/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -74,8 +74,9 @@ export function UnfillableOrdersUpdater(): null {
       return
     }
 
+    const lowerCaseAccount = account.toLowerCase()
     // Only check pending orders of the connected account
-    const pending = pendingRef.current.filter((order) => order.owner === account)
+    const pending = pendingRef.current.filter(({ owner }) => owner.toLowerCase() === lowerCaseAccount)
 
     if (pending.length === 0) {
       return


### PR DESCRIPTION
# Summary

Waterfalls into https://github.com/gnosis/cowswap/pull/1639

Do not update orders that don't belong to the connected wallet

  # To Test

1. Place an order and open the link to the Explorer
2. Switch to a different account
3. Wait until the order is matched
* You should NOT get a notification about the order being filled
* The filled order should not be visible in the activity history
4. Repeat steps after cancelling and when an order is about to expire
* There should be no notification for orders not belonging to the connected account

