### PR TITLE
[1798 - Fee zero/null] add zero logic for fee

### DIFF
--- a/src/custom/components/swap/FeeInformationTooltip.tsx
+++ b/src/custom/components/swap/FeeInformationTooltip.tsx
@@ -37,6 +37,7 @@ const FeeTooltipLine = styled.p`
   justify-content: space-between;
   align-items: center;
   margin: 0;
+  gap: 0 8px;
 
   font-size: small;
 
@@ -114,10 +115,14 @@ export default function FeeInformationTooltip(props: FeeInformationTooltipProps)
               </FeeTooltipLine>
               <FeeTooltipLine>
                 <span>Fee</span>
-                <span>
-                  {type === 'From' ? '+' : '-'}
-                  {feeAmount} {symbol}
-                </span>{' '}
+                {feeAmount ? (
+                  <span>
+                    {type === 'From' ? '+' : '-'}
+                    {feeAmount} {symbol}
+                  </span>
+                ) : (
+                  <strong className="green">Free</strong>
+                )}{' '}
               </FeeTooltipLine>
               {/* TODO: Add gas costs when available (wait for design) */}
               {allowsOffchainSigning && (

--- a/src/custom/components/swap/TradeSummary/RowFee.tsx
+++ b/src/custom/components/swap/TradeSummary/RowFee.tsx
@@ -65,7 +65,7 @@ export function RowFee({
   const { feeToken, feeUsd, fullDisplayFee } = useMemo(() => {
     const smartFeeFiatValue = formatSmart(feeFiatValue, FIAT_PRECISION)
     const smartFeeTokenValue = formatSmart(displayFee, AMOUNT_PRECISION)
-    const feeToken = smartFeeTokenValue ? `${smartFeeTokenValue} ${feeCurrencySymbol}` : '🎉 None!'
+    const feeToken = smartFeeTokenValue ? `${smartFeeTokenValue} ${feeCurrencySymbol}` : '🎉 Free!'
     const fullDisplayFee = formatMax(displayFee, displayFee?.currency.decimals) || '-'
 
     return {

--- a/src/custom/components/swap/TradeSummary/RowFee.tsx
+++ b/src/custom/components/swap/TradeSummary/RowFee.tsx
@@ -58,13 +58,22 @@ export function RowFee({
 }: RowFeeProps) {
   const theme = useContext(ThemeContext)
   const { realizedFee } = useMemo(() => computeTradePriceBreakdown(trade), [trade])
-  // trades are null when there is a fee quote error e.g
-  // so we can take both
-  const feeFiatDisplay = `(≈$${formatSmart(feeFiatValue, FIAT_PRECISION)})`
-
   const displayFee = realizedFee || fee
   const feeCurrencySymbol = displayFee?.currency.symbol || '-'
-  const fullDisplayFee = formatMax(displayFee, displayFee?.currency.decimals) || '-'
+  // trades are null when there is a fee quote error e.g
+  // so we can take both
+  const { feeToken, feeUsd, fullDisplayFee } = useMemo(() => {
+    const smartFeeFiatValue = formatSmart(feeFiatValue, FIAT_PRECISION)
+    const smartFeeTokenValue = formatSmart(displayFee, AMOUNT_PRECISION)
+    const feeToken = smartFeeTokenValue ? `${smartFeeTokenValue} ${feeCurrencySymbol}` : '🎉 None!'
+    const fullDisplayFee = formatMax(displayFee, displayFee?.currency.decimals) || '-'
+
+    return {
+      feeToken,
+      feeUsd: smartFeeFiatValue && `(≈$${smartFeeFiatValue})`,
+      fullDisplayFee,
+    }
+  }, [displayFee, feeCurrencySymbol, feeFiatValue])
 
   const includeGasMessage = allowsOffchainSigning ? ' (incl. gas costs)' : ''
   const tooltip = allowsOffchainSigning ? GASLESS_FEE_TOOLTIP_MSG : PRESIGN_FEE_TOOLTIP_MSG
@@ -83,8 +92,7 @@ export function RowFee({
       </RowFixed>
 
       <TYPE.black fontSize={fontSize} color={theme.text1} title={`${fullDisplayFee} ${feeCurrencySymbol}`}>
-        {formatSmart(displayFee, AMOUNT_PRECISION)} {feeCurrencySymbol}{' '}
-        {feeFiatValue && <LightGreyText>{feeFiatDisplay}</LightGreyText>}
+        {feeToken} {feeUsd && <LightGreyText>{feeUsd}</LightGreyText>}
       </TYPE.black>
     </RowBetween>
   )


### PR DESCRIPTION
# Summary

Closes #1798 

Fee can be zero if gas is low, fixes this. Uses `🎉 None!` if fee is zero

![image](https://user-images.githubusercontent.com/21335563/140732979-1a259d8c-f7fc-49e6-b189-c2ef8637d60b.png)
