### PR TITLE
Fix image link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/gnosis/gp-swap-ui)
 
 <p align="center">
-  <img width="400" src="docs/images/og-meta-cowswap.png">
+  <img width="400" src="docs/images/logo-cow-swap.png">
 </p>
 
 [![Lint](https://github.com/gnosis/dex-swap/workflows/Lint/badge.svg)](https://github.com/gnosis/dex-swap/actions?query=workflow%3ALint)


### PR DESCRIPTION
# Summary

This trivial PR fixes the image link in the README.

Note that there is an `og-meta-cowswap.png` image in `public/images/` with a slightly different logo, but it has a blue background which IMO doesn't look as nice in the README. If that was the one to use, let me know as it is a quick fix.

# To Test

1. Go to https://github.com/gnosis/cowswap/blob/develop/README.md and see there is no image.
2. Go to https://github.com/gnosis/cowswap/blob/fix-readme-image-link/README.md and see the image rendered.


