### PR TITLE
[1689 - Quote Endpoint] Add new quote getting methods in API and Price (fix types)

### DIFF
--- a/cypress-custom/integration/fee.test.ts
+++ b/cypress-custom/integration/fee.test.ts
@@ -1,21 +1,51 @@
 import { WETH9 as WETH } from '@uniswap/sdk-core'
-import { OrderKind } from '@gnosis.pm/gp-v2-contracts'
-import { FeeQuoteParams, FeeInformation } from '../../src/custom/utils/price'
+import { GetQuoteResponse } from '@gnosis.pm/gp-v2-contracts'
 import { parseUnits } from 'ethers/lib/utils'
 
 const DAI = '0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735'
 const FOUR_HOURS = 3600 * 4 * 1000
 const DEFAULT_SELL_TOKEN = WETH[4]
+const DEFAULT_APP_DATA = '0x0000000000000000000000000000000000000000000000000000000000000000'
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
-const getFeeQuery = ({ sellToken, buyToken, amount, kind }: Omit<FeeQuoteParams, 'chainId'>) =>
-  `https://protocol-rinkeby.dev.gnosisdev.com/api/v1/fee?sellToken=${sellToken}&buyToken=${buyToken}&amount=${amount}&kind=${kind}`
+const FEE_QUERY = `https://protocol-rinkeby.dev.gnosisdev.com/api/v1/quote`
 
