### PR TITLE
Enable 1inch

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -38,7 +38,7 @@ export const SUPPORTED_WALLETS = Object.keys(SUPPORTED_WALLETS_UNISWAP).reduce((
 }, {} as { [key: string]: WalletInfo })
 
 // Smart contract wallets are filtered out by default, no need to add them to this list
-export const UNSUPPORTED_WC_WALLETS = new Set(['DeFi Wallet', '1inch Wallet', 'WallETH'])
+export const UNSUPPORTED_WC_WALLETS = new Set(['DeFi Wallet', 'WallETH'])
 
 export const GP_SETTLEMENT_CONTRACT_ADDRESS: Partial<Record<number, string>> = {
   [ChainId.MAINNET]: GPv2Settlement[ChainId.MAINNET].address,


### PR DESCRIPTION
# Summary

Re-enable 1inch over Wallet Connect

1inch fixed their signing issues, and now should be working. Their UI is still improbable, it lead us to believe the WC window could not be closed, so it was not possible to complete a workflow.

See comment:
https://github.com/gnosis/cowswap/issues/700#issuecomment-980791760

# To Test

1. Try to connect using 1inch ios