### PR TITLE
Don't call fee/price endpoint on Wrapping (ETH/WETH || XDAI/WXDAI etc)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "CowSwap - Gnosis Protocol",
   "homepage": ".",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.7.0-rc.0",
   "engines": {
     "node": ">=14.0.0"
   },

--- a/src/custom/hooks/usePriceImpact/commonTypes.ts
+++ b/src/custom/hooks/usePriceImpact/commonTypes.ts
@@ -9,4 +9,5 @@ export type ParsedAmounts = {
 export interface FallbackPriceImpactParams {
   abTrade?: TradeGp
   fiatPriceImpact?: Percent
+  isWrapping: boolean
 }

--- a/src/custom/hooks/usePriceImpact/index.ts
+++ b/src/custom/hooks/usePriceImpact/index.ts
@@ -4,7 +4,9 @@ import useFallbackPriceImpact from './useFallbackPriceImpact'
 import { FallbackPriceImpactParams, ParsedAmounts } from './commonTypes'
 import { QuoteError } from 'state/price/actions'
 
-type PriceImpactParams = Omit<FallbackPriceImpactParams, 'fiatPriceImpact'> & { parsedAmounts: ParsedAmounts }
+type PriceImpactParams = Omit<FallbackPriceImpactParams, 'fiatPriceImpact'> & {
+  parsedAmounts: ParsedAmounts
+}
 
 export interface PriceImpact {
   priceImpact: Percent | undefined
@@ -12,14 +14,14 @@ export interface PriceImpact {
   loading: boolean
 }
 
-export default function usePriceImpact({ abTrade, parsedAmounts }: PriceImpactParams): PriceImpact {
+export default function usePriceImpact({ abTrade, parsedAmounts, isWrapping }: PriceImpactParams): PriceImpact {
   /* const fiatPriceImpact =  */ useFiatValuePriceImpact(parsedAmounts)
   // TODO: remove this - testing only - forces fallback price impact
   const {
     impact: fallbackPriceImpact,
     error,
     loading,
-  } = useFallbackPriceImpact({ abTrade, fiatPriceImpact: undefined })
+  } = useFallbackPriceImpact({ abTrade, fiatPriceImpact: undefined, isWrapping })
 
   const priceImpact = /* fiatPriceImpact ||  */ fallbackPriceImpact
 

--- a/src/custom/hooks/usePriceImpact/useFallbackPriceImpact.ts
+++ b/src/custom/hooks/usePriceImpact/useFallbackPriceImpact.ts
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from 'react'
 import { Percent } from '@uniswap/sdk-core'
 
 import { useSwapState } from 'state/swap/hooks'
-import { Field } from 'state/swap/actions'
 
 import useExactInSwap, { useCalculateQuote } from './useQuoteAndSwap'
 import { FallbackPriceImpactParams } from './commonTypes'
@@ -40,18 +39,15 @@ function _getBaTradeParsedAmount(abTrade: TradeGp | undefined, shouldCalculate: 
   return abTrade.outputAmountWithoutFee
 }
 
-export default function useFallbackPriceImpact({ abTrade, fiatPriceImpact }: FallbackPriceImpactParams) {
+export default function useFallbackPriceImpact({ abTrade, fiatPriceImpact, isWrapping }: FallbackPriceImpactParams) {
   const {
     typedValue,
     INPUT: { currencyId: sellToken },
     OUTPUT: { currencyId: buyToken },
-    independentField,
   } = useSwapState()
 
-  const abTradeIsSell = independentField === Field.INPUT
-
-  // Should we even calc this? Check if fiatPriceImpact exists
-  const shouldCalculate = !Boolean(fiatPriceImpact)
+  // Should we even calc this? Check if fiatPriceImpact exists OR user is wrapping token
+  const shouldCalculate = !Boolean(fiatPriceImpact) || !isWrapping
 
   // Calculate the necessary params to get the inverse trade impact
   const { parsedAmount, outputCurrency, ...swapQuoteParams } = useMemo(
@@ -103,7 +99,7 @@ export default function useFallbackPriceImpact({ abTrade, fiatPriceImpact }: Fal
       setImpact(undefined)
       setError(undefined)
     }
-  }, [abIn, abOut, baOut, quoteError, abTradeIsSell, loading, typedValue])
+  }, [abIn, abOut, baOut, quoteError, loading, typedValue])
 
   return { impact, error, loading }
 }

--- a/src/custom/hooks/usePriceImpact/useQuoteAndSwap.ts
+++ b/src/custom/hooks/usePriceImpact/useQuoteAndSwap.ts
@@ -16,6 +16,7 @@ import { ZERO_ADDRESS } from 'constants/misc'
 import { SupportedChainId } from 'constants/chains'
 import { DEFAULT_DECIMALS } from 'constants/index'
 import { QuoteError } from 'state/price/actions'
+import { isWrappingTrade } from 'state/swap/utils'
 
 type ExactInSwapParams = {
   parsedAmount: CurrencyAmount<Currency> | undefined
@@ -107,10 +108,15 @@ export function useCalculateQuote(params: GetQuoteParams) {
 
 // calculates a new Quote and inverse swap values
 export default function useExactInSwap({ quote, outputCurrency, parsedAmount }: ExactInSwapParams) {
+  const { chainId } = useActiveWeb3React()
+
+  const isWrapping = isWrappingTrade(parsedAmount?.currency, outputCurrency, chainId)
+
   const bestTradeExactIn = useTradeExactInWithFee({
     parsedAmount,
     outputCurrency,
     quote,
+    isWrapping,
   })
 
   return bestTradeExactIn

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -259,7 +259,7 @@ export default function Swap({
     [independentField, parsedAmount, showWrap, trade]
   )
 
-  const priceImpactParams = usePriceImpact({ abTrade: v2Trade, parsedAmounts })
+  const priceImpactParams = usePriceImpact({ abTrade: v2Trade, parsedAmounts, isWrapping: !!onWrap })
   const { priceImpact, error: priceImpactError, loading: priceImpactLoading } = priceImpactParams
 
   const { feeWarningAccepted, setFeeWarningAccepted } = useHighFeeWarning(trade)

--- a/src/custom/state/price/updater.ts
+++ b/src/custom/state/price/updater.ts
@@ -18,8 +18,7 @@ import { useActiveWeb3React } from 'hooks/web3'
 import useDebounce from 'hooks/useDebounce'
 import useIsOnline from 'hooks/useIsOnline'
 import { QuoteInformationObject } from './reducer'
-import { WETH9_EXTENDED } from 'constants/tokens'
-import { SupportedChainId } from 'constants/chains'
+import { isWrappingTrade } from 'state/swap/utils'
 
 const DEBOUNCE_TIME = 350
 const REFETCH_CHECK_INTERVAL = 10000 // Every 10s
@@ -151,11 +150,8 @@ export default function FeesUpdater(): null {
     //  - it is a wrapping operation
     if (!chainId || !sellToken || !buyToken || !typedValue || !windowVisible) return
 
-    const isWrapping =
-      (sellCurrency?.isNative && buyCurrency?.wrapped.equals(WETH9_EXTENDED[chainId || SupportedChainId.MAINNET])) ||
-      (sellCurrency?.wrapped.equals(WETH9_EXTENDED[chainId || SupportedChainId.MAINNET]) && buyCurrency?.isNative)
-
-    if (isWrapping) return
+    // Native wrap trade, return
+    if (isWrappingTrade(sellCurrency, buyCurrency, chainId)) return
 
     // Don't refetch if the amount is missing
     const kind = independentField === Field.INPUT ? OrderKind.SELL : OrderKind.BUY

--- a/src/custom/state/price/updater.ts
+++ b/src/custom/state/price/updater.ts
@@ -18,7 +18,8 @@ import { useActiveWeb3React } from 'hooks/web3'
 import useDebounce from 'hooks/useDebounce'
 import useIsOnline from 'hooks/useIsOnline'
 import { QuoteInformationObject } from './reducer'
-import { WETH9_EXTENDED } from '@src/custom/constants/tokens'
+import { WETH9_EXTENDED } from 'constants/tokens'
+import { SupportedChainId } from 'constants/chains'
 
 const DEBOUNCE_TIME = 350
 const REFETCH_CHECK_INTERVAL = 10000 // Every 10s
@@ -151,8 +152,8 @@ export default function FeesUpdater(): null {
     if (!chainId || !sellToken || !buyToken || !typedValue || !windowVisible) return
 
     const isWrapping =
-      (sellCurrency?.isNative && buyCurrency?.wrapped.equals(WETH9_EXTENDED[chainId])) ||
-      (sellCurrency?.wrapped.equals(WETH9_EXTENDED[chainId]) && buyCurrency?.isNative)
+      (sellCurrency?.isNative && buyCurrency?.wrapped.equals(WETH9_EXTENDED[chainId || SupportedChainId.MAINNET])) ||
+      (sellCurrency?.wrapped.equals(WETH9_EXTENDED[chainId || SupportedChainId.MAINNET]) && buyCurrency?.isNative)
 
     if (isWrapping) return
 

--- a/src/custom/state/price/updater.ts
+++ b/src/custom/state/price/updater.ts
@@ -18,6 +18,7 @@ import { useActiveWeb3React } from 'hooks/web3'
 import useDebounce from 'hooks/useDebounce'
 import useIsOnline from 'hooks/useIsOnline'
 import { QuoteInformationObject } from './reducer'
+import { WETH9_EXTENDED } from '@src/custom/constants/tokens'
 
 const DEBOUNCE_TIME = 350
 const REFETCH_CHECK_INTERVAL = 10000 // Every 10s
@@ -146,7 +147,14 @@ export default function FeesUpdater(): null {
     // Don't refetch if:
     //  - window is not visible
     //  - some parameter is missing
+    //  - it is a wrapping operation
     if (!chainId || !sellToken || !buyToken || !typedValue || !windowVisible) return
+
+    const isWrapping =
+      (sellCurrency?.isNative && buyCurrency?.wrapped.equals(WETH9_EXTENDED[chainId])) ||
+      (sellCurrency?.wrapped.equals(WETH9_EXTENDED[chainId]) && buyCurrency?.isNative)
+
+    if (isWrapping) return
 
     // Don't refetch if the amount is missing
     const kind = independentField === Field.INPUT ? OrderKind.SELL : OrderKind.BUY

--- a/src/custom/state/swap/extension.ts
+++ b/src/custom/state/swap/extension.ts
@@ -9,6 +9,7 @@ interface TradeParams {
   inputCurrency?: Currency | null
   outputCurrency?: Currency | null
   quote?: QuoteInformationObject
+  isWrapping: boolean
 }
 
 export const stringToCurrency = (amount: string, currency: Currency) =>
@@ -22,10 +23,11 @@ export function useTradeExactInWithFee({
   parsedAmount: parsedInputAmount,
   outputCurrency,
   quote,
+  isWrapping,
 }: Omit<TradeParams, 'inputCurrency'>) {
   // make sure we have a typed in amount, a fee, and a price
   // else we can assume the trade will be null
-  if (!parsedInputAmount || !outputCurrency || !quote?.fee || !quote?.price?.amount) return null
+  if (!parsedInputAmount || !outputCurrency || isWrapping || !quote?.fee || !quote?.price?.amount) return null
 
   const feeAsCurrency = stringToCurrency(quote.fee.amount, parsedInputAmount.currency)
   // Check that fee amount is not greater than the user's input amt
@@ -80,8 +82,9 @@ export function useTradeExactOutWithFee({
   parsedAmount: parsedOutputAmount,
   inputCurrency,
   quote,
+  isWrapping,
 }: Omit<TradeParams, 'outputCurrency'>) {
-  if (!parsedOutputAmount || !inputCurrency || !quote?.fee || !quote?.price?.amount) return null
+  if (!parsedOutputAmount || !inputCurrency || isWrapping || !quote?.fee || !quote?.price?.amount) return null
 
   const feeAsCurrency = stringToCurrency(quote.fee.amount, inputCurrency)
   // set final fee object

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -40,6 +40,7 @@ import { WETH9_EXTENDED as WETH, GpEther as ETHER } from 'constants/tokens'
 import { BAD_RECIPIENT_ADDRESSES } from 'state/swap/hooks'
 import { useIsExpertMode, useUserSlippageToleranceWithDefault } from '@src/state/user/hooks'
 import { PriceImpact } from 'hooks/usePriceImpact'
+import { isWrappingTrade } from './utils'
 
 export * from '@src/state/swap/hooks'
 
@@ -295,15 +296,19 @@ export function useDerivedSwapInfo(): /* {
     console.debug('[useDerivedSwapInfo] Fee quote: ', quote?.fee?.amount)
   }, [quote])
 
+  const isWrapping = isWrappingTrade(inputCurrency, outputCurrency, chainId)
+
   const bestTradeExactIn = useTradeExactInWithFee({
     parsedAmount: isExactIn ? parsedAmount : undefined,
     outputCurrency,
     quote,
+    isWrapping,
   })
   const bestTradeExactOut = useTradeExactOutWithFee({
     parsedAmount: isExactIn ? undefined : parsedAmount,
     inputCurrency,
     quote,
+    isWrapping,
   })
 
   // TODO: rename v2Trade to just "trade" we dont have versions

--- a/src/custom/state/swap/utils.ts
+++ b/src/custom/state/swap/utils.ts
@@ -1,5 +1,18 @@
-import { Percent, TradeType } from '@uniswap/sdk-core'
+import { SupportedChainId } from 'constants/chains'
+import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
 import TradeGp from './TradeGp'
+import { WETH9_EXTENDED } from 'constants/tokens'
+
+export function isWrappingTrade(
+  sellCurrency: Currency | null | undefined,
+  buyCurrency: Currency | null | undefined,
+  chainId?: SupportedChainId
+): boolean {
+  return Boolean(
+    (sellCurrency?.isNative && buyCurrency?.wrapped.equals(WETH9_EXTENDED[chainId || SupportedChainId.MAINNET])) ||
+      (sellCurrency?.wrapped.equals(WETH9_EXTENDED[chainId || SupportedChainId.MAINNET]) && buyCurrency?.isNative)
+  )
+}
 
 export function logTradeDetails(trade: TradeGp | undefined, allowedSlippage: Percent) {
   // don't do anything outside of dev env


### PR DESCRIPTION
# Summary

Closes tech debt: dont call fee/price on wrapping op

Closes #1853 and closes #1927 

Dont call fee/price on wrapping operation, any chain

![image](https://user-images.githubusercontent.com/21335563/143449691-0a944b2a-6e96-49c0-9e4e-afc434323472.png)

  # To Test

1. any chain
2. select native token IN/OUT
3. inverse = wrapped native
4. enter amount
5. check networks tab that no requests are made 
6. can still wrap etc