### PR TITLE
Add border radius to banner in Profile container

### DIFF
--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -1,3 +1,4 @@
+import styled from 'styled-components/macro'
 import { Txt } from 'assets/styles/styled'
 import {
   FlexCol,
@@ -55,9 +56,9 @@ export default function Profile() {
           )}
         </CardHead>
         {chainId && chainId !== ChainId.MAINNET && (
-          <NotificationBanner isVisible level="info" canClose={false}>
+          <StyledNotificationBanner isVisible level="info" canClose={false}>
             Profile data is only available for mainnet. Please change the network to see it.
-          </NotificationBanner>
+          </StyledNotificationBanner>
         )}
         <ChildWrapper>
           <Txt fs={16}>
@@ -174,3 +175,7 @@ const formatDecimal = (number?: number): string => {
 const formatInt = (number?: number): string => {
   return number ? number.toLocaleString() : '-'
 }
+
+const StyledNotificationBanner = styled(NotificationBanner)`
+  border-radius: 14px;
+`


### PR DESCRIPTION
# Summary

Closes #1738 

  # To Test

1. Connect wallet to a different network than mainnet
2. Go to /profile
3. Make sure the info message `Profile data is only available for mainnet. Please change the network to see it.` container has border radius set
