### PR TITLE
Always create a new state object when adding an order (#1686)

### DIFF
--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -140,14 +140,6 @@ function addOrderToState(
   state[chainId][status] = { ...state[chainId][status], [id]: { order, id } }
 }
 
-function popOrder(state: OrdersState, chainId: ChainId, status: OrderStatus, id: string): OrderObject | undefined {
-  const orderObj = state?.[chainId]?.[status]?.[id]
-  if (orderObj) {
-    delete state?.[chainId]?.[status]?.[id]
-  }
-  return orderObj
-}
-
 const initialState: OrdersState = {}
 
 export default createReducer(initialState, (builder) =>

--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -125,6 +125,29 @@ function deleteOrderById(state: Required<OrdersState>, chainId: ChainId, id: str
   delete stateForChain.cancelled[id]
 }
 
+function addOrderToState(
+  state: Required<OrdersState>,
+  chainId: ChainId,
+  id: string,
+  status: OrderTypeKeys,
+  order: SerializedOrder
+): void {
+  // Attempt to fix `TypeError: Cannot add property <x>, object is not extensible`
+  // seen on https://user-images.githubusercontent.com/34510341/138450105-bb94a2d1-656e-4e15-ae99-df9fb33c8ca4.png
+  // by creating a new object instead of trying to edit the existing one
+  // Seems to be due to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions
+  // but only happened on Chrome
+  state[chainId][status] = { ...state[chainId][status], [id]: { order, id } }
+}
+
+function popOrder(state: OrdersState, chainId: ChainId, status: OrderStatus, id: string): OrderObject | undefined {
+  const orderObj = state?.[chainId]?.[status]?.[id]
+  if (orderObj) {
+    delete state?.[chainId]?.[status]?.[id]
+  }
+  return orderObj
+}
+
 const initialState: OrdersState = {}
 
 export default createReducer(initialState, (builder) =>
@@ -134,12 +157,12 @@ export default createReducer(initialState, (builder) =>
       const { order, id, chainId } = action.payload
 
       const orderStateList = order.status === OrderStatus.PRESIGNATURE_PENDING ? 'presignaturePending' : 'pending'
-      state[chainId][orderStateList][id] = { order, id }
+
+      addOrderToState(state, chainId, id, orderStateList, order)
     })
     .addCase(preSignOrders, (state, action) => {
       prefillState(state, action)
       const { ids, chainId } = action.payload
-      const pendingOrders = state[chainId].pending
 
       ids.forEach((id) => {
         const orderObject = getOrderById(state, chainId, id)
@@ -148,7 +171,8 @@ export default createReducer(initialState, (builder) =>
           deleteOrderById(state, chainId, id)
 
           orderObject.order.status = OrderStatus.PENDING
-          pendingOrders[id] = orderObject
+
+          addOrderToState(state, chainId, id, 'pending', orderObject.order)
         }
       })
     })
@@ -180,7 +204,7 @@ export default createReducer(initialState, (builder) =>
         orderObject.order.fulfilledTransactionHash = transactionHash
         orderObject.order.isCancelling = false
 
-        state[chainId].fulfilled[id] = orderObject
+        addOrderToState(state, chainId, id, 'fulfilled', orderObject.order)
       }
     })
     .addCase(fulfillOrdersBatch, (state, action) => {
@@ -203,7 +227,7 @@ export default createReducer(initialState, (builder) =>
 
           orderObject.order.apiAdditionalInfo = apiAdditionalInfo
 
-          state[chainId].fulfilled[id] = orderObject
+          addOrderToState(state, chainId, id, 'fulfilled', orderObject.order)
         }
       })
     })
@@ -219,13 +243,12 @@ export default createReducer(initialState, (builder) =>
         orderObject.order.status = OrderStatus.EXPIRED
         orderObject.order.isCancelling = false
 
-        state[chainId].expired[id] = orderObject
+        addOrderToState(state, chainId, id, 'expired', orderObject.order)
       }
     })
     .addCase(expireOrdersBatch, (state, action) => {
       prefillState(state, action)
       const { ids, chainId } = action.payload
-      const fulfilledOrders = state[chainId].expired
 
       // if there are any newly fulfilled orders
       // update them
@@ -237,7 +260,8 @@ export default createReducer(initialState, (builder) =>
 
           orderObject.order.status = OrderStatus.EXPIRED
           orderObject.order.isCancelling = false
-          fulfilledOrders[id] = orderObject
+
+          addOrderToState(state, chainId, id, 'expired', orderObject.order)
         }
       })
     })
@@ -263,13 +287,12 @@ export default createReducer(initialState, (builder) =>
         orderObject.order.status = OrderStatus.CANCELLED
         orderObject.order.isCancelling = false
 
-        state[chainId].cancelled[id] = orderObject
+        addOrderToState(state, chainId, id, 'cancelled', orderObject.order)
       }
     })
     .addCase(cancelOrdersBatch, (state, action) => {
       prefillState(state, action)
       const { ids, chainId } = action.payload
-      const cancelledOrders = state[chainId].cancelled
 
       ids.forEach((id) => {
         const orderObject = getOrderById(state, chainId, id)
@@ -279,7 +302,8 @@ export default createReducer(initialState, (builder) =>
 
           orderObject.order.status = OrderStatus.CANCELLED
           orderObject.order.isCancelling = false
-          cancelledOrders[id] = orderObject
+
+          addOrderToState(state, chainId, id, 'cancelled', orderObject.order)
         }
       })
     })


### PR DESCRIPTION
# Summary

Cherry-picked https://github.com/gnosis/cowswap/pull/1684/commits/bf70822f15b8f445dfeca6f50886aa9491b19d82 from #1686 to solve issue with `can't define property` error #1844

  # To Test

See steps on https://github.com/gnosis/cowswap/pull/1686 and #1844 


