### PR TITLE
Fix autoconnect

### DIFF
--- a/src/custom/hooks/web3.ts
+++ b/src/custom/hooks/web3.ts
@@ -24,6 +24,31 @@ export function useEagerConnect() {
     }
   }, [connector, active])
 
+  const connectInjected = useCallback(() => {
+    // check if the our application is authorized/connected with Metamask
+    injected.isAuthorized().then((isAuthorized) => {
+      if (isAuthorized) {
+        activate(injected, undefined, true).catch(() => {
+          setTried(true)
+        })
+      } else {
+        if (isMobile && window.ethereum) {
+          activate(injected, undefined, true).catch(() => {
+            setTried(true)
+          })
+        } else {
+          setTried(true)
+        }
+      }
+    })
+  }, [activate, setTried])
+
+  const connectWalletConnect = useCallback(() => {
+    activate(walletconnect, undefined, true).catch(() => {
+      setTried(true)
+    })
+  }, [activate, setTried])
+
   useEffect(() => {
     if (!active) {
       const latestProvider = localStorage.getItem(STORAGE_KEY_LAST_PROVIDER)
@@ -31,48 +56,16 @@ export function useEagerConnect() {
       // if there is no last saved provider set tried state to true
       if (!latestProvider) {
         // Try to auto-connect to the injected wallet
-        injected
-          .isAuthorized()
-          .then((isAuthorized) => {
-            console.log('[web3] Injected wallet: Is authorized ', isAuthorized)
-            if (isAuthorized) {
-              activate(injected, undefined, true).catch(() => {
-                setTried(true)
-              })
-            } else {
-              setTried(true)
-            }
-          })
-          .catch((error) => {
-            console.log('[web3] Injected wallet: Error checking if isAuthorized', error)
-            setTried(true)
-          })
+        connectInjected()
       } else if (latestProvider === WalletProvider.INJECTED) {
-        // check if the last saved provider is Metamask
-        // check if the our application is authorized/connected with Metamask
-        injected.isAuthorized().then((isAuthorized) => {
-          if (isAuthorized) {
-            activate(injected, undefined, true).catch(() => {
-              setTried(true)
-            })
-          } else {
-            if (isMobile && window.ethereum) {
-              activate(injected, undefined, true).catch(() => {
-                setTried(true)
-              })
-            } else {
-              setTried(true)
-            }
-          }
-        })
-        // check if the last saved provider is WalletConnect
+        // MM is last provider
+        connectInjected()
       } else if (latestProvider === WalletProvider.WALLET_CONNECT) {
-        activate(walletconnect, undefined, true).catch(() => {
-          setTried(true)
-        })
+        // WC is last provider
+        connectWalletConnect()
       }
     }
-  }, [activate, active, connector]) // intentionally only running on mount (make sure it's only mounted once :))
+  }, [connectInjected, connectWalletConnect, active]) // intentionally only running on mount (make sure it's only mounted once :))
 
   // if the connection worked, wait until we get confirmation of that to flip the flag
   useEffect(() => {

--- a/src/custom/hooks/web3.ts
+++ b/src/custom/hooks/web3.ts
@@ -31,9 +31,22 @@ export function useEagerConnect() {
       // if there is no last saved provider set tried state to true
       if (!latestProvider) {
         // Try to auto-connect to the injected wallet
-        activate(injected, undefined, true).catch(() => {
-          setTried(true)
-        })
+        injected
+          .isAuthorized()
+          .then((isAuthorized) => {
+            console.log('[web3] Injected wallet: Is authorized ', isAuthorized)
+            if (isAuthorized) {
+              activate(injected, undefined, true).catch(() => {
+                setTried(true)
+              })
+            } else {
+              setTried(true)
+            }
+          })
+          .catch((error) => {
+            console.log('[web3] Injected wallet: Error checking if isAuthorized', error)
+            setTried(true)
+          })
       } else if (latestProvider === WalletProvider.INJECTED) {
         // check if the last saved provider is Metamask
         // check if the our application is authorized/connected with Metamask


### PR DESCRIPTION
# Summary

Auto-connect was breaking the app. Yes, that's bad!, but the good thing is that it's likely the same issues as @elena-zh @MareenG discovered some time ago and we didn't know how to reproduce.

This PR tries to solve the current issue we have in staging that makes the app to not load in the case of a locked Metamask account.

Additionally should solve #1187 #1123 too

# To Test

1. Load the app with the account locked
2. try to test in MM mobile too

  # Background

*Optional: Give background information for changes you've made, that might be difficult to explain via comments*

