### PR TITLE
When on barn.cowswap.exchange, use barn.gnosis-procol.io

### DIFF
--- a/.env
+++ b/.env
@@ -68,6 +68,7 @@ REACT_APP_PATH_REGEX_ENS="/ipfs"
 #REACT_APP_EXPLORER_URL_DEV=https://protocol-explorer.dev.gnosisdev.com
 #REACT_APP_EXPLORER_URL_STAGING=https://protocol-explorer.staging.gnosisdev.com
 #REACT_APP_EXPLORER_URL_PROD=https://gnosis-protocol.io
+#REACT_APP_EXPLORER_URL_BARN=https://barn.gnosis-protocol.io
 
 # Enables mock mode (default = true)
 REACT_APP_MOCK=true

--- a/.env.production
+++ b/.env.production
@@ -67,6 +67,7 @@ REACT_APP_PATH_REGEX_ENS="/ipfs"
 #REACT_APP_EXPLORER_URL_DEV=https://protocol-explorer.dev.gnosisdev.com
 #REACT_APP_EXPLORER_URL_STAGING=https://protocol-explorer.staging.gnosisdev.com
 #REACT_APP_EXPLORER_URL_PROD=https://gnosis-protocol.io
+#REACT_APP_EXPLORER_URL_BARN=https://barn.gnosis-protocol.io
 
 # Enables mock mode (default = false)
 REACT_APP_MOCK=false

--- a/src/custom/utils/explorer.ts
+++ b/src/custom/utils/explorer.ts
@@ -4,10 +4,12 @@ import { isLocal, isDev, isPr, isStaging, isBarn } from './environments'
 
 function _getExplorerUrlByEnvironment() {
   let baseUrl: string | undefined
-  if (isLocal || isDev || isPr || isBarn) {
+  if (isLocal || isDev || isPr) {
     baseUrl = process.env.REACT_APP_EXPLORER_URL_DEV || 'https://protocol-explorer.dev.gnosisdev.com'
   } else if (isStaging) {
     baseUrl = process.env.REACT_APP_EXPLORER_URL_STAGING || 'https://protocol-explorer.staging.gnosisdev.com'
+  } else if (isBarn) {
+    baseUrl = process.env.REACT_APP_EXPLORER_URL_BARN || 'https://barn.gnosis-protocol.io'
   } else {
     // Production by default
     baseUrl = process.env.REACT_APP_EXPLORER_URL_PROD || 'https://gnosis-protocol.io'


### PR DESCRIPTION
# Summary

Uses barn.gnosis-protocol.io for barn.cowswap.exchange

Example: https://barn.gnosis-protocol.io/rinkeby/orders/0x8ec65726990601cda15ebf7e3a125619273817899659c84e00668d33c621ff6f5b0abe214ab7875562adee331deff0fe1912fe426196eadd

Already works, would be nice to have this deployed first but not a must https://github.com/gnosis/gp-ui/pull/850

  # To Test

Needs to be merged to `master` first

# Background

Part of technical debt epic https://github.com/gnosis/cowswap/issues/1887

