### PR TITLE
 Add an id to the notification banner to track its closed status

### DIFF
--- a/src/custom/components/AffiliateStatusCheck/index.tsx
+++ b/src/custom/components/AffiliateStatusCheck/index.tsx
@@ -150,8 +150,12 @@ export default function AffiliateStatusCheck() {
 }
 
 const notificationBannerId = function (address?: string | null | undefined, referral?: string) {
-  if (!address || !referral) {
+  if (!referral) {
     return
+  }
+
+  if (!address) {
+    return `referral-${referral}`
   }
 
   return `wallet-${address}:referral-${referral}`

--- a/src/custom/components/AffiliateStatusCheck/index.tsx
+++ b/src/custom/components/AffiliateStatusCheck/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState, useRef } from 'react'
+import React, { useCallback, useEffect, useState, useRef, useMemo } from 'react'
 import { useHistory, useLocation } from 'react-router-dom'
 import { useActiveWeb3React } from 'hooks/web3'
 import NotificationBanner from 'components/NotificationBanner'
@@ -40,6 +40,18 @@ export default function AffiliateStatusCheck() {
   const isFirstTrade = useRef(false)
   const fulfilledActivity = allRecentActivity.filter((data) => data.status === OrderStatus.FULFILLED)
 
+  const notificationBannerId = useMemo(() => {
+    if (!referralAddress?.value) {
+      return
+    }
+
+    if (!account) {
+      return `referral-${referralAddress.value}`
+    }
+
+    return `wallet-${account}:referral-${referralAddress.value}:chain-${chainId}`
+  }, [account, chainId, referralAddress?.value])
+
   const uploadDataDoc = useCallback(async () => {
     if (!chainId || !account || !referralAddress) {
       return
@@ -51,7 +63,6 @@ export default function AffiliateStatusCheck() {
     }
 
     if (fulfilledActivity.length >= 1 && isFirstTrade.current) {
-      console.log('Entro')
       setAffiliateState(null)
       resetReferralAddress()
       isFirstTrade.current = false
@@ -140,23 +151,11 @@ export default function AffiliateStatusCheck() {
 
   if (affiliateState) {
     return (
-      <NotificationBanner isVisible id={notificationBannerId(account, referralAddress?.value)} level="info">
+      <NotificationBanner isVisible id={notificationBannerId} level="info">
         {STATUS_TO_MESSAGE_MAPPING[affiliateState]}
       </NotificationBanner>
     )
   }
 
   return null
-}
-
-const notificationBannerId = function (address?: string | null | undefined, referral?: string) {
-  if (!referral) {
-    return
-  }
-
-  if (!address) {
-    return `referral-${referral}`
-  }
-
-  return `wallet-${address}:referral-${referral}`
 }

--- a/src/custom/components/AffiliateStatusCheck/index.tsx
+++ b/src/custom/components/AffiliateStatusCheck/index.tsx
@@ -132,7 +132,7 @@ export default function AffiliateStatusCheck() {
 
   if (error) {
     return (
-      <NotificationBanner isVisible changeOnProp={account} level="error">
+      <NotificationBanner isVisible level="error">
         Affiliate program error: {error}
       </NotificationBanner>
     )
@@ -140,11 +140,19 @@ export default function AffiliateStatusCheck() {
 
   if (affiliateState) {
     return (
-      <NotificationBanner isVisible changeOnProp={account} level="info">
+      <NotificationBanner isVisible id={notificationBannerId(account, referralAddress?.value)} level="info">
         {STATUS_TO_MESSAGE_MAPPING[affiliateState]}
       </NotificationBanner>
     )
   }
 
   return null
+}
+
+const notificationBannerId = function (address?: string | null | undefined, referral?: string) {
+  if (!address || !referral) {
+    return
+  }
+
+  return `wallet-${address}:referral-${referral}`
 }

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -220,8 +220,7 @@ export default function Header() {
           </Title>
           <HeaderLinks>
             <StyledNavLink to="/swap">Swap</StyledNavLink>
-            <StyledNavLink to="/about">Profile</StyledNavLink>
-            <StyledNavLink to="/about">About</StyledNavLink>
+            <StyledNavLink to="/profile">Profile</StyledNavLink>
           </HeaderLinks>
         </HeaderRow>
         <HeaderControls>

--- a/src/custom/components/Menu/index.tsx
+++ b/src/custom/components/Menu/index.tsx
@@ -228,10 +228,10 @@ export function Menu({ darkMode, toggleDarkMode }: MenuProps) {
         <ResponsiveInternalMenuItem to="/profile" onClick={close}>
           <User size={14} /> Profile
         </ResponsiveInternalMenuItem>
-        <ResponsiveInternalMenuItem to="/about" onClick={close}>
+        <InternalMenuItem to="/about" onClick={close}>
           <Star size={14} />
           About
-        </ResponsiveInternalMenuItem>
+        </InternalMenuItem>
 
         <InternalMenuItem to="/faq" onClick={close}>
           <HelpCircle size={14} />

--- a/src/custom/components/NotificationBanner/index.tsx
+++ b/src/custom/components/NotificationBanner/index.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import styled from 'styled-components/macro'
 import { Colors } from 'theme/styled'
 import { X } from 'react-feather'
 import { MEDIA_WIDTHS } from '@src/theme'
-import { useDismissNotification } from 'state/affiliate/hooks'
-import { useAppDispatch } from '@src/state/hooks'
+import { useIsNotificationClosed } from 'state/affiliate/hooks'
+import { useAppDispatch } from 'state/hooks'
 import { dismissNotification } from 'state/affiliate/actions'
 
 type Level = 'info' | 'warning' | 'error'
@@ -13,7 +13,7 @@ export interface BannerProps {
   children: React.ReactNode
   level: Level
   isVisible: boolean
-  changeOnProp?: string | null
+  id?: string
   canClose?: boolean
 }
 
@@ -50,28 +50,22 @@ const BannerContainer = styled.div`
   justify-content: center;
 `
 export default function NotificationBanner(props: BannerProps) {
-  const [isActive, setIsActive] = useState(props.isVisible)
-  const [changeOnPropStore, setChangeOnPropStore] = useState(props.changeOnProp)
-  const { canClose = true } = props
-
+  const { id, canClose = true } = props
   const dispatch = useAppDispatch()
-  const isNotificationDismissed = useDismissNotification()
-  const noteHandleClose = () => {
+  const isNotificationClosed = useIsNotificationClosed(id) // TODO: the notification closed state is now tied to the Affiliate state, this should generic
+  const [isActive, setIsActive] = useState(!isNotificationClosed ?? props.isVisible)
+
+  const handleClose = () => {
     setIsActive(false)
-    dispatch(dismissNotification(!isNotificationDismissed))
+    if (id) {
+      dispatch(dismissNotification({ id, dismiss: true }))
+    }
   }
 
-  useEffect(() => {
-    if (changeOnPropStore !== props.changeOnProp) {
-      dispatch(dismissNotification(false))
-      setChangeOnPropStore(props.changeOnProp)
-    }
-  }, [dispatch, props.changeOnProp, changeOnPropStore])
-
   return (
-    <Banner {...props} isVisible={isActive} style={{ display: isNotificationDismissed ? 'none' : 'flex' }}>
+    <Banner {...props} isVisible={isActive}>
       <BannerContainer>{props.children}</BannerContainer>
-      {canClose && <StyledClose size={24} onClick={() => noteHandleClose()} />}
+      {canClose && <StyledClose size={24} onClick={handleClose} />}
     </Banner>
   )
 }

--- a/src/custom/components/NotificationBanner/index.tsx
+++ b/src/custom/components/NotificationBanner/index.tsx
@@ -58,7 +58,7 @@ export default function NotificationBanner(props: BannerProps) {
   const handleClose = () => {
     setIsActive(false)
     if (id) {
-      dispatch(dismissNotification({ id, dismiss: true }))
+      dispatch(dismissNotification(id))
     }
   }
 

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -25,7 +25,6 @@ export const LONG_LOAD_THRESHOLD = 2000
 
 export const APP_DATA_HASH = getAppDataHash()
 export const PRODUCTION_URL = 'cowswap.exchange'
-export const IS_NOTIFICATION_CLOSED = false
 
 const DISABLED_WALLETS = /^(?:WALLET_LINK|COINBASE_LINK|FORTMATIC|Portis)$/i
 

--- a/src/custom/state/affiliate/actions.ts
+++ b/src/custom/state/affiliate/actions.ts
@@ -6,4 +6,4 @@ export const updateReferralAddress = createAction<{
 } | null>('affiliate/updateReferralAddress')
 export const updateAppDataHash = createAction<string>('affiliate/updateAppDataHash')
 
-export const dismissNotification = createAction<boolean>('affiliate/dismissNotification')
+export const dismissNotification = createAction<{ id: string; dismiss: boolean }>('affiliate/dismissNotification')

--- a/src/custom/state/affiliate/actions.ts
+++ b/src/custom/state/affiliate/actions.ts
@@ -6,4 +6,4 @@ export const updateReferralAddress = createAction<{
 } | null>('affiliate/updateReferralAddress')
 export const updateAppDataHash = createAction<string>('affiliate/updateAppDataHash')
 
-export const dismissNotification = createAction<{ id: string; dismiss: boolean }>('affiliate/dismissNotification')
+export const dismissNotification = createAction<string>('affiliate/dismissNotification')

--- a/src/custom/state/affiliate/hooks.ts
+++ b/src/custom/state/affiliate/hooks.ts
@@ -4,7 +4,7 @@ import { AppState } from 'state'
 import { useAppDispatch } from 'state/hooks'
 import { updateAppDataHash, updateReferralAddress } from 'state/affiliate/actions'
 import { generateReferralMetadataDoc, uploadMetadataDocToIpfs } from 'utils/metadata'
-import { APP_DATA_HASH, IS_NOTIFICATION_CLOSED } from 'constants/index'
+import { APP_DATA_HASH } from 'constants/index'
 
 export function useAppDataHash() {
   return useSelector<AppState, string>((state) => {
@@ -31,9 +31,9 @@ export function useResetReferralAddress() {
   return useCallback(() => dispatch(updateReferralAddress(null)), [dispatch])
 }
 
-export function useDismissNotification() {
-  return useSelector<AppState, boolean>((state) => {
-    return state.affiliate.isNotificationClosed || IS_NOTIFICATION_CLOSED
+export function useIsNotificationClosed(id?: string) {
+  return useSelector<AppState, boolean | null>((state) => {
+    return id ? state.affiliate.isNotificationClosed?.[id] ?? false : null
   })
 }
 

--- a/src/custom/state/affiliate/reducer.ts
+++ b/src/custom/state/affiliate/reducer.ts
@@ -1,6 +1,6 @@
 import { createReducer } from '@reduxjs/toolkit'
 import { dismissNotification, updateAppDataHash, updateReferralAddress } from './actions'
-import { APP_DATA_HASH, IS_NOTIFICATION_CLOSED } from 'constants/index'
+import { APP_DATA_HASH } from 'constants/index'
 
 export interface AffiliateState {
   referralAddress?: {
@@ -8,12 +8,13 @@ export interface AffiliateState {
     isValid: boolean
   }
   appDataHash?: string
-  isNotificationClosed?: boolean
+  isNotificationClosed?: {
+    [key: string]: boolean
+  }
 }
 
 export const initialState: AffiliateState = {
   appDataHash: APP_DATA_HASH,
-  isNotificationClosed: IS_NOTIFICATION_CLOSED,
 }
 
 export default createReducer(initialState, (builder) =>
@@ -25,6 +26,7 @@ export default createReducer(initialState, (builder) =>
       state.appDataHash = action.payload
     })
     .addCase(dismissNotification, (state, action) => {
-      state.isNotificationClosed = action.payload
+      state.isNotificationClosed = state.isNotificationClosed ?? {}
+      state.isNotificationClosed[action.payload.id] = action.payload.dismiss
     })
 )

--- a/src/custom/state/affiliate/reducer.ts
+++ b/src/custom/state/affiliate/reducer.ts
@@ -27,6 +27,6 @@ export default createReducer(initialState, (builder) =>
     })
     .addCase(dismissNotification, (state, action) => {
       state.isNotificationClosed = state.isNotificationClosed ?? {}
-      state.isNotificationClosed[action.payload.id] = action.payload.dismiss
+      state.isNotificationClosed[action.payload] = true
     })
 )


### PR DESCRIPTION
# Summary

Closes #1806

Adds an id to the NotificationBanner component to track its closed status.

  # To Test

1. Connect a wallet and copy an affiliate link into the URL
2. The main Affiliate banner should be displayed
3. Close the banner by clicking the X, reload the page. The banner shouldn't appear again
4. Change the current wallet account and/or the current affiliate link and/or the network. The banner should appear again. Close it
5. The app shouldn't display any of the banners that were previously closed when switching back to previous wallet accounts