### PR TITLE
[safe]  Handle Gnosis Safe rejections

### DIFF
--- a/src/custom/api/gnosisSafe/index.ts
+++ b/src/custom/api/gnosisSafe/index.ts
@@ -43,14 +43,14 @@ function _getClientOrThrow(chainId: number): SafeServiceClient {
   return client
 }
 
-export function getSafeWebUrl(chaindId: number, safeAddress: string): string | null {
+export function getSafeWebUrl(chaindId: number, safeAddress: string, isPending: boolean): string | null {
   const chainShortName = CHAIN_SHORT_NAME[chaindId]
 
   if (!chainShortName) {
     return null
   }
 
-  return `${SAFE_BASE_URL}/app/${chainShortName}:${safeAddress}/transactions/queue` // TODO: This will change soon in https://github.com/gnosis/safe-react/issues/970
+  return `${SAFE_BASE_URL}/app/${chainShortName}:${safeAddress}/transactions/${isPending ? 'queue' : 'history'}` // TODO: This will change soon in https://github.com/gnosis/safe-react/issues/970
 }
 
 export function getSafeTransaction(chainId: number, safeTxHash: string): Promise<SafeMultisigTransactionResponse> {

--- a/src/custom/components/AccountDetails/Transaction/ActivityDetails.tsx
+++ b/src/custom/components/AccountDetails/Transaction/ActivityDetails.tsx
@@ -51,9 +51,10 @@ function GnosisSafeTxDetails(props: {
   const { chainId, activityDerivedState } = props
   const { gnosisSafeInfo, enhancedTransaction, status, isOrder, order, isExpired, isCancelled } = activityDerivedState
   const gnosisSafeThreshold = gnosisSafeInfo?.threshold
+  const gnosisSafeNonce = gnosisSafeInfo?.nonce
   const safeTransaction = enhancedTransaction?.safeTransaction || order?.presignGnosisSafeTx
 
-  if (!gnosisSafeThreshold || !gnosisSafeInfo || !safeTransaction) {
+  if (!gnosisSafeThreshold || !gnosisSafeInfo || !safeTransaction || gnosisSafeNonce === undefined) {
     return null
   }
 
@@ -69,6 +70,8 @@ function GnosisSafeTxDetails(props: {
 
   const { confirmations, nonce, isExecuted } = safeTransaction
 
+  const nonceIsOld = gnosisSafeNonce > nonce
+
   const numConfirmations = confirmations?.length ?? 0
   const pendingSignaturesCount = gnosisSafeThreshold - numConfirmations
   const isPendingSignatures = pendingSignaturesCount > 0
@@ -81,6 +84,8 @@ function GnosisSafeTxDetails(props: {
     signaturesMessage = <span>Executed</span>
   } else if (isCancelled) {
     signaturesMessage = <span>Cancelled order</span>
+  } else if (nonceIsOld) {
+    signaturesMessage = <span>Rejected</span>
   } else if (isExpired) {
     signaturesMessage = <span>Expired order</span>
   } else if (alreadySigned) {
@@ -135,7 +140,12 @@ function GnosisSafeTxDetails(props: {
       {signaturesMessage}
 
       {/* View in: Gnosis Safe */}
-      <GnosisSafeLink chainId={chainId} safeTransaction={safeTransaction} gnosisSafeThreshold={gnosisSafeThreshold} />
+      <GnosisSafeLink
+        chainId={chainId}
+        safeTransaction={safeTransaction}
+        gnosisSafeThreshold={gnosisSafeThreshold}
+        gnosisSafeNonce={gnosisSafeNonce}
+      />
     </TransactionInnerDetail>
   )
 }

--- a/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
+++ b/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
@@ -26,8 +26,9 @@ export function GnosisSafeLink(props: {
     return null
   }
 
-  const { safe } = safeTransaction
-  const safeUrl = getSafeWebUrl(chainId, safe)
+  const { safe, isExecuted } = safeTransaction
+  const isPending = !isExecuted
+  const safeUrl = getSafeWebUrl(chainId, safe, isPending)
 
   // Only show the link to the safe, if we have the "safeUrl"
   if (safeUrl === null) {

--- a/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
+++ b/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
@@ -19,17 +19,16 @@ export function GnosisSafeLink(props: {
   chainId: number
   safeTransaction?: SafeMultisigTransactionResponse
   gnosisSafeThreshold: number
-  gnosisSafeNonce: number
+  gnosisSafeOldNonce: boolean
 }): JSX.Element | null {
-  const { chainId, safeTransaction, gnosisSafeNonce } = props
+  const { chainId, safeTransaction, gnosisSafeOldNonce } = props
 
   if (!safeTransaction) {
     return null
   }
 
-  const { safe, isExecuted, nonce } = safeTransaction
-  const isOldNonce = gnosisSafeNonce > nonce
-  const isPending = !isExecuted && !isOldNonce
+  const { safe, isExecuted } = safeTransaction
+  const isPending = !isExecuted && !gnosisSafeOldNonce
   const safeUrl = getSafeWebUrl(chainId, safe, isPending)
 
   // Only show the link to the safe, if we have the "safeUrl"
@@ -49,6 +48,7 @@ function _getStateLabel({
   isPresignaturePending,
   isCancelled,
   enhancedTransaction,
+  isRejected,
 }: ActivityDerivedState) {
   if (isPending) {
     if (enhancedTransaction) {
@@ -64,6 +64,10 @@ function _getStateLabel({
 
   if (isConfirmed) {
     return 'Filled'
+  }
+
+  if (isRejected) {
+    return 'Rejected'
   }
 
   if (isExpired) {
@@ -101,6 +105,7 @@ export function StatusDetails(props: { chainId: number; activityDerivedState: Ac
     isTransaction,
     isCancelled,
     isCancellable,
+    isRejected,
   } = activityDerivedState
 
   const [showCancelModal, setShowCancelModal] = useState(false)
@@ -121,6 +126,8 @@ export function StatusDetails(props: { chainId: number; activityDerivedState: Ac
           <SVG src={OrderCheckImage} description="Transaction Confirmed" />
         ) : isConfirmed ? (
           <SVG src={OrderCheckImage} description="Order Filled" />
+        ) : isRejected ? (
+          <SVG src={OrderCancelledImage} description="Rejected" />
         ) : isExpired && isTransaction ? (
           <SVG src={OrderCancelledImage} description="Transaction Failed" />
         ) : isExpired ? (

--- a/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
+++ b/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
@@ -19,15 +19,17 @@ export function GnosisSafeLink(props: {
   chainId: number
   safeTransaction?: SafeMultisigTransactionResponse
   gnosisSafeThreshold: number
+  gnosisSafeNonce: number
 }): JSX.Element | null {
-  const { chainId, safeTransaction } = props
+  const { chainId, safeTransaction, gnosisSafeNonce } = props
 
   if (!safeTransaction) {
     return null
   }
 
-  const { safe, isExecuted } = safeTransaction
-  const isPending = !isExecuted
+  const { safe, isExecuted, nonce } = safeTransaction
+  const isOldNonce = gnosisSafeNonce > nonce
+  const isPending = !isExecuted && !isOldNonce
   const safeUrl = getSafeWebUrl(chainId, safe, isPending)
 
   // Only show the link to the safe, if we have the "safeUrl"

--- a/src/custom/components/AccountDetails/Transaction/index.tsx
+++ b/src/custom/components/AccountDetails/Transaction/index.tsx
@@ -175,8 +175,8 @@ export default function Activity({ activity: activityData }: { activity: Activit
   const creationTimeFull = creationTimeEnhanced
     ? new Date(creationTimeEnhanced)
     : creationTimeOrder
-    ? new Date(Date.parse(creationTimeOrder))
-    : undefined
+      ? new Date(Date.parse(creationTimeOrder))
+      : undefined
 
   const timeFormatOptionHM: Intl.DateTimeFormatOptions = {
     timeStyle: 'short',

--- a/src/custom/components/AccountDetails/Transaction/index.tsx
+++ b/src/custom/components/AccountDetails/Transaction/index.tsx
@@ -175,8 +175,8 @@ export default function Activity({ activity: activityData }: { activity: Activit
   const creationTimeFull = creationTimeEnhanced
     ? new Date(creationTimeEnhanced)
     : creationTimeOrder
-      ? new Date(Date.parse(creationTimeOrder))
-      : undefined
+    ? new Date(Date.parse(creationTimeOrder))
+    : undefined
 
   const timeFormatOptionHM: Intl.DateTimeFormatOptions = {
     timeStyle: 'short',

--- a/src/custom/components/AccountDetails/Transaction/index.tsx
+++ b/src/custom/components/AccountDetails/Transaction/index.tsx
@@ -187,7 +187,6 @@ export default function Activity({ activity: activityData }: { activity: Activit
     () => getActivityDerivedState({ chainId, activityData, allowsOffchainSigning, gnosisSafeInfo }),
     [chainId, activityData, allowsOffchainSigning, gnosisSafeInfo]
   )
-  console.log('activityDerivedState', activityDerivedState)
 
   if (!activityDerivedState || !chainId) return null
   const { activityLinkUrl } = activityDerivedState

--- a/src/custom/components/AccountDetails/Transaction/index.tsx
+++ b/src/custom/components/AccountDetails/Transaction/index.tsx
@@ -93,8 +93,9 @@ function getActivityLinkUrl(params: {
       return getEtherscanLink(chainId, transactionHash, 'transaction')
     } else if (safeTransaction && safeTransaction) {
       // Its a safe transaction: Gnosis Safe Web link
-      const { safe } = safeTransaction
-      return getSafeWebUrl(chainId, safe) ?? undefined
+      const { safe, isExecuted } = safeTransaction
+      const isPending = !isExecuted
+      return getSafeWebUrl(chainId, safe, isPending) ?? undefined
     }
   } else if (order) {
     // Its an order: GP Explorer link
@@ -174,8 +175,8 @@ export default function Activity({ activity: activityData }: { activity: Activit
   const creationTimeFull = creationTimeEnhanced
     ? new Date(creationTimeEnhanced)
     : creationTimeOrder
-    ? new Date(Date.parse(creationTimeOrder))
-    : undefined
+      ? new Date(Date.parse(creationTimeOrder))
+      : undefined
 
   const timeFormatOptionHM: Intl.DateTimeFormatOptions = {
     timeStyle: 'short',

--- a/src/custom/hooks/useGetSafeTransactionInfo.ts
+++ b/src/custom/hooks/useGetSafeTransactionInfo.ts
@@ -7,12 +7,12 @@ import { RetryResult } from '../types'
 
 const DEFAULT_RETRY_OPTIONS: RetryOptions = { n: 3, minWait: 1000, maxWait: 3000 }
 
-export type GetSafeInfo = (hash: string) => RetryResult<SafeMultisigTransactionResponse>
+export type GetSafeTransactionInfo = (hash: string) => RetryResult<SafeMultisigTransactionResponse>
 
-export function useGetSafeInfo(): GetSafeInfo {
+export function useGetSafeTransactionInfo(): GetSafeTransactionInfo {
   const { chainId } = useActiveWeb3React()
 
-  const getSafeInfo = useCallback<GetSafeInfo>(
+  const getSafeTransactionInfo = useCallback<GetSafeTransactionInfo>(
     (hash) => {
       return retry(() => {
         if (chainId === undefined) {
@@ -25,5 +25,5 @@ export function useGetSafeInfo(): GetSafeInfo {
     [chainId]
   )
 
-  return getSafeInfo
+  return getSafeTransactionInfo
 }

--- a/src/custom/hooks/useWalletInfo.ts
+++ b/src/custom/hooks/useWalletInfo.ts
@@ -18,6 +18,7 @@ export interface ConnectedWalletInfo {
   chainId?: number
   active: boolean
   account?: string | null
+  library?: any
   activeNetwork: boolean // active default connection
   provider?: WalletProvider
   isSmartContractWallet: boolean
@@ -77,7 +78,7 @@ async function getWcPeerMetadata(connector: WalletConnectConnector): Promise<{ w
 }
 
 export function useWalletInfo(): ConnectedWalletInfo {
-  const { active, account, connector, chainId } = useWeb3React()
+  const { active, account, connector, chainId, library } = useWeb3React()
   const web3Instance = useActiveWeb3Instance()
   const [walletName, setWalletName] = useState<string>()
   const [icon, setIcon] = useState<string>()
@@ -128,6 +129,7 @@ export function useWalletInfo(): ConnectedWalletInfo {
     chainId,
     active,
     account,
+    library,
     activeNetwork: contextNetwork.active,
     provider,
     isSmartContractWallet,

--- a/src/custom/state/enhancedTransactions/actions.ts
+++ b/src/custom/state/enhancedTransactions/actions.ts
@@ -28,6 +28,14 @@ export const checkedTransaction = createAction<{
   blockNumber: number
 }>('enhancedTransactions/checkedTransaction')
 
+/**
+ * Reject multisig transactions
+ */
+export const rejectTransaction = createAction<{
+  chainId: number
+  hash: string
+}>('enhancedTransactions/rejectTransaction')
+
 export const cancelTransaction = createAction<{
   chainId: number
   hash: string

--- a/src/custom/state/enhancedTransactions/reducer.ts
+++ b/src/custom/state/enhancedTransactions/reducer.ts
@@ -5,6 +5,7 @@ import {
   checkedTransaction,
   finalizeTransaction,
   cancelTransaction,
+  rejectTransaction,
   replaceTransaction,
   updateSafeTransaction,
 } from 'state/enhancedTransactions/actions'
@@ -29,6 +30,7 @@ export interface EnhancedTransactionDetails {
   from: string
   summary?: string
   confirmedTime?: number
+  rejectedTime?: number
   receipt?: SerializableTransactionReceipt // Ethereum transaction receipt
 
   // Operations
@@ -114,6 +116,14 @@ export default createReducer(initialState, (builder) =>
       }
       const allTxs = transactions[chainId] ?? {}
       delete allTxs[hash]
+    })
+
+    .addCase(rejectTransaction, (transactions, { payload: { chainId, hash } }) => {
+      const tx = transactions[chainId]?.[hash]
+      if (!tx) {
+        return
+      }
+      tx.rejectedTime = now()
     })
 
     .addCase(replaceTransaction, (transactions, { payload: { chainId, oldHash, newHash } }) => {

--- a/src/custom/state/orders/actions.ts
+++ b/src/custom/state/orders/actions.ts
@@ -116,6 +116,7 @@ export interface UpdatePresignGnosisSafeTxParams {
   orderId: OrderID
   chainId: ChainId
   safeTransaction: SafeMultisigTransactionResponse
+  isRejected?: boolean
 }
 export type ExpireOrdersBatchParams = BatchOrdersUpdateParams
 export type CancelOrdersBatchParams = BatchOrdersUpdateParams

--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -154,11 +154,15 @@ export default createReducer(initialState, (builder) =>
     })
     .addCase(updatePresignGnosisSafeTx, (state, action) => {
       prefillState(state, action)
-      const { orderId, chainId, safeTransaction } = action.payload
+      const { orderId, chainId, safeTransaction, isRejected } = action.payload
 
       const orderObject = getOrderById(state, chainId, orderId)
       if (orderObject) {
         orderObject.order.presignGnosisSafeTx = safeTransaction
+
+        if (isRejected !== undefined) {
+          orderObject.order.status = OrderStatus.CANCELLED
+        }
       }
     })
     .addCase(removeOrder, (state, action) => {


### PR DESCRIPTION
# Summary

Closes #1877 and #1852 

This PR handles Gnosis Safe rejection of transactions and orders.
Additionally, now it creates the link to the right place /queue or the /history depending if the order is final or not.

# Not included
As all these PRs, u might experience some short delays getting the new state from the Gnosis Safe. So you might have to wait a few seconds to see that a tx has been rejected.

# To Test

Test the Gnosis Safe link
1. Test the link for Tx and Orders
2. Make sure you test the link when the transaction is pending and when is executed

Test the gnosis safe rejections
1. Test that rejections of TX are being handled
2. Test that rejections of Orders are being handled