### PR TITLE
Small refactor in #1639

### DIFF
--- a/src/custom/hooks/useTokenLazy.ts
+++ b/src/custom/hooks/useTokenLazy.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react'
+import { Web3Provider } from '@ethersproject/providers'
 
 import { Token } from '@uniswap/sdk-core'
 import { Contract } from '@ethersproject/contracts'
@@ -14,6 +15,105 @@ const contractsCache: Record<string, Erc20> = {}
 const bytes32ContractsCache: Record<string, Contract> = {}
 
 const RETRY_OPTIONS = { n: 3, minWait: 100, maxWait: 3_000 }
+
+export interface TokenInfo {
+  decimals: number
+  symbol?: string
+  name?: string
+}
+
+export interface GetTokenInfoParams {
+  chainId: number
+  address: string
+  account: string
+
+  library: Web3Provider
+}
+
+async function _getTokenContract(params: GetTokenInfoParams): Promise<Erc20> {
+  const { address, account, chainId, library } = params
+
+  const tokenContract = contractsCache[address] || getTokenContract(address, undefined, library, account, chainId)
+
+  return tokenContract
+}
+
+async function _getTokenByte32Contract(params: GetTokenInfoParams): Promise<Contract> {
+  const { address, account, chainId, library } = params
+
+  const tokenContract =
+    bytes32ContractsCache[address] || getBytes32TokenContract(address, undefined, library, account, chainId)
+
+  return tokenContract
+}
+
+async function _getTokenInfo(params: GetTokenInfoParams): Promise<TokenInfo | null> {
+  const { address, account, chainId } = params
+  console.debug(`[useTokenLazy::callback] input is valid`, address, account, chainId)
+
+  const contract = await _getTokenContract(params)
+
+  // Fetch each property individually
+  const { promise: decimalsPromise } = retry(contract.decimals, RETRY_OPTIONS)
+  const { promise: namePromise, cancel: cancelNamePromise } = retry(contract.name, RETRY_OPTIONS)
+  const { promise: symbolPromise, cancel: cancelSymbolPromise } = retry(contract.symbol, RETRY_OPTIONS)
+
+  let decimals: number
+
+  try {
+    // If no decimals, stop here
+    decimals = await decimalsPromise
+  } catch (e) {
+    console.debug(`[useTokenLazy::callback] no decimals, stopping`, address, account, chainId, e)
+
+    cancelNamePromise()
+    cancelSymbolPromise()
+    return null
+  }
+
+  const [nameSettled, symbolSettled] = await Promise.allSettled([namePromise, symbolPromise])
+
+  let name, symbol
+  // If no name or symbol, try the bytes32 contract
+  if (
+    nameSettled.status === 'rejected' ||
+    !nameSettled.value ||
+    symbolSettled.status === 'rejected' ||
+    !symbolSettled.value
+  ) {
+    console.debug(
+      `[useTokenLazy::callback] name or symbol failed, trying bytes32`,
+      address,
+      account,
+      chainId,
+      nameSettled,
+      symbolSettled
+    )
+
+    const bytes32Contract = await _getTokenByte32Contract(params)
+    const [nameBytes32Settled, symbolBytes32Settled] = await Promise.allSettled([
+      retry<string>(bytes32Contract.name, RETRY_OPTIONS).promise,
+      retry<string>(bytes32Contract.symbol, RETRY_OPTIONS).promise,
+    ])
+
+    // Merge regular and bytes32 versions in case one them was good
+    name = parseStringOrBytes32(
+      nameSettled.status === 'fulfilled' ? nameSettled.value : '',
+      nameBytes32Settled.status === 'fulfilled' ? nameBytes32Settled.value : '',
+      'Unknown Token'
+    )
+    symbol = parseStringOrBytes32(
+      symbolSettled.status === 'fulfilled' ? symbolSettled.value : '',
+      symbolBytes32Settled.status === 'fulfilled' ? (symbolBytes32Settled.value as any) : '',
+      'UNKNOWN'
+    )
+  } else {
+    name = nameSettled.value
+    symbol = symbolSettled.value
+  }
+
+  return { decimals, symbol, name }
+}
 
 /**
  * Hook that returns a callback which fetches data for a single token from the chain
@@ -33,75 +133,13 @@ export function useTokenLazy() {
         return null
       }
 
-      console.debug(`[useTokenLazy::callback] input is valid`, address, account, chainId)
+      const tokenInfo = await _getTokenInfo({ chainId, account, address, library })
 
-      contractsCache[address] =
-        contractsCache[address] || getTokenContract(address, undefined, library, account, chainId)
-      bytes32ContractsCache[address] =
-        bytes32ContractsCache[address] || getBytes32TokenContract(address, undefined, library, account, chainId)
-
-      const contract = contractsCache[address]
-      const bytes32Contract = bytes32ContractsCache[address]
-
-      // Fetch each property individually
-      const { promise: decimalsPromise } = retry(contract.decimals, RETRY_OPTIONS)
-      const { promise: namePromise, cancel: cancelNamePromise } = retry(contract.name, RETRY_OPTIONS)
-      const { promise: symbolPromise, cancel: cancelSymbolPromise } = retry(contract.symbol, RETRY_OPTIONS)
-
-      let decimals: number
-
-      try {
-        // If no decimals, stop here
-        decimals = await decimalsPromise
-      } catch (e) {
-        console.debug(`[useTokenLazy::callback] no decimals, stopping`, address, account, chainId, e)
-
-        cancelNamePromise()
-        cancelSymbolPromise()
+      if (!tokenInfo) {
         return null
       }
 
-      const [nameSettled, symbolSettled] = await Promise.allSettled([namePromise, symbolPromise])
-
-      let name, symbol
-
-      // If no name or symbol, try the bytes32 contract
-      if (
-        nameSettled.status === 'rejected' ||
-        !nameSettled.value ||
-        symbolSettled.status === 'rejected' ||
-        !symbolSettled.value
-      ) {
-        console.debug(
-          `[useTokenLazy::callback] name or symbol failed, trying bytes32`,
-          address,
-          account,
-          chainId,
-          nameSettled,
-          symbolSettled
-        )
-
-        const [nameBytes32Settled, symbolBytes32Settled] = await Promise.allSettled([
-          retry<string>(bytes32Contract.name, RETRY_OPTIONS).promise,
-          retry<string>(bytes32Contract.symbol, RETRY_OPTIONS).promise,
-        ])
-
-        // Merge regular and bytes32 versions in case one them was good
-        name = parseStringOrBytes32(
-          nameSettled.status === 'fulfilled' ? nameSettled.value : '',
-          nameBytes32Settled.status === 'fulfilled' ? nameBytes32Settled.value : '',
-          'Unknown Token'
-        )
-        symbol = parseStringOrBytes32(
-          symbolSettled.status === 'fulfilled' ? symbolSettled.value : '',
-          symbolBytes32Settled.status === 'fulfilled' ? (symbolBytes32Settled.value as any) : '',
-          'UNKNOWN'
-        )
-      } else {
-        name = nameSettled.value
-        symbol = symbolSettled.value
-      }
-
+      const { decimals, symbol, name } = tokenInfo
       const token = new Token(chainId, address, decimals, symbol, name)
 
       console.debug(`[useTokenLazy::callback] loaded token`, address, account, chainId, token)

--- a/src/custom/hooks/useTokenLazy.ts
+++ b/src/custom/hooks/useTokenLazy.ts
@@ -129,7 +129,7 @@ export function useTokenLazy() {
     async (address: string): Promise<Token | null> => {
       console.debug(`[useTokenLazy::callback] callback called`, address, account, chainId)
 
-      if (!account || !chainId || !address) {
+      if (!account || !chainId || !address || !library) {
         return null
       }
 


### PR DESCRIPTION
# Summary

This is a small refactor i did trying to reduce the size and complexity of the token fetching logic.

`useTokenLazy` is way smaller now, and the work has been moved to different private functions.

I continued with the refactor further in another PR (https://github.com/gnosis/cowswap/pull/1858), however this other PR is more ambitious because it also tries to address the issue that https://github.com/gnosis/cowswap/pull/1639 doesn't use the `cancel` that is returned by the `retry` function. So this part is not included in this PR.


For both PR, @alfetopito u don't need to use my code. I just wanted to give it a try to refactor it, and understand it a bit better. Feel free to merge, take bits and pieces, use inspiration, or ignore all together these two PRs.