### PR TITLE
[ABA] Final logic check - use SELL > SELL and BUY > SELL

### DIFF
--- a/src/custom/components/SwapWarnings/index.tsx
+++ b/src/custom/components/SwapWarnings/index.tsx
@@ -108,15 +108,11 @@ const HighFeeWarningMessage = ({ feePercentage }: { feePercentage?: Fraction }) 
 const NoImpactWarningMessage = (
   <div>
     <small>
-      We are unfortunately unable to calculate any price impact for this order.
+      We are unable to calculate the price impact for this order.
       <br />
       <br />
-      <u>
-        <strong>We strongly advise you to do your due diligence before advancing.</strong>
-      </u>
-      <br />
-      <br />
-      You may still move forward with this order but make sure the receive amounts are what you expect.
+      You may still move forward but{' '}
+      <strong>please review carefully that the receive amounts are what you expect.</strong>
     </small>
   </div>
 )

--- a/src/custom/components/swap/ConfirmSwapModal/ConfirmSwapModalMod.tsx
+++ b/src/custom/components/swap/ConfirmSwapModal/ConfirmSwapModalMod.tsx
@@ -45,6 +45,7 @@ export default function ConfirmSwapModal({
   onConfirm,
   onDismiss,
   recipient,
+  priceImpact,
   swapErrorMessage,
   isOpen,
   attemptingTxn,
@@ -59,6 +60,7 @@ export default function ConfirmSwapModal({
   attemptingTxn: boolean
   txHash: string | undefined
   recipient: string | null
+  priceImpact?: Percent
   allowedSlippage: Percent
   onAcceptChanges: () => void
   onConfirm: () => void
@@ -89,12 +91,13 @@ export default function ConfirmSwapModal({
         trade={trade}
         allowsOffchainSigning={allowsOffchainSigning}
         allowedSlippage={allowedSlippage}
+        priceImpact={priceImpact}
         recipient={recipient}
         showAcceptChanges={showAcceptChanges}
         onAcceptChanges={onAcceptChanges}
       />
     ) : null
-  }, [allowedSlippage, onAcceptChanges, recipient, showAcceptChanges, trade, allowsOffchainSigning])
+  }, [trade, allowsOffchainSigning, allowedSlippage, priceImpact, recipient, showAcceptChanges, onAcceptChanges])
 
   const modalBottom = useCallback(() => {
     return trade ? (

--- a/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
+++ b/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
@@ -9,7 +9,7 @@ import { useHigherUSDValue /* , useUSDCValue */ } from 'hooks/useUSDCPrice'
 import { TYPE } from 'theme'
 import { ButtonPrimary } from 'components/Button'
 import { isAddress, shortenAddress } from 'utils'
-import { computeFiatValuePriceImpact } from 'utils/computeFiatValuePriceImpact'
+// import { computeFiatValuePriceImpact } from 'utils/computeFiatValuePriceImpact'
 import { AutoColumn } from 'components/Column'
 import { FiatValue } from 'components/CurrencyInputPanel/FiatValue'
 import CurrencyLogo from 'components/CurrencyLogo'
@@ -60,6 +60,7 @@ export interface SwapModalHeaderProps {
   recipient: string | null
   showAcceptChanges: boolean
   priceImpactWithoutFee?: Percent
+  priceImpact?: Percent
   onAcceptChanges: () => void
   LightCard: LightCardType
   HighFeeWarning: React.FC<WarningProps>
@@ -72,6 +73,7 @@ export default function SwapModalHeader({
   allowedSlippage,
   recipient,
   showAcceptChanges,
+  priceImpact,
   onAcceptChanges,
   LightCard,
   HighFeeWarning,
@@ -176,10 +178,7 @@ SwapModalHeaderProps) {
               <Trans>To</Trans>
             </TYPE.body>
             <TYPE.body fontSize={14} color={theme.text3}>
-              <FiatValue
-                fiatValue={fiatValueOutput}
-                priceImpact={computeFiatValuePriceImpact(fiatValueInput, fiatValueOutput)}
-              />
+              <FiatValue fiatValue={fiatValueOutput} priceImpact={priceImpact} />
             </TYPE.body>
           </RowBetween>
           <RowBetween align="flex-end">
@@ -293,7 +292,7 @@ SwapModalHeaderProps) {
       {/* High Fee Warning */}
       <HighFeeWarning trade={trade} />
       {/* No Impact Warning */}
-      <NoImpactWarning margin="0" />
+      {!priceImpact && <NoImpactWarning margin="0" />}
     </AutoColumn>
   )
 }

--- a/src/custom/hooks/usePriceImpact/useFallbackPriceImpact.ts
+++ b/src/custom/hooks/usePriceImpact/useFallbackPriceImpact.ts
@@ -3,55 +3,41 @@ import { Percent } from '@uniswap/sdk-core'
 
 import { useSwapState } from 'state/swap/hooks'
 import { Field } from 'state/swap/actions'
-import { useGetQuoteAndStatus } from 'state/price/hooks'
 
 import useExactInSwap, { useCalculateQuote } from './useQuoteAndSwap'
 import { FallbackPriceImpactParams } from './commonTypes'
 import { calculateFallbackPriceImpact, FeeQuoteParams } from 'utils/price'
 import TradeGp from 'state/swap/TradeGp'
-import { useActiveWeb3React } from 'hooks/web3'
 import { QuoteInformationObject } from 'state/price/reducer'
 import { QuoteError } from 'state/price/actions'
 
-type SwapParams = { trade?: TradeGp; sellToken?: string | null; buyToken?: string | null }
+type SwapParams = { abTrade?: TradeGp; sellToken?: string | null; buyToken?: string | null }
 
 function _isQuoteValid(quote: QuoteInformationObject | FeeQuoteParams | undefined): quote is QuoteInformationObject {
   return Boolean(quote && 'lastCheck' in quote)
 }
 
-function _calculateSwapParams(isExactIn: boolean, { trade, sellToken, buyToken }: SwapParams) {
-  if (!trade) return undefined
+function _getBaTradeParams({ abTrade, sellToken, buyToken }: SwapParams) {
+  if (!abTrade) return undefined
 
-  if (isExactIn) {
-    return {
-      outputCurrency: trade.inputAmount.currency,
-      // Run inverse (B > A) sell trade
-      sellToken: buyToken,
-      buyToken: sellToken,
-      fromDecimals: trade.outputAmount.currency.decimals,
-      toDecimals: trade.inputAmount.currency.decimals,
-    }
-  } else {
-    // First trade was a buy order
-    // we need to use the same order but make a sell order
-    return {
-      outputCurrency: trade.outputAmount.currency,
-      // on buy orders we dont inverse it
-      sellToken,
-      buyToken,
-      fromDecimals: trade.inputAmount.currency.decimals,
-      toDecimals: trade.outputAmount.currency.decimals,
-    }
+  const { inputAmount, outputAmount } = abTrade
+
+  return {
+    // We need to inverse the AB Trade parameters
+    // Sell the AB Trade output amount for input tokens
+    outputCurrency: inputAmount.currency,
+    sellToken: buyToken,
+    buyToken: sellToken,
+    fromDecimals: outputAmount.currency.decimals,
+    toDecimals: inputAmount.currency.decimals,
   }
 }
 
-function _calculateParsedAmount(trade: TradeGp | undefined, isExactIn: boolean, shouldCalculate: boolean) {
-  if (!shouldCalculate || !trade) return undefined
-  // First trade was a sell order, we need to make a new sell order using the
-  // first trade's output amount
-  const amount = isExactIn ? trade.outputAmount : trade.inputAmount
+function _getBaTradeParsedAmount(abTrade: TradeGp | undefined, shouldCalculate: boolean) {
+  if (!shouldCalculate || !abTrade) return undefined
 
-  return amount
+  // return the AB Trade's output amount WITHOUT fee
+  return abTrade.outputAmountWithoutFee
 }
 
 export default function useFallbackPriceImpact({ abTrade, fiatPriceImpact }: FallbackPriceImpactParams) {
@@ -61,8 +47,8 @@ export default function useFallbackPriceImpact({ abTrade, fiatPriceImpact }: Fal
     OUTPUT: { currencyId: buyToken },
     independentField,
   } = useSwapState()
-  const isExactIn = independentField === Field.INPUT
-  const { chainId } = useActiveWeb3React()
+
+  const abTradeIsSell = independentField === Field.INPUT
 
   // Should we even calc this? Check if fiatPriceImpact exists
   const shouldCalculate = !Boolean(fiatPriceImpact)
@@ -70,23 +56,22 @@ export default function useFallbackPriceImpact({ abTrade, fiatPriceImpact }: Fal
   // Calculate the necessary params to get the inverse trade impact
   const { parsedAmount, outputCurrency, ...swapQuoteParams } = useMemo(
     () => ({
-      parsedAmount: _calculateParsedAmount(abTrade, isExactIn, shouldCalculate),
-      ..._calculateSwapParams(isExactIn, { trade: abTrade, sellToken, buyToken }),
+      parsedAmount: _getBaTradeParsedAmount(abTrade, shouldCalculate),
+      ..._getBaTradeParams({ abTrade, sellToken, buyToken }),
     }),
-    [abTrade, buyToken, sellToken, shouldCalculate, isExactIn]
+    [abTrade, buyToken, sellToken, shouldCalculate]
   )
 
-  const { quote, loading: loading } = useCalculateQuote({
+  const { quote, loading } = useCalculateQuote({
     amountAtoms: parsedAmount?.quotient.toString(),
     ...swapQuoteParams,
   })
 
-  // we calculate the trade going B > A
+  // Calculate BA trade
   // using the output values from the original A > B trade
   const baTrade = useExactInSwap({
-    // if impact, give undefined and dont compute swap
+    // if fiat impact exists, return undefined and dont compute swap
     // the amount traded now is the A > B output amount without fees
-    // TODO: is this the amount with or without fees?
     quote: _isQuoteValid(quote) ? quote : undefined,
     parsedAmount,
     outputCurrency,
@@ -95,13 +80,10 @@ export default function useFallbackPriceImpact({ abTrade, fiatPriceImpact }: Fal
   const [impact, setImpact] = useState<Percent | undefined>()
   const [error, setError] = useState<QuoteError | undefined>()
 
-  // we set price impact to undefined when loading a NEW quote only
-  const { isGettingNewQuote } = useGetQuoteAndStatus({ token: sellToken, chainId })
-
   // primitive values to use as dependencies
-  const abIn = abTrade?.inputAmount.quotient.toString()
-  const abOut = abTrade?.outputAmount.quotient.toString()
-  const baOut = baTrade?.outputAmount.quotient.toString()
+  const abIn = abTrade?.inputAmountWithoutFee.quotient.toString()
+  const abOut = abTrade?.outputAmountWithoutFee?.quotient.toString()
+  const baOut = baTrade?.outputAmountWithoutFee?.quotient.toString()
   const quoteError = quote?.error
 
   useEffect(() => {
@@ -110,7 +92,10 @@ export default function useFallbackPriceImpact({ abTrade, fiatPriceImpact }: Fal
       setImpact(undefined)
       setError(quoteError)
     } else if (!loading && abIn && abOut && baOut) {
-      const impact = calculateFallbackPriceImpact(isExactIn ? abIn : abOut, baOut)
+      // AB Trade is a SELL - we pass the inputAMount as the initial value
+      // else we pass the outputAmount as the initialValue
+      // Final value is the output of the BA trade as we always SELL in BA
+      const impact = calculateFallbackPriceImpact(abIn, baOut)
       setImpact(impact)
       setError(undefined)
     } else {
@@ -118,17 +103,7 @@ export default function useFallbackPriceImpact({ abTrade, fiatPriceImpact }: Fal
       setImpact(undefined)
       setError(undefined)
     }
-  }, [abIn, abOut, baOut, quoteError, isExactIn, loading])
-
-  // on changes to typedValue, we hide impact
-  // quote loading so we hide impact
-  // prevents lingering calculations and jumping impacts
-  useEffect(() => {
-    if (typedValue || isGettingNewQuote) {
-      setImpact(undefined)
-      setError(undefined)
-    }
-  }, [isGettingNewQuote, typedValue])
+  }, [abIn, abOut, baOut, quoteError, abTradeIsSell, loading, typedValue])
 
   return { impact, error, loading }
 }

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -545,6 +545,7 @@ export default function Swap({
             txHash={txHash}
             recipient={recipient}
             allowedSlippage={allowedSlippage}
+            priceImpact={priceImpact}
             onConfirm={handleSwap}
             swapErrorMessage={swapErrorMessage}
             onDismiss={handleConfirmDismiss}


### PR DESCRIPTION
# Summary

Part of #aba

Uses the formula/function as outlined by @anxolin in #1953

Notes:
1. UI was inverting impact as a representation as to what impact means to the user, this requires us to invert the maths inside the utils/price function for calcing price impact
2. fallback price impact function is: `(finalValue - initialValue) / initialValue / 2`

  # To Test

1. select a token pair
2. copy output amount
3. invert pair
4. paste output amount from 2 into input field
5. check amounts
6. price impact should show negative for LESS tokens and vice versa


