### PR TITLE
Turning on thousand separator for FIAT values

### DIFF
--- a/src/custom/components/CurrencyInputPanel/FiatValue/FiatValueMod.tsx
+++ b/src/custom/components/CurrencyInputPanel/FiatValue/FiatValueMod.tsx
@@ -34,7 +34,11 @@ export function FiatValue({
         <Trans>
           ≈ $
           <HoverInlineText
-            text={formatSmart(fiatValue, FIAT_PRECISION) /* fiatValue?.toSignificant(6, { groupSeparator: ',' }) */}
+            text={
+              formatSmart(fiatValue, FIAT_PRECISION, {
+                thousandSeparator: true,
+              }) /* fiatValue?.toSignificant(6, { groupSeparator: ',' }) */
+            }
           />
         </Trans>
       ) : (

--- a/src/custom/components/CurrencyInputPanel/FiatValue/FiatValueMod.tsx
+++ b/src/custom/components/CurrencyInputPanel/FiatValue/FiatValueMod.tsx
@@ -37,6 +37,7 @@ export function FiatValue({
             text={
               formatSmart(fiatValue, FIAT_PRECISION, {
                 thousandSeparator: true,
+                isLocaleAware: true,
               }) /* fiatValue?.toSignificant(6, { groupSeparator: ',' }) */
             }
           />


### PR DESCRIPTION
# Summary

Closes #1876 

It's also locale aware.
Meaning, if your locale uses `,` as decimals separator and `.` as thousand separator you'll see `13.232.432,11` and so on

*Left: after; Right: before*
![Screenshot from 2021-11-26 12-29-31](https://user-images.githubusercontent.com/43217/143627607-92eb79f9-48e4-42ad-a603-e182ac6ea192.png)

  # To Test

1. On mainnet, pick a pair and insert a high enough amount
2. The usd estimation will be split every 1k by a `,`

  # Background

*Optional: Give background information for changes you've made, that might be difficult to explain via comments*

