### PR TITLE
Version images to prevent hard caches

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,23 +12,23 @@
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
   <meta name="theme-color" media="(prefers-color-scheme: light)" content="white">
   <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#163861">
-  <link rel="shortcut icon" type="image/png" href="%PUBLIC_URL%/favicon.png" />
-  <link rel="apple-touch-icon" sizes="192x192" href="%PUBLIC_URL%/favicon.png" />
-  <link rel="apple-touch-icon" sizes="512x512" href="%PUBLIC_URL%/favicon.png" />
+  <link rel="shortcut icon" type="image/png" href="%PUBLIC_URL%/favicon.png?v=1" />
+  <link rel="apple-touch-icon" sizes="192x192" href="%PUBLIC_URL%/favicon.png?v=1" />
+  <link rel="apple-touch-icon" sizes="512x512" href="%PUBLIC_URL%/favicon.png?v=1" />
 
   <!-- Social media tags -->
   <meta property="og:type" content="website" />
   <meta property="og:title" content="CowSwap | Meta DEX aggregator">
   <meta property="og:description"
     content="Ethereums MetaDEX Aggregator built by Gnosis. It allows users to trade tokens with MEV protection while using ETH-less orders that are settled p2p among users or into the best on-chain liquidity pool.">
-  <meta property="og:image" content="https://cowswap.exchange/images/og-meta-cowswap.png">
+  <meta property="og:image" content="https://cowswap.exchange/images/og-meta-cowswap.png?v=1">
   <meta property="og:url" content="https://cowswap.exchange">
 
   <!-- Twitter media tags -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@MEVprotection">
   <meta name="twitter:title" content="CowSwap | Meta DEX aggregator">
-  <meta name="twitter:image" content="https://cowswap.exchange/images/og-meta-cowswap.png">
+  <meta name="twitter:image" content="https://cowswap.exchange/images/og-meta-cowswap.png?v=1">
 
   <!-- Other tags -->
   <meta name="fortmatic-site-verification" content="%REACT_APP_FORTMATIC_SITE_VERIFICATION%" />
@@ -53,7 +53,7 @@
       }
     </style>
     <main>
-      <img src="https://cowswap.exchange/images/og-meta-cowswap.png" alt="CowSwap Logo" />
+      <img src="https://cowswap.exchange/images/og-meta-cowswap.png?v=1" alt="CowSwap Logo" />
       <p class="banner">CowSwap uses JavasScript. Please <a href="https://support.google.com/adsense/answer/12654?hl=en"
           target="_blank" rel="noopener noreferrer">enable it in your browser</a> 🐮</p>
 


### PR DESCRIPTION
# Summary

Version images to prevent serve caching

Context: https://gnosisinc.slack.com/archives/C025G521XQD/p1637854928013400

# To Test
Make sure the images are still loading, but now there's a version in the URL of the images.


