### PR TITLE
Fix e2e and autoconnect

### DIFF
--- a/cypress-custom/integration/swap.test.ts
+++ b/cypress-custom/integration/swap.test.ts
@@ -3,17 +3,20 @@
 // GP doesn't use ETH, so we need to test for this
 
 describe('Swap (custom)', () => {
-  beforeEach(() => {
-    cy.visit('/swap')
-  })
-
   // uses WETH instead of ETH
   // it('can swap ETH for DAI', () => {
   it('can swap WETH for DAI', () => {
     // select DAI
-    cy.get('#swap-currency-output .open-currency-select-button').click()
-    cy.get('.token-item-0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735').should('be.visible')
-    cy.get('.token-item-0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735').click({ force: true })
+    // TODO: Define our command, so it search by name and select the input
+    // cy.get('#swap-currency-output .open-currency-select-button').click()
+
+    // cy.get('.token-item-0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735').should('be.visible')
+    // cy.get('.token-item-0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735').click({ force: true })
+
+    cy.visit(
+      '/swap?inputCurrency=0xc778417E063141139Fce010982780140Aa0cD5Ab&outputCurrency=0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa'
+    )
+
     // input amounts
     cy.get('#swap-currency-input .token-amount-input').should('be.visible')
     cy.get('#swap-currency-input .token-amount-input').type('0.5', { force: true, delay: 200 })
@@ -24,14 +27,16 @@ describe('Swap (custom)', () => {
 
   // ETH should be tradable but show Switch to Weth
   it('Swap ETH for DAI - shows Switch to WETH ', () => {
+    cy.visit('/swap?inputCurrency=ETH&outputCurrency=0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa')
+
     // select ETH
-    cy.get('#swap-currency-input .open-currency-select-button').click()
-    cy.get('.token-item-ETHER').should('be.visible')
-    cy.get('.token-item-ETHER').click({ force: true })
+    // cy.get('#swap-currency-input .open-currency-select-button').click()
+    // cy.get('.token-item-ETHER').should('be.visible')
+    // cy.get('.token-item-ETHER').click({ force: true })
     // select DAI
-    cy.get('#swap-currency-output .open-currency-select-button').click()
-    cy.get('.token-item-0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735').should('be.visible')
-    cy.get('.token-item-0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735').click({ force: true })
+    // cy.get('#swap-currency-output .open-currency-select-button').click()
+    // cy.get('.token-item-0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735').should('be.visible')
+    // cy.get('.token-item-0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735').click({ force: true })
     // input amounts
     cy.get('#swap-currency-input .token-amount-input').should('be.visible')
     cy.get('#swap-currency-input .token-amount-input').type('0.001', { force: true, delay: 400 })

--- a/src/custom/hooks/web3.ts
+++ b/src/custom/hooks/web3.ts
@@ -30,11 +30,12 @@ export function useEagerConnect() {
 
       // if there is no last saved provider set tried state to true
       if (!latestProvider) {
-        setTried(true)
-      }
-
-      // check if the last saved provider is Metamask
-      if (latestProvider === WalletProvider.INJECTED) {
+        // Try to auto-connect to the injected wallet
+        activate(injected, undefined, true).catch(() => {
+          setTried(true)
+        })
+      } else if (latestProvider === WalletProvider.INJECTED) {
+        // check if the last saved provider is Metamask
         // check if the our application is authorized/connected with Metamask
         injected.isAuthorized().then((isAuthorized) => {
           if (isAuthorized) {


### PR DESCRIPTION
# Summary

Fix issue with e2e not being able to select a token:
![image](https://user-images.githubusercontent.com/2352112/142208051-89ec1624-bbbd-43bb-b21f-76ceea1fcdf2.png)

Also solves https://github.com/gnosis/cowswap/issues/1830

This is what happens:
![image](https://user-images.githubusercontent.com/2352112/142208081-a31d4c78-310d-4f1f-8f8a-2b7f0eab2811.png)


The issue is related to https://github.com/bvaughn/react-window that is used for the selector
This component phiscally remove elements that are not visible from the DOM while you scroll. So obviously Cypress can find it


See more context
https://gnosisinc.slack.com/archives/C025G521XQD/p1637143944007100


## Solution

![image](https://user-images.githubusercontent.com/2352112/142208562-20309ee0-1bd8-45ea-8fb9-7bf79791ebd3.png)

Basically the solution was to use the URL to select the tokens, it's easier :) 

Also, there was another error. The auto-connect logic implemented by @nenadV91 broke the automatic connections for e2e. The solution was quite easy, but pls Nenad double check what i did there i case u see any issue. 

## Not included
I left a TODO for an improvement. Also mentioned it in the thread in case @MareenG can implement it. Basically would 


# Test
1. See tests are passing