### PR TITLE
top margin for profile form

### DIFF
--- a/src/custom/pages/Profile/styled.tsx
+++ b/src/custom/pages/Profile/styled.tsx
@@ -17,6 +17,7 @@ export const Wrapper = styled(Page)`
   background: ${({ theme }) => transparentize(0.5, theme.bg1)};
   box-shadow: none;
   border: 1px solid ${({ theme }) => theme.cardBorder};
+  margin-top: 1rem;
   ${({ theme }) => theme.mediaWidth.upToSmall`
     padding: 16px;
   `}


### PR DESCRIPTION
# Summary

Fixes #1751 

there were no indent between the form and header at the profile page

  # To Test

1. Open the page `profile`
2. reduce the screen width to 320px
3. see the indent

