### PR TITLE
Add cancelation support

### DIFF
--- a/src/custom/hooks/useTokenLazy.ts
+++ b/src/custom/hooks/useTokenLazy.ts
@@ -10,6 +10,11 @@ import { parseStringOrBytes32 } from 'hooks/Tokens'
 import { useAddUserToken } from 'state/user/hooks'
 import { Erc20 } from 'abis/types'
 import { retry } from 'utils/retry'
+import { RetryResult } from 'types/index'
+
+const DEFAULT_TOKEN_NAME = 'Unknown Token'
+const DEFAULT_TOKEN_SYMBOL = 'UNKNOWN'
+const NO_TOKEN_INFO = { promise: Promise.resolve(null), cancel: () => {} } // eslint-disable-line
 
 const contractsCache: Record<string, Erc20> = {}
 const bytes32ContractsCache: Record<string, Contract> = {}
@@ -47,73 +52,132 @@ async function _getTokenByte32Contract(params: GetTokenInfoParams): Promise<Cont
   return tokenContract
 }
 
-async function _getTokenInfo(params: GetTokenInfoParams): Promise<TokenInfo | null> {
-  const { address, account, chainId } = params
-  console.debug(`[useTokenLazy::callback] input is valid`, address, account, chainId)
-
+function _tryGetToken(params: GetTokenInfoParams): { promise: Promise<TokenInfo | null>; cancel: () => void } {
+  // Fetch each property individually
   const contract = await _getTokenContract(params)
 
-  // Fetch each property individually
-  const { promise: decimalsPromise } = retry(contract.decimals, RETRY_OPTIONS)
+  const { promise: decimalsPromise, cancel: cancelDecimalsPromise } = retry(contract.decimals, RETRY_OPTIONS)
   const { promise: namePromise, cancel: cancelNamePromise } = retry(contract.name, RETRY_OPTIONS)
   const { promise: symbolPromise, cancel: cancelSymbolPromise } = retry(contract.symbol, RETRY_OPTIONS)
 
-  let decimals: number
-
-  try {
-    // If no decimals, stop here
-    decimals = await decimalsPromise
-  } catch (e) {
-    console.debug(`[useTokenLazy::callback] no decimals, stopping`, address, account, chainId, e)
-
+  const cancel = () => {
+    cancelDecimalsPromise()
     cancelNamePromise()
     cancelSymbolPromise()
-    return null
   }
 
-  const [nameSettled, symbolSettled] = await Promise.allSettled([namePromise, symbolPromise])
+  const promise = decimalsPromise
+    .then((decimals) => {
+      return Promise.allSettled([namePromise, symbolPromise]).then(([nameSettled, symbolSettled]) => {
+        let name
+        if (nameSettled.status === 'fulfilled' && nameSettled.value) {
+          name = nameSettled.value
+        }
 
-  let name, symbol
-  // If no name or symbol, try the bytes32 contract
-  if (
-    nameSettled.status === 'rejected' ||
-    !nameSettled.value ||
-    symbolSettled.status === 'rejected' ||
-    !symbolSettled.value
-  ) {
-    console.debug(
-      `[useTokenLazy::callback] name or symbol failed, trying bytes32`,
-      address,
-      account,
-      chainId,
-      nameSettled,
-      symbolSettled
-    )
+        let symbol
+        if (symbolSettled.status === 'fulfilled' && symbolSettled.value) {
+          symbol = symbolSettled.value
+        }
 
-    const bytes32Contract = await _getTokenByte32Contract(params)
-    const [nameBytes32Settled, symbolBytes32Settled] = await Promise.allSettled([
-      retry<string>(bytes32Contract.name, RETRY_OPTIONS).promise,
-      retry<string>(bytes32Contract.symbol, RETRY_OPTIONS).promise,
-    ])
+        return {
+          decimals,
+          name,
+          symbol,
+        }
+      })
+    })
+    .catch((e) => {
+      const { address, account, chainId } = params
+      console.debug(`[useTokenLazy::callback] no decimals, stopping`, address, account, chainId, e)
 
-    // Merge regular and bytes32 versions in case one them was good
-    name = parseStringOrBytes32(
-      nameSettled.status === 'fulfilled' ? nameSettled.value : '',
-      nameBytes32Settled.status === 'fulfilled' ? nameBytes32Settled.value : '',
-      'Unknown Token'
-    )
-    symbol = parseStringOrBytes32(
-      symbolSettled.status === 'fulfilled' ? symbolSettled.value : '',
-      symbolBytes32Settled.status === 'fulfilled' ? (symbolBytes32Settled.value as any) : '',
-      'UNKNOWN'
-    )
-  } else {
-    name = nameSettled.value
-    symbol = symbolSettled.value
-  }
+      cancel()
+      return null
+    })
 
-  return { decimals, symbol, name }
+  return { promise, cancel }
 }
+
+function _tryGetFieldByte32(
+  params: GetTokenInfoParams,
+  bytes32Contract: Contract,
+  contractField: string,
+  defaultValue: string
+): { promise: Promise<string>; cancel: () => void } {
+  const { address, account, chainId } = params
+  console.debug(`[useTokenLazy::callback] "${contractField}" fetch failed, trying bytes32`, address, account, chainId)
+  const { promise, cancel } = retry<string>(bytes32Contract[contractField], RETRY_OPTIONS)
+
+  const getFieldPromise = promise
+    .then((name) => parseStringOrBytes32(undefined, name, DEFAULT_TOKEN_NAME))
+    .catch(() => {
+      console.debug(
+        `[useTokenLazy::callback] "${contractField}" fetch failed also as bytes32`,
+        address,
+        account,
+        chainId
+      )
+      return defaultValue
+    })
+
+  return { promise: getFieldPromise, cancel }
+}
+
+function _getTokenInfo(params: GetTokenInfoParams): { promise: Promise<TokenInfo | null>; cancel: () => void } {
+  const { address, account, chainId } = params
+  console.debug(`[useTokenLazy::callback] input is valid`, address, account, chainId)
+
+  // Get token info
+  const { promise: tryGetTokenPromise, cancel: cancelGetToken } = _tryGetToken(params)
+  const allCancellations = [cancelGetToken]
+
+  // Get token with some fallback logic
+  const promise = tryGetTokenPromise.then(async (tokenInfo) => {
+    // If no token info, return early
+    if (!tokenInfo) {
+      return null
+    }
+
+    const { decimals, symbol, name } = tokenInfo
+
+    // Get name
+    let namePromise
+    if (!name) {
+      // name is missing, try to get it as byte32
+      const bytes32Contract = await _getTokenByte32Contract(params)
+      const { promise, cancel } = _tryGetFieldByte32(params, bytes32Contract, 'name', DEFAULT_TOKEN_NAME)
+      allCancellations.push(cancel)
+
+      namePromise = promise
+    } else {
+      namePromise = name
+    }
+
+    // Get symbol
+    let symbolPromise
+    if (!symbol) {
+      // symbol is missing, try to get it as byte32
+      const bytes32Contract = await _getTokenByte32Contract(params)
+      const { promise, cancel } = _tryGetFieldByte32(params, bytes32Contract, 'symbol', DEFAULT_TOKEN_SYMBOL)
+      symbolPromise = promise
+      allCancellations.push(cancel)
+    } else {
+      symbolPromise = symbol
+    }
+
+    // Wait for name and symbol promises
+    const [nameFallback, symbolFallback] = await Promise.all([namePromise, symbolPromise])
+
+    // Return the token info
+    return { decimals, name: nameFallback, symbol: symbolFallback }
+  })
+
+  // Cancel any pending promise
+  const cancel = () => allCancellations.forEach((cancel) => cancel())
+
+  return { promise, cancel }
+}
+
+export type TokenGetter = (address: string) => RetryResult<Token | null>
 
 /**
  * Hook that returns a callback which fetches data for a single token from the chain
@@ -121,32 +185,36 @@ async function _getTokenInfo(params: GetTokenInfoParams): Promise<TokenInfo | nu
  * Alternative to hooks/Token/useToken where token address does not need to be known
  * at hook phase nor uses multicall
  */
-export function useTokenLazy() {
+export function useTokenLazy(): TokenGetter {
   const { library, account, chainId } = useActiveWeb3React()
   const addUserToken = useAddUserToken()
 
-  return useCallback(
-    async (address: string): Promise<Token | null> => {
+  return useCallback<TokenGetter>(
+    (address) => {
       console.debug(`[useTokenLazy::callback] callback called`, address, account, chainId)
 
-      if (!account || !chainId || !address) {
-        return null
+      if (!account || !chainId || !address || !library) {
+        return NO_TOKEN_INFO
       }
 
-      const tokenInfo = await _getTokenInfo({ chainId, account, address, library })
+      const { promise: getTokenPromise, cancel } = _getTokenInfo({ chainId, account, address, library })
 
-      if (!tokenInfo) {
-        return null
-      }
+      const promise = getTokenPromise.then((tokenInfo) => {
+        if (!tokenInfo) {
+          return null
+        }
 
-      const { decimals, symbol, name } = tokenInfo
-      const token = new Token(chainId, address, decimals, symbol, name)
+        const { decimals, symbol, name } = tokenInfo
+        const token = new Token(chainId, address, decimals, symbol, name)
 
-      console.debug(`[useTokenLazy::callback] loaded token`, address, account, chainId, token)
+        console.debug(`[useTokenLazy::callback] loaded token`, address, account, chainId, token)
 
-      addUserToken(token)
+        addUserToken(token)
 
-      return token
+        return token
+      })
+
+      return { promise, cancel }
     },
     [account, addUserToken, chainId, library]
   )

--- a/src/custom/hooks/useTokenLazy.ts
+++ b/src/custom/hooks/useTokenLazy.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react'
+import { Web3Provider } from '@ethersproject/providers'
 
 import { Token } from '@uniswap/sdk-core'
 import { Contract } from '@ethersproject/contracts'
@@ -14,6 +15,105 @@ const contractsCache: Record<string, Erc20> = {}
 const bytes32ContractsCache: Record<string, Contract> = {}
 
 const RETRY_OPTIONS = { n: 3, minWait: 100, maxWait: 3_000 }
+
+export interface TokenInfo {
+  decimals: number
+  symbol?: string
+  name?: string
+}
+
+export interface GetTokenInfoParams {
+  chainId: number
+  address: string
+  account: string
+
+  library: Web3Provider
+}
+
+async function _getTokenContract(params: GetTokenInfoParams): Promise<Erc20> {
+  const { address, account, chainId, library } = params
+
+  const tokenContract = contractsCache[address] || getTokenContract(address, undefined, library, account, chainId)
+
+  return tokenContract
+}
+
+async function _getTokenByte32Contract(params: GetTokenInfoParams): Promise<Contract> {
+  const { address, account, chainId, library } = params
+
+  const tokenContract =
+    bytes32ContractsCache[address] || getBytes32TokenContract(address, undefined, library, account, chainId)
+
+  return tokenContract
+}
+
+async function _getTokenInfo(params: GetTokenInfoParams): Promise<TokenInfo | null> {
+  const { address, account, chainId } = params
+  console.debug(`[useTokenLazy::callback] input is valid`, address, account, chainId)
+
+  const contract = await _getTokenContract(params)
+
+  // Fetch each property individually
+  const { promise: decimalsPromise } = retry(contract.decimals, RETRY_OPTIONS)
+  const { promise: namePromise, cancel: cancelNamePromise } = retry(contract.name, RETRY_OPTIONS)
+  const { promise: symbolPromise, cancel: cancelSymbolPromise } = retry(contract.symbol, RETRY_OPTIONS)
+
+  let decimals: number
+
+  try {
+    // If no decimals, stop here
+    decimals = await decimalsPromise
+  } catch (e) {
+    console.debug(`[useTokenLazy::callback] no decimals, stopping`, address, account, chainId, e)
+
+    cancelNamePromise()
+    cancelSymbolPromise()
+    return null
+  }
+
+  const [nameSettled, symbolSettled] = await Promise.allSettled([namePromise, symbolPromise])
+
+  let name, symbol
+  // If no name or symbol, try the bytes32 contract
+  if (
+    nameSettled.status === 'rejected' ||
+    !nameSettled.value ||
+    symbolSettled.status === 'rejected' ||
+    !symbolSettled.value
+  ) {
+    console.debug(
+      `[useTokenLazy::callback] name or symbol failed, trying bytes32`,
+      address,
+      account,
+      chainId,
+      nameSettled,
+      symbolSettled
+    )
+
+    const bytes32Contract = await _getTokenByte32Contract(params)
+    const [nameBytes32Settled, symbolBytes32Settled] = await Promise.allSettled([
+      retry<string>(bytes32Contract.name, RETRY_OPTIONS).promise,
+      retry<string>(bytes32Contract.symbol, RETRY_OPTIONS).promise,
+    ])
+
+    // Merge regular and bytes32 versions in case one them was good
+    name = parseStringOrBytes32(
+      nameSettled.status === 'fulfilled' ? nameSettled.value : '',
+      nameBytes32Settled.status === 'fulfilled' ? nameBytes32Settled.value : '',
+      'Unknown Token'
+    )
+    symbol = parseStringOrBytes32(
+      symbolSettled.status === 'fulfilled' ? symbolSettled.value : '',
+      symbolBytes32Settled.status === 'fulfilled' ? (symbolBytes32Settled.value as any) : '',
+      'UNKNOWN'
+    )
+  } else {
+    name = nameSettled.value
+    symbol = symbolSettled.value
+  }
+
+  return { decimals, symbol, name }
+}
 
 /**
  * Hook that returns a callback which fetches data for a single token from the chain
@@ -33,75 +133,13 @@ export function useTokenLazy() {
         return null
       }
 
-      console.debug(`[useTokenLazy::callback] input is valid`, address, account, chainId)
+      const tokenInfo = await _getTokenInfo({ chainId, account, address, library })
 
-      contractsCache[address] =
-        contractsCache[address] || getTokenContract(address, undefined, library, account, chainId)
-      bytes32ContractsCache[address] =
-        bytes32ContractsCache[address] || getBytes32TokenContract(address, undefined, library, account, chainId)
-
-      const contract = contractsCache[address]
-      const bytes32Contract = bytes32ContractsCache[address]
-
-      // Fetch each property individually
-      const { promise: decimalsPromise } = retry(contract.decimals, RETRY_OPTIONS)
-      const { promise: namePromise, cancel: cancelNamePromise } = retry(contract.name, RETRY_OPTIONS)
-      const { promise: symbolPromise, cancel: cancelSymbolPromise } = retry(contract.symbol, RETRY_OPTIONS)
-
-      let decimals: number
-
-      try {
-        // If no decimals, stop here
-        decimals = await decimalsPromise
-      } catch (e) {
-        console.debug(`[useTokenLazy::callback] no decimals, stopping`, address, account, chainId, e)
-
-        cancelNamePromise()
-        cancelSymbolPromise()
+      if (!tokenInfo) {
         return null
       }
 
-      const [nameSettled, symbolSettled] = await Promise.allSettled([namePromise, symbolPromise])
-
-      let name, symbol
-
-      // If no name or symbol, try the bytes32 contract
-      if (
-        nameSettled.status === 'rejected' ||
-        !nameSettled.value ||
-        symbolSettled.status === 'rejected' ||
-        !symbolSettled.value
-      ) {
-        console.debug(
-          `[useTokenLazy::callback] name or symbol failed, trying bytes32`,
-          address,
-          account,
-          chainId,
-          nameSettled,
-          symbolSettled
-        )
-
-        const [nameBytes32Settled, symbolBytes32Settled] = await Promise.allSettled([
-          retry<string>(bytes32Contract.name, RETRY_OPTIONS).promise,
-          retry<string>(bytes32Contract.symbol, RETRY_OPTIONS).promise,
-        ])
-
-        // Merge regular and bytes32 versions in case one them was good
-        name = parseStringOrBytes32(
-          nameSettled.status === 'fulfilled' ? nameSettled.value : '',
-          nameBytes32Settled.status === 'fulfilled' ? nameBytes32Settled.value : '',
-          'Unknown Token'
-        )
-        symbol = parseStringOrBytes32(
-          symbolSettled.status === 'fulfilled' ? symbolSettled.value : '',
-          symbolBytes32Settled.status === 'fulfilled' ? (symbolBytes32Settled.value as any) : '',
-          'UNKNOWN'
-        )
-      } else {
-        name = nameSettled.value
-        symbol = symbolSettled.value
-      }
-
+      const { decimals, symbol, name } = tokenInfo
       const token = new Token(chainId, address, decimals, symbol, name)
 
       console.debug(`[useTokenLazy::callback] loaded token`, address, account, chainId, token)

--- a/src/custom/state/orders/updaters/ApiOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/ApiOrdersUpdater.ts
@@ -153,7 +153,7 @@ export function ApiOrdersUpdater(): null {
   allTokensRef.current = allTokens
 
   const updateOrders = useCallback(
-    (chainId: ChainId, account: string): Promise<void> => {
+    (chainId: ChainId, account: string): (() => void) => {
       const tokens = allTokensRef.current
       console.log(
         `ApiOrdersUpdater:: updating orders. Network ${chainId}, account ${account}, loaded tokens count ${
@@ -197,10 +197,11 @@ export function ApiOrdersUpdater(): null {
   )
 
   useEffect(() => {
+    let cancel
     if (account && chainId && tokensAreLoaded) {
-      const cancel = updateOrders(chainId, account)
-      return cancel
+      cancel = updateOrders(chainId, account)
     }
+    return cancel
   }, [account, chainId, tokensAreLoaded, updateOrders])
 
   return null


### PR DESCRIPTION
# Summary

Continuation of https://github.com/gnosis/cowswap/pull/1857 where I continue the refactor, and try to make the code more robust and easier to read.

However, the code is still complex because of the viral nature of the `retry` function. 

I started to handle the cancelations, but I had to go back in the call hierachy of the application logic, making asyn/await methods to use a cancelable logic, so at the end this useEffect can cancel all retry logics:

![image](https://user-images.githubusercontent.com/2352112/142009134-f367df62-a540-4763-b1da-5833e89b455d.png)


Honestly, this PR lead me to be more convinced we need SWR or React Query to simplify logics.


For both PR, @alfetopito u don't need to use my code. I just wanted to give it a try to refactor it, and understand it a bit better. Feel free to merge, take bits and pieces, use inspiration, or ignore all together these two PRs.