### PR TITLE
Add no-js website

### DIFF
--- a/.env
+++ b/.env
@@ -70,6 +70,3 @@ REACT_APP_PATH_REGEX_ENS="/ipfs"
 
 # Enables mock mode (default = true)
 REACT_APP_MOCK=true
-
-# Meta tags (max 200 characters)
-REACT_APP_META_DESCRIPTION=Ethereums MetaDEX Aggregator built by Gnosis. It allows users to trade tokens with MEV protection while using ETH-less orders that are settled p2p among users or into the best on-chain liquidity pool.

--- a/public/index.html
+++ b/public/index.html
@@ -48,7 +48,7 @@
       }
     </style>
     <main>
-      <img src="https://cowswap.exchange/images/og-meta-cowswap.png" />
+      <img src="https://cowswap.exchange/images/og-meta-cowswap.png" alt="CowSwap Logo" />
       <p class="banner">CowSwap uses JavasScript. Please <a href="https://support.google.com/adsense/answer/12654?hl=en"
           target="_blank" rel="noopener noreferrer">enable it in your browser</a> 🐮</p>
 

--- a/public/index.html
+++ b/public/index.html
@@ -30,7 +30,37 @@
 </head>
 
 <body>
-  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <noscript>
+    <style>
+      main {
+        max-width: 35em;
+        margin: 0 auto;
+      }
+
+      main img {
+        width: 100%;
+      }
+
+      .banner {
+        padding: 1em;
+        background-color: #fdfda8;
+        border-radius: 0.5em;
+      }
+    </style>
+    <main>
+      <img src="https://cowswap.exchange/images/og-meta-cowswap.png" />
+      <p class="banner">CowSwap uses JavasScript. Please <a href="https://support.google.com/adsense/answer/12654?hl=en"
+          target="_blank" rel="noopener noreferrer">enable it in your browser</a> 🐮</p>
+
+      <ul>
+        <li><a href="https://cowswap.exchange/">Home | CowSwap</a></li>
+        <li><a href="https://chat.cowswap.exchange">Chat</a></li>
+        <li><a href="https://docs.cowswap.exchange">Docs</a></li>
+        <li><a href="https://dune.xyz/gnosis.protocol/Gnosis-Protocol-V2">Stats</a></li>
+        <li><a href="https://twitter.com/MEVprotection">Twitter (@MEVprotection)</a></li>
+      </ul>
+    </main>
+  </noscript>
   <div id="root"></div>
 </body>
 


### PR DESCRIPTION
# Summary

Adds some custom basic information when the user doesn't have JS


![image](https://user-images.githubusercontent.com/2352112/141113968-42ee7480-5871-46c6-a48d-b964cad770bb.png)


And mobile: 
![image](https://user-images.githubusercontent.com/2352112/141114707-2a86f5c9-8bf1-4ea3-97fb-a3ad1a5fb896.png)


Provides also an image, to facilitate services to index it, plus some links to relevant sections (same reason).


# To Test

1. Clicl on the lock in the address bar:

![image](https://user-images.githubusercontent.com/2352112/141114120-74e2af48-9f19-487f-a4e8-9bbcc1006a96.png)

2. Click on Site Settings 
3. Block JS
![image](https://user-images.githubusercontent.com/2352112/141114264-cc55709c-c407-4e9a-947b-62ea120eb7e7.png)

4. Update the web and test the links