### PR TITLE
Show proper warning when on barn

### DIFF
--- a/src/custom/components/Header/URLWarning/index.tsx
+++ b/src/custom/components/Header/URLWarning/index.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components/macro'
-import { PRODUCTION_URL } from 'constants/index'
+import { BARN_URL, PRODUCTION_URL } from 'constants/index'
 import { AlertTriangle } from 'react-feather'
 import URLWarningUni, { PhishAlert, StyledClose } from './URLWarningMod'
 import { useAnnouncementVisible, useCloseAnnouncement } from 'state/profile/hooks'
@@ -8,6 +8,7 @@ import useFetchFile from 'hooks/useFetchFile'
 import { Markdown } from 'components/Markdown'
 import { useActiveWeb3React } from '@src/hooks/web3'
 import { ChainId } from '@uniswap/sdk'
+import { isBarn } from 'utils/environments'
 
 export * from './URLWarningMod'
 
@@ -54,6 +55,8 @@ function getAnnouncementUrl(chainId: number) {
   return `${ANNOUNCEMENTS_MARKDOWN_BASE_URL}/announcements-${chainId}.md`
 }
 
+const WARNING_URL = isBarn ? BARN_URL : PRODUCTION_URL
+
 export default function URLWarning() {
   const { chainId = ChainId.MAINNET } = useActiveWeb3React()
 
@@ -81,7 +84,7 @@ export default function URLWarning() {
 
   return (
     <Wrapper>
-      <URLWarningUni url={PRODUCTION_URL} announcement={announcement} />
+      <URLWarningUni url={WARNING_URL} announcement={announcement} />
     </Wrapper>
   )
 }

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -25,6 +25,7 @@ export const LONG_LOAD_THRESHOLD = 2000
 
 export const APP_DATA_HASH = getAppDataHash()
 export const PRODUCTION_URL = 'cowswap.exchange'
+export const BARN_URL = `barn.${PRODUCTION_URL}`
 
 const DISABLED_WALLETS = /^(?:WALLET_LINK|COINBASE_LINK|FORTMATIC|Portis)$/i
 


### PR DESCRIPTION
# Summary

Closes #1207 

Show proper warning when on barn

(I forced locally to show the warning, it won't be visible in this PR)
![screenshot_2021-11-18_14-48-34](https://user-images.githubusercontent.com/43217/142509221-bea0f465-f93e-4f09-8a4e-d358e62b2b88.png)

  # To Test

Need to be deployed to barn, cannot be seen otherwise

  # Background

Quick task from the technical debt list https://github.com/gnosis/cowswap/issues/1887

