### PR TITLE
1836/txs notification

### DIFF
--- a/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
+++ b/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
@@ -181,7 +181,7 @@ export default function Updater(): null {
 
   // Get, from the pending transaction, the ones that we should re-check
   const shouldCheckFilter = useMemo(() => {
-    if (!lastBlockNumber || !accountLowerCase) {
+    if (!lastBlockNumber) {
       return
     }
     return (tx: EnhancedTransactionDetails) =>

--- a/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
+++ b/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
@@ -100,7 +100,7 @@ function finalizeEthereumTransaction(
 function checkEthereumTransactions(params: CheckEthereumTransactions): Cancel[] {
   const { transactions, chainId, lastBlockNumber, getReceipt, getSafeInfo, dispatch } = params
 
-  const promiseCancellations = transactions.map((transaction) => {
+  return transactions.map((transaction) => {
     const { hash, hashType, receipt } = transaction
 
     if (hashType === HashType.GNOSIS_SAFE_TX) {
@@ -165,8 +165,6 @@ function checkEthereumTransactions(params: CheckEthereumTransactions): Cancel[] 
       return cancel
     }
   })
-
-  return promiseCancellations
 }
 
 export default function Updater(): null {


### PR DESCRIPTION
# Summary

Closes #1836 

Tx filter was not applied when not connected

Bug introduced when filtering txs per account (I did it ;) )

  # To Test

1. Perform transactions (wrap/unwrap/approvals) with regular and EOA and Safe
2. Do a swap with each as well
3. Disconnect all wallets (lock metamask)
4. Refresh the page
* Assuming there is no wallet connected, there shouldn't be any notifications in the UI
