### PR TITLE
Do not update orders other accounts

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,11 +8,7 @@
       "jsx": true
     }
   },
-  "ignorePatterns": [
-    "node_modules/**/*",
-    ".github/*",
-    "src/components/RateToggle/index.tsx"
-  ],
+  "ignorePatterns": ["node_modules/**/*", ".github/*", "src/components/RateToggle/index.tsx"],
   "settings": {
     "react": {
       "version": "detect"
@@ -34,10 +30,7 @@
     "@typescript-eslint/ban-ts-ignore": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "react/react-in-jsx-scope": "off",
-    "object-shorthand": [
-      "error",
-      "always"
-    ],
+    "object-shorthand": ["error", "always"],
     "no-restricted-imports": [
       "error",
       {
@@ -47,9 +40,7 @@
             "message": "Please import from styled-components/macro."
           }
         ],
-        "patterns": [
-          "!styled-components/macro"
-        ]
+        "patterns": ["!styled-components/macro"]
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "CowSwap - Gnosis Protocol",
   "homepage": ".",
   "private": true,
-  "version": "1.4.4-rc.0",
+  "version": "1.4.4",
   "engines": {
     "node": ">=14.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "CowSwap - Gnosis Protocol",
   "homepage": ".",
   "private": true,
-  "version": "1.4.3",
+  "version": "1.4.4-rc.0",
   "engines": {
     "node": ">=14.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "CowSwap - Gnosis Protocol",
   "homepage": ".",
   "private": true,
-  "version": "1.4.3",
+  "version": "1.4.4-cache.1",
   "engines": {
     "node": ">=14.0.0"
   },
@@ -141,7 +141,7 @@
   "scripts": {
     "start:default": "craco start",
     "start": "REACT_APP_DISABLE_TOKEN_WARNING=true yarn start:default",
-    "start:service-worker": "yarn build && yarn serve -s build",
+    "start:service-worker": "yarn build && yarn serve",
     "mock": "REACT_APP_MOCK=true yarn start",
     "build": "craco build",
     "ipfs:build": "cross-env PUBLIC_URL=\".\" yarn build",

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -216,7 +216,7 @@ export default function Swap({
   const nativeInput = !!(tradeCurrentVersion?.tradeType === TradeType.EXACT_INPUT)
     ? tradeCurrentVersion?.inputAmount
     : // else use the slippage + fee adjusted amount
-    computeSlippageAdjustedAmounts(tradeCurrentVersion, allowedSlippage).INPUT
+      computeSlippageAdjustedAmounts(tradeCurrentVersion, allowedSlippage).INPUT
 
   const {
     wrapType,
@@ -244,15 +244,15 @@ export default function Swap({
     () =>
       showWrap
         ? {
-          [Field.INPUT]: parsedAmount,
-          [Field.OUTPUT]: parsedAmount,
-        }
+            [Field.INPUT]: parsedAmount,
+            [Field.OUTPUT]: parsedAmount,
+          }
         : {
-          // [Field.INPUT]: independentField === Field.INPUT ? parsedAmount : trade?.inputAmount,
-          // [Field.OUTPUT]: independentField === Field.OUTPUT ? parsedAmount : trade?.outputAmount,
-          [Field.INPUT]: independentField === Field.INPUT ? parsedAmount : trade?.inputAmountWithoutFee,
-          [Field.OUTPUT]: independentField === Field.OUTPUT ? parsedAmount : trade?.outputAmountWithoutFee,
-        },
+            // [Field.INPUT]: independentField === Field.INPUT ? parsedAmount : trade?.inputAmount,
+            // [Field.OUTPUT]: independentField === Field.OUTPUT ? parsedAmount : trade?.outputAmount,
+            [Field.INPUT]: independentField === Field.INPUT ? parsedAmount : trade?.inputAmountWithoutFee,
+            [Field.OUTPUT]: independentField === Field.OUTPUT ? parsedAmount : trade?.outputAmountWithoutFee,
+          },
     [independentField, parsedAmount, showWrap, trade]
   )
 
@@ -404,8 +404,8 @@ export default function Swap({
             recipient === null
               ? 'Swap w/o Send'
               : (recipientAddress ?? recipient) === account
-                ? 'Swap w/o Send + recipient'
-                : 'Swap w/ Send',
+              ? 'Swap w/o Send + recipient'
+              : 'Swap w/ Send',
           label: [
             trade?.inputAmount?.currency?.symbol,
             trade?.outputAmount?.currency?.symbol,
@@ -594,7 +594,7 @@ export default function Swap({
               <AutoColumn justify="space-between" style={{ margin: `${isExpertMode ? 10 : 3}px 0` }}>
                 <AutoRow
                   justify={isExpertMode ? 'space-between' : 'center'}
-                // style={{ padding: '0 1rem' }}
+                  // style={{ padding: '0 1rem' }}
                 >
                   <ArrowWrapperLoader onSwitchTokens={onSwitchTokens} setApprovalSubmitted={setApprovalSubmitted} />
                   {recipient === null && !showWrap && isExpertMode ? (
@@ -900,7 +900,7 @@ export default function Swap({
                       !isValid ||
                       (approvalState !== ApprovalState.APPROVED && signatureState !== UseERC20PermitState.SIGNED) // || priceImpactTooHigh
                     }
-                  // error={isValid && priceImpactSeverity > 2}
+                    // error={isValid && priceImpactSeverity > 2}
                   >
                     <SwapButton showLoading={swapBlankState || isGettingNewQuote}>
                       <Trans>Swap</Trans>
@@ -935,7 +935,7 @@ export default function Swap({
                 }}
                 id="swap-button"
                 disabled={!isValid /*|| priceImpactTooHigh */ || !!swapCallbackError}
-              // error={isValid && priceImpactSeverity > 2 && !swapCallbackError}
+                // error={isValid && priceImpactSeverity > 2 && !swapCallbackError}
               >
                 <SwapButton showLoading={swapBlankState || isGettingNewQuote}>
                   {swapInputError || <Trans>Swap</Trans>}

--- a/src/custom/state/orders/updaters/CancelledOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/CancelledOrdersUpdater.ts
@@ -40,14 +40,15 @@ export function CancelledOrdersUpdater(): null {
   const updateOrders = useCallback(
     async (chainId: ChainId, account: string) => {
       const lowerCaseAccount = account.toLowerCase()
+      const now = Date.now()
       // Filter orders:
       // - Owned by the current connected account
       // - Created in the last 5 min, no further
-      const pending = cancelledRef.current.filter(
-        ({ owner, creationTime }) =>
-          owner.toLowerCase() === lowerCaseAccount &&
-          Date.now() - new Date(creationTime).getTime() < CANCELLED_ORDERS_PENDING_TIME
-      )
+      const pending = cancelledRef.current.filter(({ owner, creationTime: creationTimeString }) => {
+        const creationTime = new Date(creationTimeString).getTime()
+
+        return owner.toLowerCase() === lowerCaseAccount && now - creationTime < CANCELLED_ORDERS_PENDING_TIME
+      })
 
       if (pending.length === 0) {
         return

--- a/src/custom/state/orders/updaters/CancelledOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/CancelledOrdersUpdater.ts
@@ -39,12 +39,14 @@ export function CancelledOrdersUpdater(): null {
 
   const updateOrders = useCallback(
     async (chainId: ChainId, account: string) => {
+      const lowerCaseAccount = account.toLowerCase()
       // Filter orders:
       // - Owned by the current connected account
       // - Created in the last 5 min, no further
       const pending = cancelledRef.current.filter(
-        (order) =>
-          order.owner === account && Date.now() - new Date(order.creationTime).getTime() < CANCELLED_ORDERS_PENDING_TIME
+        ({ owner, creationTime }) =>
+          owner.toLowerCase() === lowerCaseAccount &&
+          Date.now() - new Date(creationTime).getTime() < CANCELLED_ORDERS_PENDING_TIME
       )
 
       if (pending.length === 0) {

--- a/src/custom/state/orders/updaters/CancelledOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/CancelledOrdersUpdater.ts
@@ -27,7 +27,7 @@ import { fetchOrderPopupData, OrderLogPopupMixData } from 'state/orders/updaters
  * period and say it's cancelled even though in some cases it might actually be filled.
  */
 export function CancelledOrdersUpdater(): null {
-  const { chainId } = useActiveWeb3React()
+  const { chainId, account } = useActiveWeb3React()
 
   const cancelled = useCancelledOrders({ chainId })
 
@@ -38,10 +38,13 @@ export function CancelledOrdersUpdater(): null {
   const fulfillOrdersBatch = useFulfillOrdersBatch()
 
   const updateOrders = useCallback(
-    async (chainId: ChainId) => {
-      // Filter orders created in the last 5 min, no further
+    async (chainId: ChainId, account: string) => {
+      // Filter orders:
+      // - Owned by the current connected account
+      // - Created in the last 5 min, no further
       const pending = cancelledRef.current.filter(
-        (order) => Date.now() - new Date(order.creationTime).getTime() < CANCELLED_ORDERS_PENDING_TIME
+        (order) =>
+          order.owner === account && Date.now() - new Date(order.creationTime).getTime() < CANCELLED_ORDERS_PENDING_TIME
       )
 
       if (pending.length === 0) {
@@ -74,14 +77,14 @@ export function CancelledOrdersUpdater(): null {
   )
 
   useEffect(() => {
-    if (!chainId) {
+    if (!chainId || !account) {
       return
     }
 
-    const interval = setInterval(() => updateOrders(chainId), OPERATOR_API_POLL_INTERVAL)
+    const interval = setInterval(() => updateOrders(chainId, account), OPERATOR_API_POLL_INTERVAL)
 
     return () => clearInterval(interval)
-  }, [chainId, updateOrders])
+  }, [account, chainId, updateOrders])
 
   return null
 }

--- a/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
@@ -113,7 +113,8 @@ async function _updateOrders({
   getSafeInfo,
 }: UpdateOrdersParams): Promise<void> {
   // Only check pending orders of current connected account
-  const pending = orders.filter((order) => order.owner === account)
+  const lowerCaseAccount = account.toLowerCase()
+  const pending = orders.filter(({ owner }) => owner.toLowerCase() === lowerCaseAccount)
 
   // Exit early when there are no pending orders
   if (pending.length === 0) {
@@ -192,8 +193,12 @@ export function PendingOrdersUpdater(): null {
   const getSafeInfo = useGetSafeInfo()
 
   const updateOrders = useCallback(
-    async (chainId: ChainId) =>
-      _updateOrders({
+    async (chainId: ChainId, account: string) => {
+      if (!account) {
+        return []
+      }
+
+      return _updateOrders({
         account,
         chainId,
         orders: pendingRef.current,
@@ -203,16 +208,9 @@ export function PendingOrdersUpdater(): null {
         presignOrders,
         updatePresignGnosisSafeTx,
         getSafeInfo,
-      }),
-    [
-      account,
-      cancelOrdersBatch,
-      updatePresignGnosisSafeTx,
-      expireOrdersBatch,
-      fulfillOrdersBatch,
-      presignOrders,
-      getSafeInfo,
-    ]
+      })
+    },
+    [cancelOrdersBatch, updatePresignGnosisSafeTx, expireOrdersBatch, fulfillOrdersBatch, presignOrders, getSafeInfo]
   )
 
   useEffect(() => {

--- a/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -74,8 +74,9 @@ export function UnfillableOrdersUpdater(): null {
       return
     }
 
+    const lowerCaseAccount = account.toLowerCase()
     // Only check pending orders of the connected account
-    const pending = pendingRef.current.filter((order) => order.owner === account)
+    const pending = pendingRef.current.filter(({ owner }) => owner.toLowerCase() === lowerCaseAccount)
 
     if (pending.length === 0) {
       return


### PR DESCRIPTION
# Summary

Applies the changes to the updater, so they don't try to check the status of orders/tx that are not connected:

Cherry-picks 🍒👌:
1d2fa1aa12e5b0f93d1c3d0a9bac723cce2a6ffa
cae8cd0ec5e19e2b535ae523d7750d571e3a2e54
c6cc3ebaf85c8a7926c396efd56c0852003467c2
68b0b2ebb6dc878e42899ae145663969ccfc22e5

Part of #1684

# To Test

1. Create tx/order
2. Open explorer/etherscan to follow its status
2. Switch to another account
3. Wait until is executed (check explorer/etherscan), make sure there's no mooooo or notification

 