### PR TITLE
fix unsupported tokens footer width

### DIFF
--- a/src/custom/components/swap/UnsupportedCurrencyFooter/UnsupportedCurrencyFooterMod.tsx
+++ b/src/custom/components/swap/UnsupportedCurrencyFooter/UnsupportedCurrencyFooterMod.tsx
@@ -21,7 +21,7 @@ export const DetailsFooter = styled.div<{ show: boolean }>`
   padding-bottom: 20px;
   margin-top: -2rem;
   width: 100%;
-  max-width: 400px;
+  max-width: 460px;
   border-bottom-left-radius: 20px;
   border-bottom-right-radius: 20px;
   color: ${({ theme }) => theme.text2};


### PR DESCRIPTION
# Summary

The unsupported footer width is not consistent with that of trading window in prod.
![image](https://user-images.githubusercontent.com/3824034/142730086-b81a4055-3792-4fd0-aeb2-eefdccce4aa1.png)

Change it to the width used commonly in swap/add liquidity window.


  # To Test
1. input an unsupported token to swap for eg. PEOPLE
2. Make sure the unsupported token footer looks good
![image](https://user-images.githubusercontent.com/3824034/142730167-93675f4d-1b48-4911-ae16-994e4428a1c8.png)
 
# Reviewers
@anxolin @biocom @elena-zh @alfetopito 