### PR TITLE
[USD Estimation] Add blocknumber refresh & set Coingecko as default price source

### DIFF
--- a/src/custom/hooks/useUSDCPrice/index.ts
+++ b/src/custom/hooks/useUSDCPrice/index.ts
@@ -250,7 +250,7 @@ export function useHigherUSDValue(currencyAmount: CurrencyAmount<Currency> | und
       // BOTH AVAILABLE
     } else if (usdcValue && coingeckoUsdPrice) {
       console.debug('[USD Estimation]::[BOTH] ==> COIN')
-      // uni logic takes precedence
+      // coingecko logic takes precedence
       return coingeckoUsdPrice
     } else {
       console.debug('[USD Estimation]::None found')

--- a/src/custom/hooks/useUSDCPrice/index.ts
+++ b/src/custom/hooks/useUSDCPrice/index.ts
@@ -18,6 +18,7 @@ import { tryParseAmount } from 'state/swap/hooks'
 import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
 import { currencyId } from 'utils/currencyId'
 import { USDC } from 'constants/tokens'
+import { useBlockNumber } from '@src/state/application/hooks'
 
 export * from '@src/hooks/useUSDCPrice'
 
@@ -37,6 +38,7 @@ export default function useUSDCPrice(currency?: Currency) {
   const [error, setError] = useState<Error | null>(null)
 
   const { chainId, account } = useActiveWeb3React()
+  const blockNumber = useBlockNumber()
 
   const amountOut = chainId ? STABLECOIN_AMOUNT_OUT[chainId] : undefined
   const stablecoin = amountOut?.currency
@@ -121,7 +123,7 @@ export default function useUSDCPrice(currency?: Currency) {
           })
         })
     }
-  }, [amountOut, chainId, currency, stablecoin, account])
+  }, [amountOut, chainId, currency, stablecoin, account, blockNumber])
 
   return { price: bestUsdPrice, error }
 }
@@ -161,9 +163,11 @@ export function useUSDCValue(currencyAmount?: CurrencyAmount<Currency>) {
 export function useCoingeckoUsdPrice(currency?: Currency) {
   // default to MAINNET (if disconnected e.g)
   const { chainId = DEFAULT_NETWORK_FOR_LISTS } = useActiveWeb3React()
+  const blockNumber = useBlockNumber()
   const [price, setPrice] = useState<Price<Token, Currency> | null>(null)
   const [error, setError] = useState<Error | null>(null)
 
+  //uwc-debug
   useEffect(() => {
     const isSupportedChainId = supportedChainId(chainId)
     if (!isSupportedChainId || !currency) return
@@ -219,7 +223,7 @@ export function useCoingeckoUsdPrice(currency?: Currency) {
           })
         })
     }
-  }, [chainId, currency])
+  }, [chainId, currency, blockNumber])
 
   return { price, error }
 }
@@ -237,15 +241,19 @@ export function useHigherUSDValue(currencyAmount: CurrencyAmount<Currency> | und
   return useMemo(() => {
     // USDC PRICE UNAVAILABLE
     if (!usdcValue && coingeckoUsdPrice) {
+      console.debug('[USD Estimation]::COINGECKO')
       return coingeckoUsdPrice
       // COINGECKO PRICE UNAVAILABLE
     } else if (usdcValue && !coingeckoUsdPrice) {
+      console.debug('[USD Estimation]::UNIv2')
       return usdcValue
       // BOTH AVAILABLE
     } else if (usdcValue && coingeckoUsdPrice) {
-      // take the greater of the 2 values
-      return usdcValue.greaterThan(coingeckoUsdPrice) ? usdcValue : coingeckoUsdPrice
+      console.debug('[USD Estimation]::[BOTH] ==> COIN')
+      // uni logic takes precedence
+      return coingeckoUsdPrice
     } else {
+      console.debug('[USD Estimation]::None found')
       return null
     }
   }, [usdcValue, coingeckoUsdPrice])


### PR DESCRIPTION
Part of #1507 and several other USD related issues

Fixes stale USD values from non-updating hook and set `Coingecko` as the default price source, should they both exist

Adds `blockNumber` as a dependency to update usd price

## TESTING
1. pick tokens 
2. leave tab open for a while and check prices are updating/ok (can be done by comparing against another dex)
3. check the prices (now using CG as default so can be checked against Paraswap // 1inch for example), also check against Uniswap (they use tokenA vs 100k USDC)