### PR TITLE
[Hotfix - 1.5.2 fire ] - 1930/balances not loading

### DIFF
--- a/src/custom/components/WalletModal/WalletModalMod.tsx
+++ b/src/custom/components/WalletModal/WalletModalMod.tsx
@@ -15,6 +15,7 @@ import { SUPPORTED_WALLETS } from 'constants/index'
 import usePrevious from 'hooks/usePrevious'
 import { ApplicationModal } from 'state/application/actions'
 import { useModalOpen, useWalletModalToggle } from 'state/application/hooks'
+import { SupportedChainId } from 'constants/chains'
 import {
   // ExternalLink,
   TYPE,
@@ -222,10 +223,11 @@ export default function WalletModal({
         })
         .then(() => {
           // manually set the WalletConnectConnector http.connection.url to currently connected network url
+          // fix for the https://github.com/gnosis/cowswap/issues/1930 issue
           if (connector instanceof WalletConnectConnector) {
             const { http, rpc, signer } = connector.walletConnectProvider
-            const chainId = (signer.connection as SignerConnection).chainId
-            http.connection.url = rpc.custom[chainId || 1]
+            const chainId = (signer.connection as SignerConnection).chainId || SupportedChainId.MAINNET
+            http.connection.url = rpc.custom[chainId]
           }
         })
   }


### PR DESCRIPTION
# Summary

Fixes #1930

This fix will manually set http.connection.url on the walletConnectProvider after the wallet is connected with based on the chainId that found on the signer and this will provide the correct infura link from which the balances should be loaded
  
# To Test

Try connecting with WalletConnect to one of the supported networks and see if the balances are loaded correctly
