### PR TITLE
Change tooltips behaviour and add sample link

### DIFF
--- a/src/components/QuestionHelper/index.tsx
+++ b/src/components/QuestionHelper/index.tsx
@@ -31,13 +31,17 @@ const QuestionMark = styled.span`
 export default function QuestionHelper({ text }: { text: ReactNode; size?: number }) {
   const [show, setShow] = useState<boolean>(false)
 
-  const open = useCallback(() => setShow(true), [setShow])
-  const close = useCallback(() => setShow(false), [setShow])
+  const toggle = useCallback(() => setShow((show) => !show), [setShow])
 
   return (
     <span style={{ marginLeft: 4, display: 'flex', alignItems: 'center' }}>
       <Tooltip text={text} show={show}>
-        <QuestionWrapper onClick={open} onMouseEnter={open} onMouseLeave={close}>
+        <QuestionWrapper
+          style={{ display: 'inline-block', lineHeight: 0, padding: '0.25rem', cursor: 'pointer' }}
+          onMouseDown={toggle}
+          role="button"
+          tabIndex={0}
+        >
           <QuestionMark>?</QuestionMark>
         </QuestionWrapper>
       </Tooltip>

--- a/src/custom/components/QuestionHelper/QuestionHelperMod.tsx
+++ b/src/custom/components/QuestionHelper/QuestionHelperMod.tsx
@@ -45,13 +45,17 @@ export interface QuestionHelperProps extends Omit<TooltipProps, 'children' | 'sh
 export default function QuestionHelper({ text, className, QuestionMark, ...tooltipProps }: QuestionHelperProps) {
   const [show, setShow] = useState<boolean>(false)
 
-  const open = useCallback(() => setShow(true), [setShow])
-  const close = useCallback(() => setShow(false), [setShow])
+  const toggle = useCallback(() => setShow((show) => !show), [setShow])
 
   return (
     <QuestionHelperContainer className={className}>
       <Tooltip {...tooltipProps} show={show} text={text}>
-        <QuestionWrapper onClick={open} onMouseEnter={open} onMouseLeave={close}>
+        <QuestionWrapper
+          style={{ display: 'inline-block', lineHeight: 0, padding: '0.25rem', cursor: 'pointer' }}
+          onMouseDown={toggle}
+          role="button"
+          tabIndex={0}
+        >
           {/* <QuestionMark>?</QuestionMark> */}
           <QuestionMark />
         </QuestionWrapper>

--- a/src/custom/components/Tooltip/TooltipMod.tsx
+++ b/src/custom/components/Tooltip/TooltipMod.tsx
@@ -28,11 +28,16 @@ export function TooltipContent({ content, ...rest }: TooltipContentProps) {
 
 export function MouseoverTooltip({ children, ...rest }: Omit<TooltipProps, 'show'>) {
   const [show, setShow] = useState(false)
-  const open = useCallback(() => setShow(true), [setShow])
-  const close = useCallback(() => setShow(false), [setShow])
+  const toggle = useCallback(() => setShow((show) => !show), [setShow])
+
   return (
     <Tooltip {...rest} show={show}>
-      <div onMouseEnter={open} onMouseLeave={close}>
+      <div
+        style={{ display: 'inline-block', lineHeight: 0, padding: '0.25rem', cursor: 'pointer' }}
+        onMouseDown={toggle}
+        role="button"
+        tabIndex={0}
+      >
         {children}
       </div>
     </Tooltip>
@@ -41,14 +46,14 @@ export function MouseoverTooltip({ children, ...rest }: Omit<TooltipProps, 'show
 
 export function MouseoverTooltipContent({ content, children, ...rest }: Omit<TooltipContentProps, 'show'>) {
   const [show, setShow] = useState(false)
-  const open = useCallback(() => setShow(true), [setShow])
-  const close = useCallback(() => setShow(false), [setShow])
+  const toggle = useCallback(() => setShow((show) => !show), [setShow])
   return (
     <TooltipContent {...rest} show={show} content={content}>
       <div
-        style={{ display: 'inline-block', lineHeight: 0, padding: '0.25rem' }}
-        onMouseEnter={open}
-        onMouseLeave={close}
+        style={{ display: 'inline-block', lineHeight: 0, padding: '0.25rem', cursor: 'pointer' }}
+        onMouseDown={toggle}
+        role="button"
+        tabIndex={0}
       >
         {children}
       </div>

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -76,7 +76,13 @@ export default function Profile() {
           <ChildWrapper>
             <ItemTitle>
               Trades&nbsp;
-              <MouseoverTooltipContent content="Statistics regarding your own trades.">
+              <MouseoverTooltipContent
+                content={
+                  <p>
+                    Statistics regarding your own trades. <a href="faq#/faq#trading">See FAQ section</a>
+                  </p>
+                }
+              >
                 <HelpCircle size={14} />
               </MouseoverTooltipContent>
             </ItemTitle>


### PR DESCRIPTION
# Summary

**WIP!**

Fixes #1744 
I've changed the tooltips behaviour in order to open it when the user click/tap the icon insted of hover it. Also added a sample link inside a tooltip. 
Perhaps it will work on hover, but the tooltip will not disappear when the pointer leaves the icon (? or i) as Leandro suggested. 

![image](https://user-images.githubusercontent.com/622217/139942745-24b35c76-53ce-4d42-bb07-cecf58bf7898.png)

  # To Test

1. Open the page `profile` and try to open the tooltip beside Trades title. There is a sample link to FAQ page.

