### PR TITLE
Filter by connected user

### DIFF
--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -63,9 +63,10 @@ export default function useRecentActivity() {
     // Filter out any pending/fulfilled orders OLDER than 1 day
     // and adjust order object to match TransactionDetail addedTime format
     // which is used later in app to render list of activity
+    const accountLowerCase = account.toLowerCase()
     const adjustedOrders = allNonEmptyOrders
       // Only show orders for connected account
-      .filter((order) => order.owner.toLowerCase() === account.toLowerCase())
+      .filter((order) => order.owner.toLowerCase() === accountLowerCase)
       // Only recent orders
       .filter(isOrderRecent)
       .map((order) => {
@@ -81,12 +82,17 @@ export default function useRecentActivity() {
   }, [allNonEmptyOrders, account])
 
   const recentTransactionsAdjusted = useMemo<TransactionAndOrder[]>(() => {
+    if (!account) {
+      return []
+    }
+
     // Filter out any pending/fulfilled transactions OLDER than 1 day
     // and adjust order object to match Order id + status format
     // which is used later in app to render list of activity
+    const accountLowerCase = account.toLowerCase()
     const adjustedTransactions = Object.values(allTransactions)
       // Only show orders for connected account
-      .filter((tx) => tx.from.toLowerCase() === account.toLowerCase())
+      .filter((tx) => tx.from.toLowerCase() === accountLowerCase)
       // Only recent transactions
       .filter(isTransactionRecent)
       .map((tx) => {

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -99,7 +99,7 @@ export default function useRecentActivity() {
       })
 
     return adjustedTransactions
-  }, [allTransactions])
+  }, [allTransactions, account])
 
   return useMemo(() => {
     // Concat together the EnhancedTransactionDetails[] and Orders[]

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -64,9 +64,9 @@ export default function useRecentActivity() {
     // and adjust order object to match TransactionDetail addedTime format
     // which is used later in app to render list of activity
     const adjustedOrders = allNonEmptyOrders
-      // only show orders for connected account
+      // Only show orders for connected account
       .filter((order) => order.owner.toLowerCase() === account.toLowerCase())
-      // Only recent
+      // Only recent orders
       .filter(isOrderRecent)
       .map((order) => {
         // we need to essentially match EnhancedTransactionDetails type which uses "addedTime" for date checking
@@ -85,6 +85,9 @@ export default function useRecentActivity() {
     // and adjust order object to match Order id + status format
     // which is used later in app to render list of activity
     const adjustedTransactions = Object.values(allTransactions)
+      // Only show orders for connected account
+      .filter((tx) => tx.from === account)
+      // Only recent transactions
       .filter(isTransactionRecent)
       .map((tx) => {
         return {

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -86,7 +86,7 @@ export default function useRecentActivity() {
     // which is used later in app to render list of activity
     const adjustedTransactions = Object.values(allTransactions)
       // Only show orders for connected account
-      .filter((tx) => tx.from === account)
+      .filter((tx) => tx.from.toLowerCase() === account.toLowerCase())
       // Only recent transactions
       .filter(isTransactionRecent)
       .map((tx) => {


### PR DESCRIPTION
# Summary

This PR makes the recent activity not to show all the activities from all accounts anymore.

Now, only the connected wallet will be displayed. 

## Not included
It doesn't prevent the process that check if tx are mined in the background (aka: Updater) to stop checking on other account's tx.

This is why you might hear a mooooo even thought there's "nothing pending" for the current account. 
A future PR will address this. 


# To Test

1. Use 2 accounts to do some operations. 
2. Each account should have only their own activities

# Background
This is part of what Leandro is doing for loading orders from the API: https://github.com/gnosis/cowswap/pull/1639 
However, his Pr is more ambitious, and will take a bit more to complete.
This will be just a temporary feature while we don't have the loading of orders from the API. 