-function _assertFeeData(fee: FeeInformation | string): void {
+const baseParams = {
+  from: ZERO_ADDRESS,
+  receiver: ZERO_ADDRESS,
+  validTo: Math.ceil(Date.now() / 1000 + 500),
+  appData: DEFAULT_APP_DATA,
+  sellTokenBalance: 'erc20',
+  buyTokenBalance: 'erc20',
+  partiallyFillable: false,
+}
+
+const mockQuoteResponse = {
+  quote: {
+    // arb props here..
+    sellToken: '0x6810e776880c02933d47db1b9fc05908e5386b96',
+    buyToken: '0x6810e776880c02933d47db1b9fc05908e5386b96',
+    receiver: '0x6810e776880c02933d47db1b9fc05908e5386b96',
+    sellAmount: '1234567890',
+    buyAmount: '1234567890',
+    validTo: 0,
+    appData: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    feeAmount: '1234567890',
+    kind: 'buy',
+    partiallyFillable: true,
+    sellTokenBalance: 'erc20',
+    buyTokenBalance: 'erc20',
+  },
+  from: ZERO_ADDRESS,
+}
+
+function _assertFeeData(fee: GetQuoteResponse): void {
   if (typeof fee === 'string') {
     fee = JSON.parse(fee)
   }
-  expect(fee).to.have.property('amount')
-  expect(fee).to.have.property('expirationDate')
+  expect(fee).to.have.property('quote')
+  expect(fee).to.have.property('expiration')
+  expect(fee.quote).to.have.property('feeAmount')
 }
 
 /* Fee not currently being saved in local so commenting this out
@@ -54,18 +84,25 @@ function _assertFeeFetched(token: string): Cypress.Chainable {
 
 describe('Fee endpoint', () => {
   it('Returns the expected info', () => {
-    const FEE_QUERY = getFeeQuery({
+    const params = {
       sellToken: DEFAULT_SELL_TOKEN.address,
       buyToken: DAI,
-      amount: parseUnits('0.1', DEFAULT_SELL_TOKEN.decimals).toString(),
-      kind: OrderKind.SELL,
+      sellAmountBeforeFee: parseUnits('0.1', DEFAULT_SELL_TOKEN.decimals).toString(),
+      kind: 'sell',
       fromDecimals: DEFAULT_SELL_TOKEN.decimals,
       toDecimals: 6,
-    })
+      // BASE PARAMS
+      ...baseParams,
+    }
 
     // GIVEN: -
     // WHEN: Call fee API
-    cy.request(FEE_QUERY)
+    cy.request({
+      method: 'POST',
+      url: FEE_QUERY,
+      body: params,
+      log: true,
+    })
       .its('body')
       // THEN: The API response has the expected data
       .should(_assertFeeData)
@@ -74,14 +111,6 @@ describe('Fee endpoint', () => {
 
 describe('Fee: Complex fetch and persist fee', () => {
   const INPUT_AMOUNT = '0.1'
-  const FEE_QUERY = getFeeQuery({
-    sellToken: DEFAULT_SELL_TOKEN.address,
-    buyToken: DAI,
-    amount: parseUnits(INPUT_AMOUNT, DEFAULT_SELL_TOKEN.decimals).toString(),
-    kind: OrderKind.SELL,
-    fromDecimals: DEFAULT_SELL_TOKEN.decimals,
-    toDecimals: 6,
-  })
 
   // Needs to run first to pass because of Cypress async issues between tests
   it('Re-fetched when it expires', () => {
@@ -89,8 +118,8 @@ describe('Fee: Complex fetch and persist fee', () => {
     const SIX_HOURS = FOUR_HOURS * 1.5
     const LATER_TIME = new Date(Date.now() + SIX_HOURS).toISOString()
     const LATER_FEE = {
-      expirationDate: LATER_TIME,
-      amount: '0',
+      ...mockQuoteResponse,
+      expiration: LATER_TIME,
     }
 
     // only override Date functions (default is to override all time based functions)
@@ -116,9 +145,9 @@ describe('Fee: Complex fetch and persist fee', () => {
           const mockedTime = new Date($clock.details().now)
 
           // THEN: fee time is properly stubbed and
-          expect(body.expirationDate).to.equal(LATER_TIME)
+          expect(body.expiration).to.equal(LATER_TIME)
           // THEN: the mocked later date is indeed less than the new fee (read: the fee is valid)
-          expect(new Date(body.expirationDate)).to.be.greaterThan(mockedTime)
+          expect(new Date(body.expiration)).to.be.greaterThan(mockedTime)
         })
     })
   })
@@ -126,18 +155,10 @@ describe('Fee: Complex fetch and persist fee', () => {
 
 describe('Fee: simple checks it exists', () => {
   const INPUT_AMOUNT = '0.1'
-  const FEE_QUERY = getFeeQuery({
-    sellToken: DEFAULT_SELL_TOKEN.address,
-    buyToken: DAI,
-    amount: parseUnits(INPUT_AMOUNT, DEFAULT_SELL_TOKEN.decimals).toString(),
-    kind: OrderKind.SELL,
-    fromDecimals: DEFAULT_SELL_TOKEN.decimals,
-    toDecimals: 6,
-  })
-  const FEE_RESP = {
+  const QUOTE_RESP = {
+    ...mockQuoteResponse,
     // 1 min in future
-    expirationDate: new Date(Date.now() + 60000).toISOString(),
-    amount: parseUnits('0.05', DEFAULT_SELL_TOKEN.decimals).toString(),
+    expiration: new Date(Date.now() + 60000).toISOString(),
   }
 
   it('Fetch fee when selecting both tokens', () => {
@@ -145,7 +166,7 @@ describe('Fee: simple checks it exists', () => {
     cy.stubResponse({
       url: FEE_QUERY,
       alias: 'feeRequest',
-      body: FEE_RESP,
+      body: QUOTE_RESP,
     })
     // GIVEN: A user loads the swap page
     // WHEN: Select DAI token as output and sells 0.1 WETH

--- a/cypress-custom/support/commands.js
+++ b/cypress-custom/support/commands.js
@@ -53,7 +53,7 @@ function enterOutputAmount(tokenAddress, amount, selectToken = false) {
 }
 
 function stubResponse({ url, alias = 'stubbedResponse', body }) {
-  cy.intercept({ method: 'GET', url }, _responseHandlerFactory(body)).as(alias)
+  cy.intercept({ method: 'POST', url }, _responseHandlerFactory(body)).as(alias)
 }
 
 Cypress.Commands.add('swapClickInputToken', () => clickInputToken)

--- a/src/custom/api/gnosisProtocol/index.ts
+++ b/src/custom/api/gnosisProtocol/index.ts
@@ -17,9 +17,8 @@ export const {
   getOrderLink = realApi.getOrderLink,
   sendOrder = realApi.sendOrder,
   sendSignedOrderCancellation = realApi.sendSignedOrderCancellation,
-  getPriceQuote = realApi.getPriceQuote,
+  getQuote = realApi.getQuote,
   getPriceQuoteLegacy = realApi.getPriceQuoteLegacy,
-  getFeeQuote = realApi.getFeeQuote,
   getOrder = realApi.getOrder,
   // functions that only have a mock
 } = useMock ? { ...mockApi } : { ...realApi }

--- a/src/custom/api/gnosisProtocol/index.ts
+++ b/src/custom/api/gnosisProtocol/index.ts
@@ -18,6 +18,7 @@ export const {
   sendOrder = realApi.sendOrder,
   sendSignedOrderCancellation = realApi.sendSignedOrderCancellation,
   getPriceQuote = realApi.getPriceQuote,
+  getPriceQuoteLegacy = realApi.getPriceQuoteLegacy,
   getFeeQuote = realApi.getFeeQuote,
   getOrder = realApi.getOrder,
   // functions that only have a mock

--- a/src/custom/hooks/useGetGpApiStatus.ts
+++ b/src/custom/hooks/useGetGpApiStatus.ts
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react'
 export type GpQuoteStatus = 'COWSWAP' | 'LEGACY'
 // TODO: use actual API call
 export async function checkGpQuoteApiStatus(): Promise<GpQuoteStatus> {
-  return new Promise((accept) => setTimeout(() => accept('COWSWAP'), 500))
+  return new Promise((accept) => setTimeout(() => accept('LEGACY'), 500))
 }
 const GP_QUOTE_STATUS_INTERVAL_TIME = ms`2 hours`
 

--- a/src/custom/hooks/useUSDCPrice/index.ts
+++ b/src/custom/hooks/useUSDCPrice/index.ts
@@ -18,6 +18,7 @@ import { tryParseAmount } from 'state/swap/hooks'
 import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
 import { currencyId } from 'utils/currencyId'
 import { USDC } from 'constants/tokens'
+import { useOrderValidTo } from 'state/user/hooks'
 
 export * from '@src/hooks/useUSDCPrice'
 
@@ -37,6 +38,7 @@ export default function useUSDCPrice(currency?: Currency) {
   const [error, setError] = useState<Error | null>(null)
 
   const { chainId, account } = useActiveWeb3React()
+  const validTo = useOrderValidTo()
 
   const amountOut = chainId ? STABLECOIN_AMOUNT_OUT[chainId] : undefined
   const stablecoin = amountOut?.currency
@@ -83,6 +85,7 @@ export default function useUSDCPrice(currency?: Currency) {
       fromDecimals: currency.decimals,
       toDecimals: stablecoin.decimals,
       userAddress: account,
+      validTo,
     }
 
     if (currency.wrapped.equals(stablecoin)) {
@@ -121,7 +124,7 @@ export default function useUSDCPrice(currency?: Currency) {
           })
         })
     }
-  }, [amountOut, chainId, currency, stablecoin, account])
+  }, [amountOut, chainId, currency, stablecoin, account, validTo])
 
   return { price: bestUsdPrice, error }
 }

--- a/src/custom/state/price/reducer.ts
+++ b/src/custom/state/price/reducer.ts
@@ -62,7 +62,7 @@ export default createReducer(initialState, (builder) =>
      */
     .addCase(getNewQuote, (state, action) => {
       const quoteData = action.payload
-      const { sellToken, buyToken, fromDecimals, toDecimals, amount, chainId, kind } = quoteData
+      const { sellToken, buyToken, fromDecimals, toDecimals, amount, chainId, kind, validTo } = quoteData
       initializeState(state.quotes, action)
 
       // Reset quote params
@@ -79,6 +79,7 @@ export default createReducer(initialState, (builder) =>
         lastCheck: Date.now(),
         // Reset price
         price: getResetPrice(sellToken, buyToken, kind),
+        validTo,
       }
 
       // Activate loader

--- a/src/custom/state/price/updater.ts
+++ b/src/custom/state/price/updater.ts
@@ -18,6 +18,7 @@ import { useActiveWeb3React } from 'hooks/web3'
 import useDebounce from 'hooks/useDebounce'
 import useIsOnline from 'hooks/useIsOnline'
 import { QuoteInformationObject } from './reducer'
+import { useOrderValidTo } from 'state/user/hooks'
 
 const DEBOUNCE_TIME = 350
 const REFETCH_CHECK_INTERVAL = 10000 // Every 10s
@@ -140,6 +141,7 @@ export default function FeesUpdater(): null {
 
   const windowVisible = useIsWindowVisible()
   const isOnline = useIsOnline()
+  const validTo = useOrderValidTo()
 
   // Update if any parameter is changing
   useEffect(() => {
@@ -164,6 +166,7 @@ export default function FeesUpdater(): null {
       kind,
       amount: amount.quotient.toString(),
       userAddress: account,
+      validTo,
     }
 
     // Don't refetch if offline.
@@ -241,6 +244,7 @@ export default function FeesUpdater(): null {
     setQuoteError,
     account,
     lastUnsupportedCheck,
+    validTo,
   ])
 
   return null

--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -2,7 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import BigNumberJs from 'bignumber.js'
 import * as Sentry from '@sentry/browser'
 
-import { getFeeQuote, getPriceQuote, getPriceQuoteLegacy as getPriceQuoteGp, OrderMetaData } from 'api/gnosisProtocol'
+import { getQuote, getPriceQuoteLegacy as getPriceQuoteGp, OrderMetaData } from 'api/gnosisProtocol'
 import GpQuoteError, { GpQuoteErrorCodes } from 'api/gnosisProtocol/errors/QuoteError'
 import { getCanonicalMarket, isPromiseFulfilled, withTimeout } from 'utils/misc'
 import { formatAtoms } from 'utils/format'
@@ -255,7 +255,7 @@ export async function getBestPrice(params: PriceQuoteParams, options?: GetBestPr
  */
 export async function getFullQuote({ quoteParams }: { quoteParams: FeeQuoteParams }): Promise<QuoteResult> {
   const { kind } = quoteParams
-  const { quote, expirationDate } = await getPriceQuote(quoteParams)
+  const { quote, expirationDate } = await getQuote(quoteParams)
 
   const price = {
     amount: kind === OrderKind.SELL ? quote.buyAmount : quote.sellAmount,
@@ -279,7 +279,7 @@ export async function getBestQuoteLegacy({ quoteParams, fetchFee, previousFee }:
   // Get a new fee quote (if required)
   const feePromise =
     fetchFee || !previousFee
-      ? getFeeQuote({ chainId, sellToken, buyToken, fromDecimals, toDecimals, amount, kind, validTo })
+      ? getQuote(quoteParams).then((resp) => ({ amount: resp.quote.feeAmount, expirationDate: resp.expirationDate }))
       : Promise.resolve(previousFee)
 
   // Get a new price quote

--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -2,7 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import BigNumberJs from 'bignumber.js'
 import * as Sentry from '@sentry/browser'
 
-import { getFeeQuote, getPriceQuote as getPriceQuoteGp, OrderMetaData } from 'api/gnosisProtocol'
+import { getFeeQuote, getPriceQuote, getPriceQuoteLegacy as getPriceQuoteGp, OrderMetaData } from 'api/gnosisProtocol'
 import GpQuoteError, { GpQuoteErrorCodes } from 'api/gnosisProtocol/errors/QuoteError'
 import { getCanonicalMarket, isPromiseFulfilled, withTimeout } from 'utils/misc'
 import { formatAtoms } from 'utils/format'
@@ -15,9 +15,10 @@ import {
 } from 'api/matcha-0x'
 
 import { OptimalRate } from 'paraswap-core'
-import { OrderKind } from '@gnosis.pm/gp-v2-contracts'
+import { GetQuoteResponse, OrderKind } from '@gnosis.pm/gp-v2-contracts'
 import { ChainId } from 'state/lists/actions'
 import { toErc20Address } from 'utils/tokens'
+import { GpQuoteStatus } from 'hooks/useGetGpApiStatus'
 
 const FEE_EXCEEDS_FROM_ERROR = new GpQuoteError({
   errorType: GpQuoteErrorCodes.FeeExceedsFrom,
@@ -41,6 +42,19 @@ export interface PriceInformation {
   amount: string | null
 }
 
+// GetQuoteResponse from @gnosis.pm/gp-v2-contracts types Timestamp and BigNumberish
+// do not play well with our existing methods, using string instead
+export type SimpleGetQuoteResponse = Pick<GetQuoteResponse, 'from'> & {
+  // We need to map BigNumberIsh and Timestamp to what we use: string
+  quote: Omit<GetQuoteResponse['quote'], 'sellAmount' | 'buyAmount' | 'feeAmount' | 'validTo'> & {
+    sellAmount: string
+    buyAmount: string
+    validTo: string
+    feeAmount: string
+  }
+  expirationDate: string
+}
+
 export class PriceQuoteError extends Error {
   params: PriceQuoteParams
   results: PromiseSettledResult<any>[]
@@ -58,14 +72,12 @@ export type FeeQuoteParams = Pick<OrderMetaData, 'sellToken' | 'buyToken' | 'kin
   toDecimals: number
   chainId: ChainId
   userAddress?: string | null
+  validTo: number
 }
 
 export type PriceQuoteParams = Omit<FeeQuoteParams, 'sellToken' | 'buyToken'> & {
   baseToken: string
   quoteToken: string
-  fromDecimals: number
-  toDecimals: number
-  userAddress?: string | null
 }
 
 export type PriceSource = 'gnosis-protocol' | 'paraswap' | 'matcha-0x'
@@ -237,16 +249,37 @@ export async function getBestPrice(params: PriceQuoteParams, options?: GetBestPr
 }
 
 /**
+ * getFullQuote
+ * Queries the new Quote api endpoint found here: https://protocol-mainnet.gnosis.io/api/#/default/post_api_v1_quote
+ * TODO: consider name // check with backend when logic returns best quote, not first
+ */
+export async function getFullQuote({ quoteParams }: { quoteParams: FeeQuoteParams }): Promise<QuoteResult> {
+  const { kind } = quoteParams
+  const { quote, expirationDate } = await getPriceQuote(quoteParams)
+
+  const price = {
+    amount: kind === OrderKind.SELL ? quote.buyAmount : quote.sellAmount,
+    token: kind === OrderKind.SELL ? quote.buyToken : quote.sellToken,
+  }
+  const fee = {
+    amount: quote.feeAmount,
+    expirationDate,
+  }
+
+  return Promise.allSettled([price, fee])
+}
+
+/**
+ * (LEGACY) Will be overwritten in the near future
  *  Return the best quote considering all price feeds. The quote contains information about the price and fee
  */
-export async function getBestQuote({ quoteParams, fetchFee, previousFee }: QuoteParams): Promise<QuoteResult> {
-  const { sellToken, buyToken, fromDecimals, toDecimals, amount, kind, chainId, userAddress } = quoteParams
+export async function getBestQuoteLegacy({ quoteParams, fetchFee, previousFee }: QuoteParams): Promise<QuoteResult> {
+  const { sellToken, buyToken, fromDecimals, toDecimals, amount, kind, chainId, userAddress, validTo } = quoteParams
   const { baseToken, quoteToken } = getCanonicalMarket({ sellToken, buyToken, kind })
-
   // Get a new fee quote (if required)
   const feePromise =
     fetchFee || !previousFee
-      ? getFeeQuote({ chainId, sellToken, buyToken, fromDecimals, toDecimals, amount, kind })
+      ? getFeeQuote({ chainId, sellToken, buyToken, fromDecimals, toDecimals, amount, kind, validTo })
       : Promise.resolve(previousFee)
 
   // Get a new price quote
@@ -280,11 +313,35 @@ export async function getBestQuote({ quoteParams, fetchFee, previousFee }: Quote
           amount: exchangeAmount,
           kind,
           userAddress,
+          validTo,
         })
       : // fee exceeds our price, is invalid
         Promise.reject(FEE_EXCEEDS_FROM_ERROR)
 
   return Promise.allSettled([pricePromise, feePromise])
+}
+
+export async function getBestQuote({
+  quoteParams,
+  fetchFee,
+  previousFee,
+  apiStatus,
+}: QuoteParams & {
+  apiStatus: GpQuoteStatus
+}): Promise<QuoteResult> {
+  if (apiStatus === 'COWSWAP') {
+    return getFullQuote({ quoteParams }).catch((err) => {
+      console.error(
+        '[PRICE::API] getBestQuote - error in COWSWAP full quote endpoint, reason: <',
+        err,
+        '> - trying back up price sources...'
+      )
+      // ATTEMPT LEGACY CALL
+      return getBestQuote({ apiStatus: 'LEGACY', quoteParams, fetchFee, previousFee, isPriceRefresh: false })
+    })
+  } else {
+    return getBestQuoteLegacy({ quoteParams, fetchFee, previousFee, isPriceRefresh: false })
+  }
 }
 
 export function getValidParams(params: PriceQuoteParams) {


### PR DESCRIPTION
# Summary

Part of #1689 - adds methods // logic for new quote endpoint and fixes some types 

1. uses `SimpleGetQuoteResponse` to replace `GetQuoteResponse` as the exported types from `@gnosis.pm/gp-v2-contracts` types: `Timestamp` and `BigNumberIsh` (for `validTo` and `sellAmount` & `buyAmount`, respectively) do not work well with our app, which expects `string` for those properties. (see [here](https://github.com/gnosis/cowswap/commit/7e376e37474cff7e7ea874aaa30e9d2253e38df5#diff-45a217d510a1a27581373f32a6b4f34a139903da2b31d5a722c281f104715695R47))
2. checks against `gpApiStatus` returned by `useGetGpApiStatus` hook (which is currently mocked) and returns the proper api price getting method. COWSWAP (new) errors and falls back to LEGACY