### PR TITLE
Update API endpopint

### DIFF
--- a/src/custom/api/gnosisProtocol/api.ts
+++ b/src/custom/api/gnosisProtocol/api.ts
@@ -365,25 +365,20 @@ export type ProfileData = {
 
 export async function getProfileData(chainId: ChainId, address: string): Promise<ProfileData | null> {
   console.log(`[api:${API_NAME}] Get profile data for`, chainId, address)
-  try {
-    if (chainId !== ChainId.MAINNET) {
-      console.info('Profile data is only available for mainnet')
-      return null
-    }
+  if (chainId !== ChainId.MAINNET) {
+    console.info('Profile data is only available for mainnet')
+    return null
+  }
 
-    const response = await _getProfile(chainId, `/profile/${address}`)
+  const response = await _getProfile(chainId, `/profile/${address}`)
 
-    // TODO: Update the error handler when the openAPI profile spec is defined
-    if (!response.ok) {
-      const errorResponse = await response.json()
-      console.log(errorResponse)
-      throw new Error(errorResponse?.description)
-    } else {
-      return response.json()
-    }
-  } catch (error) {
-    console.error('Error getting profile data:', error)
-    throw error
+  // TODO: Update the error handler when the openAPI profile spec is defined
+  if (!response.ok) {
+    const errorResponse = await response.json()
+    console.log(errorResponse)
+    throw new Error(errorResponse?.description)
+  } else {
+    return response.json()
   }
 }
 

--- a/src/custom/hooks/useFetchProfile.ts
+++ b/src/custom/hooks/useFetchProfile.ts
@@ -10,7 +10,11 @@ export default function useFetchProfile() {
   useEffect(() => {
     async function fetchAndSetProfileData() {
       if (chainId && account) {
-        const profileData = await getProfileData(chainId, account)
+        const profileData = await getProfileData(chainId, account).catch((error) => {
+          console.error('Error getting profile data:', error)
+          return null
+        })
+
         setProfileData(profileData)
       } else {
         setProfileData(null)


### PR DESCRIPTION
# Summary

Temporarily the backend will change the endpoint to reduce some downtime risks on deployments.

This PR separate the endpoint for profile and the API. It should be reverted after we manage to reunite the APIs again. 

The endpoints will be:
* https://protocol-affiliate.dev.gnosisdev.com/api
* https://protocol-affiliate.gnosis.io/api

## Additionally
It solves where it wouldn't handle un-rejected promises, plus removes some strange error handling (that just re-throws)

# To Test
> Once the new endpoint is up 🚨

1. Test the profile page, it should work same as before