### PR TITLE
Update Firefox scrollbar style.

### DIFF
--- a/src/custom/components/OrdersPanel/index.tsx
+++ b/src/custom/components/OrdersPanel/index.tsx
@@ -31,6 +31,7 @@ const SideBar = styled.div`
   box-shadow: 0 16px 32px 0 rgb(0 0 0 / 5%);
   animation: slideIn 0.3s cubic-bezier(0.87, 0, 0.13, 1);
   background: ${({ theme }) => theme.card.background2};
+  scrollbar-color: ${({ theme }) => `${theme.card.border} ${theme.card.background2}`};
 
   ${({ theme }) => theme.mediaWidth.upToMedium`    
     width: 100%;


### PR DESCRIPTION
# Summary

Improve Firefox scrollbar styles (orders panel):
<img width="803" alt="Screen Shot 2021-11-16 at 12 48 20" src="https://user-images.githubusercontent.com/31534717/141981244-2c820fad-2954-4e22-84ea-e8c92b5725e5.png">
<img width="845" alt="Screen Shot 2021-11-16 at 12 48 08" src="https://user-images.githubusercontent.com/31534717/141981250-b33af280-39b7-4a4a-b7b3-4a72655362ab.png">

