### PR TITLE
Fix wrong label

### DIFF
--- a/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
+++ b/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
@@ -60,7 +60,7 @@ function _getStateLabel({
   }
 
   if (isConfirmed) {
-    return 'Filled'
+    return isOrder ? 'Filled' : 'Executed'
   }
 
   if (isExpired) {


### PR DESCRIPTION
# Summary

Fixes #1732 

![image](https://user-images.githubusercontent.com/2352112/142485590-40ed825a-650b-4fae-914e-65dfc48e51ec.png)

Now it says "Executed" for transactions , and "Filled" for orders

# To Test

1. Make sure the labels are correct for orders and txs