### PR TITLE
Update orders faster

### DIFF
--- a/src/custom/state/orders/consts.ts
+++ b/src/custom/state/orders/consts.ts
@@ -7,7 +7,7 @@ export const ContractDeploymentBlocks: Partial<Record<ChainId, number>> = {
   [ChainId.XDAI]: 13566914,
 }
 
-export const OPERATOR_API_POLL_INTERVAL = 10000 // in ms
-export const PENDING_ORDERS_PRICE_CHECK_POLL_INTERVAL = 30000 // in ms
+export const OPERATOR_API_POLL_INTERVAL = 2000 // in ms
+export const PENDING_ORDERS_PRICE_CHECK_POLL_INTERVAL = 15000 // in ms
 
 export const OUT_OF_MARKET_PRICE_DELTA_PERCENTAGE = new Percent(1, 100) // 1/100 => 0.01 => 1%

--- a/src/custom/state/orders/updaters/CancelledOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/CancelledOrdersUpdater.ts
@@ -33,6 +33,7 @@ export function CancelledOrdersUpdater(): null {
 
   // Ref, so we don't rerun useEffect
   const cancelledRef = useRef(cancelled)
+  const isUpdating = useRef(false) // TODO: Implement using SWR or retry/cancellable promises
   cancelledRef.current = cancelled
 
   const fulfillOrdersBatch = useFulfillOrdersBatch()
@@ -41,40 +42,57 @@ export function CancelledOrdersUpdater(): null {
     async (chainId: ChainId, account: string) => {
       const lowerCaseAccount = account.toLowerCase()
       const now = Date.now()
-      // Filter orders:
-      // - Owned by the current connected account
-      // - Created in the last 5 min, no further
-      const pending = cancelledRef.current.filter(({ owner, creationTime: creationTimeString }) => {
-        const creationTime = new Date(creationTimeString).getTime()
 
-        return owner.toLowerCase() === lowerCaseAccount && now - creationTime < CANCELLED_ORDERS_PENDING_TIME
-      })
-
-      if (pending.length === 0) {
+      if (isUpdating.current) {
         return
       }
 
-      // Iterate over pending orders fetching operator order data, async
-      const unfilteredOrdersData = await Promise.all(
-        pending.map(async (orderFromStore) => fetchOrderPopupData(orderFromStore, chainId))
-      )
+      // const startTime = Date.now()
+      // console.debug('[CancelledOrdersUpdater] Checking recently canceled orders....')
+      try {
+        isUpdating.current = true
 
-      // Group resolved promises by status
-      // Only pick fulfilled
-      const { fulfilled } = unfilteredOrdersData.reduce<Record<OrderTransitionStatus, OrderLogPopupMixData[]>>(
-        (acc, { status, popupData }) => {
-          popupData && acc[status].push(popupData)
-          return acc
-        },
-        { fulfilled: [], presigned: [], expired: [], cancelled: [], unknown: [], pending: [] }
-      )
+        // Filter orders:
+        // - Owned by the current connected account
+        // - Created in the last 5 min, no further
+        const pending = cancelledRef.current.filter(({ owner, creationTime: creationTimeString }) => {
+          const creationTime = new Date(creationTimeString).getTime()
 
-      // Bach state update fulfilled orders, if any
-      fulfilled.length > 0 &&
-        fulfillOrdersBatch({
-          ordersData: fulfilled as OrderFulfillmentData[],
-          chainId,
+          return owner.toLowerCase() === lowerCaseAccount && now - creationTime < CANCELLED_ORDERS_PENDING_TIME
         })
+
+        if (pending.length === 0) {
+          // console.debug(`[CancelledOrdersUpdater] No orders are being cancelled`)
+          return
+        } /* else {
+          console.debug(`[CancelledOrdersUpdater] Checking ${pending.length} recently canceled orders...`)
+        }*/
+
+        // Iterate over pending orders fetching operator order data, async
+        const unfilteredOrdersData = await Promise.all(
+          pending.map(async (orderFromStore) => fetchOrderPopupData(orderFromStore, chainId))
+        )
+
+        // Group resolved promises by status
+        // Only pick fulfilled
+        const { fulfilled } = unfilteredOrdersData.reduce<Record<OrderTransitionStatus, OrderLogPopupMixData[]>>(
+          (acc, { status, popupData }) => {
+            popupData && acc[status].push(popupData)
+            return acc
+          },
+          { fulfilled: [], presigned: [], expired: [], cancelled: [], unknown: [], pending: [] }
+        )
+
+        // Bach state update fulfilled orders, if any
+        fulfilled.length > 0 &&
+          fulfillOrdersBatch({
+            ordersData: fulfilled as OrderFulfillmentData[],
+            chainId,
+          })
+      } finally {
+        isUpdating.current = false
+        // console.debug(`[CancelledOrdersUpdater] Checked recently canceled orders in ${Date.now() - startTime}ms`)
+      }
     },
     [fulfillOrdersBatch]
   )


### PR DESCRIPTION
# Summary

Tries to improve the UX around when we detect an order has been fullfileed.

This PR is a bit sensitive because changes:
- the update logic for pending orders
- the update logic for recently cancelled orders
- the update logic for the check that tells the user if the order is still with a good price (or if they are out of market)

However, the changes try to be scoped to only:
- Update faster (5X) the pending orders --> 2s
- Also the check where we verify if orders are still within the market price (2x) --> 15s
- Additionally, there's a flag to prevent concurrent execution of checks. If there's a previous check onging, the check will be skipped. This rarely occur since checks are fast (way less than 100ms)


## For reviewers
I left some commented console logs, was helpful while analysing, but i think is too much output. I left it there cause it's handy imo, but if you totally hate it, i would remove

# To Test

1. Make sure pending orders work as expected
2.Make sure cancelling orders work as expected 
3. Ideally, try to reproduce a situation where market conditions change. I think this is hard to test. I guess one way is trying to move the market price (big trade in Uniswap v2) while you are creating a CowSwap order with a very tight slippage tolerance (0.00001%)

# context
We need to make sure we detect the trades as soon as possible. Maybe we can research in hybrid approach using (time, bock, events, or a combination of the three). Related #1892