### PR TITLE
[Affiliate] Add tooltip and FAQ section 

### DIFF
--- a/src/custom/pages/Faq/index.tsx
+++ b/src/custom/pages/Faq/index.tsx
@@ -848,25 +848,11 @@ export default function Faq() {
             ).
           </p>
 
-          <h3 id="why-is-my-total-trade-referral-trade-volume-smaller-than-the-real-volume">
-            Why is my total trade/referral trade volume smaller than the real volume?
-          </h3>
-
-          <p>
-            Some tokens might not yet have a proper price feed linking them to a USD estimation at the date/time when
-            your trade was executed. When that happens the trade volume is set to 0. Thus, your total volume can be
-            smaller, or even be shown as 0 (see FAQ entry{' '}
-            <LinkScrollable href={'#what-is-the-source-of-truth-for-accounting-trade-volume'}>
-              What is the source of truth for accounting trade volume?
-            </LinkScrollable>
-            ).
-          </p>
-
           <h3 id="why-do-i-see-more-trades">
             Why do I see more trades and referrals in my profile page than I actually see in the activity list?
           </h3>
 
-          <p>The number of trades on the profile page is calculated based on blockchain data.</p>
+          <p>The number of trades on the profile page is calculated based on on-chain data.</p>
           <p>We have two publicly facing interfaces where both use the same contracts, which are:</p>
           <ul>
             <li>
@@ -882,9 +868,13 @@ export default function Faq() {
               </ExternalLink>
             </li>
           </ul>
+
           <p>
-            Even though both use the same contract, the backend services are different, and the data is stored in
-            isolated databases. Thus, when accessing{' '}
+            Even though both use the same contract, the backend services, solvers and infrastructure are independent.
+          </p>
+
+          <p>
+            Thus, when accessing{' '}
             <ExternalLink href="https://cowswap.exchange" target="_blank" rel="noopener noreferrer">
               <strong>https://cowswap.exchange</strong>
             </ExternalLink>{' '}
@@ -892,8 +882,12 @@ export default function Faq() {
             <ExternalLink href="https://barn.cowswap.exchange" target="_blank" rel="noopener noreferrer">
               <strong>https://barn.cowswap.exchange</strong>
             </ExternalLink>
-            . If you ever traded on both, you might have more trades than you would expect.
+            .
           </p>
+
+          <p>If you ever traded on both, you might have more trades than you would expect.</p>
+
+          <p>In the future, the data will be consolidated and this number will match your expectations.</p>
 
           <hr />
 

--- a/src/custom/pages/Faq/index.tsx
+++ b/src/custom/pages/Faq/index.tsx
@@ -848,6 +848,53 @@ export default function Faq() {
             ).
           </p>
 
+          <h3 id="why-is-my-total-trade-referral-trade-volume-smaller-than-the-real-volume">
+            Why is my total trade/referral trade volume smaller than the real volume?
+          </h3>
+
+          <p>
+            Some tokens might not yet have a proper price feed linking them to a USD estimation at the date/time when
+            your trade was executed. When that happens the trade volume is set to 0. Thus, your total volume can be
+            smaller, or even be shown as 0 (see FAQ entry{' '}
+            <LinkScrollable href={'#what-is-the-source-of-truth-for-accounting-trade-volume'}>
+              What is the source of truth for accounting trade volume?
+            </LinkScrollable>
+            ).
+          </p>
+
+          <h3 id="why-do-i-see-more-trades">
+            Why do I see more trades and referrals in my profile page than I actually see in the activity list?
+          </h3>
+
+          <p>The number of trades on the profile page is calculated based on blockchain data.</p>
+          <p>We have two publicly facing interfaces where both use the same contracts, which are:</p>
+          <ul>
+            <li>
+              The production version:{' '}
+              <ExternalLink href="https://cowswap.exchange" target="_blank" rel="noopener noreferrer">
+                <strong>https://cowswap.exchange</strong>
+              </ExternalLink>
+            </li>
+            <li>
+              The public test version:{' '}
+              <ExternalLink href="https://barn.cowswap.exchange" target="_blank" rel="noopener noreferrer">
+                <strong>https://barn.cowswap.exchange</strong>
+              </ExternalLink>
+            </li>
+          </ul>
+          <p>
+            Even though both use the same contract, the backend services are different, and the data is stored in
+            isolated databases. Thus, when accessing{' '}
+            <ExternalLink href="https://cowswap.exchange" target="_blank" rel="noopener noreferrer">
+              <strong>https://cowswap.exchange</strong>
+            </ExternalLink>{' '}
+            you&apos;ll see orders/trades placed only using this interface. The same is true for orders/trades placed on{' '}
+            <ExternalLink href="https://barn.cowswap.exchange" target="_blank" rel="noopener noreferrer">
+              <strong>https://barn.cowswap.exchange</strong>
+            </ExternalLink>
+            . If you ever traded on both, you might have more trades than you would expect.
+          </p>
+
           <hr />
 
           <p>

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -114,7 +114,12 @@ export default function Profile() {
                     <strong>{formatInt(profileData?.totalTrades)}</strong>
                   </Loader>
                   <Loader isLoading={isLoading}>
-                    <span>Total trades</span>
+                    <span>
+                      Total trades
+                      <MouseoverTooltipContent content="You may see more trades here that what you see in the activity list. To understand why, check out the FAQ.">
+                        <HelpCircle size={14} />
+                      </MouseoverTooltipContent>
+                    </span>
                   </Loader>
                 </FlexCol>
                 <FlexCol>

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -116,7 +116,7 @@ export default function Profile() {
                   <Loader isLoading={isLoading}>
                     <span>
                       Total trades
-                      <MouseoverTooltipContent content="You may see more trades here that what you see in the activity list. To understand why, check out the FAQ.">
+                      <MouseoverTooltipContent content="You may see more trades here than what you see in the activity list. To understand why, check out the FAQ.">
                         <HelpCircle size={14} />
                       </MouseoverTooltipContent>
                     </span>


### PR DESCRIPTION
# Summary

Closes #1705
[Source information.
](https://docs.google.com/document/d/1BC66i33FT3eAK3o3B01uM7xDha9fJ1pvNN5TuBBzwCA/edit#)![image](https://user-images.githubusercontent.com/622217/141193111-a17dfdaa-1a1b-45f3-8275-a995fc560d54.png)
![image](https://user-images.githubusercontent.com/622217/141195731-3d97488b-fb5c-4981-838c-12bdbdcabcb3.png)
  # To Test

1. Open the [page `profile`](https://pr1721--gpswapui.review.gnosisdev.com/#/profile) and hove the question icon near "Total trades" title to see the new tooltip.

2. Open the [page `FAQ`](https://pr1721--gpswapui.review.gnosisdev.com/#/faq#why-do-i-see-more-trades) and open the Why do I see more trades and referrals in my profile page than I actually see in the activity list? new entry.
