### PR TITLE
[ABA - fixes] - Fix warning showing when not needed, and show correct impact in modal

### DIFF
--- a/src/custom/components/SwapWarnings/index.tsx
+++ b/src/custom/components/SwapWarnings/index.tsx
@@ -108,15 +108,11 @@ const HighFeeWarningMessage = ({ feePercentage }: { feePercentage?: Fraction }) 
 const NoImpactWarningMessage = (
   <div>
     <small>
-      We are unfortunately unable to calculate any price impact for this order.
+      We are unable to calculate the price impact for this order.
       <br />
       <br />
-      <u>
-        <strong>We strongly advise you to do your due diligence before advancing.</strong>
-      </u>
-      <br />
-      <br />
-      You may still move forward with this order but make sure the receive amounts are what you expect.
+      You may still move forward but{' '}
+      <strong>please review carefully that the receive amounts are what you expect.</strong>
     </small>
   </div>
 )

--- a/src/custom/components/swap/ConfirmSwapModal/ConfirmSwapModalMod.tsx
+++ b/src/custom/components/swap/ConfirmSwapModal/ConfirmSwapModalMod.tsx
@@ -45,6 +45,7 @@ export default function ConfirmSwapModal({
   onConfirm,
   onDismiss,
   recipient,
+  priceImpact,
   swapErrorMessage,
   isOpen,
   attemptingTxn,
@@ -59,6 +60,7 @@ export default function ConfirmSwapModal({
   attemptingTxn: boolean
   txHash: string | undefined
   recipient: string | null
+  priceImpact?: Percent
   allowedSlippage: Percent
   onAcceptChanges: () => void
   onConfirm: () => void
@@ -89,12 +91,13 @@ export default function ConfirmSwapModal({
         trade={trade}
         allowsOffchainSigning={allowsOffchainSigning}
         allowedSlippage={allowedSlippage}
+        priceImpact={priceImpact}
         recipient={recipient}
         showAcceptChanges={showAcceptChanges}
         onAcceptChanges={onAcceptChanges}
       />
     ) : null
-  }, [allowedSlippage, onAcceptChanges, recipient, showAcceptChanges, trade, allowsOffchainSigning])
+  }, [trade, allowsOffchainSigning, allowedSlippage, priceImpact, recipient, showAcceptChanges, onAcceptChanges])
 
   const modalBottom = useCallback(() => {
     return trade ? (

--- a/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
+++ b/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
@@ -9,7 +9,7 @@ import { useHigherUSDValue /* , useUSDCValue */ } from 'hooks/useUSDCPrice'
 import { TYPE } from 'theme'
 import { ButtonPrimary } from 'components/Button'
 import { isAddress, shortenAddress } from 'utils'
-import { computeFiatValuePriceImpact } from 'utils/computeFiatValuePriceImpact'
+// import { computeFiatValuePriceImpact } from 'utils/computeFiatValuePriceImpact'
 import { AutoColumn } from 'components/Column'
 import { FiatValue } from 'components/CurrencyInputPanel/FiatValue'
 import CurrencyLogo from 'components/CurrencyLogo'
@@ -60,6 +60,7 @@ export interface SwapModalHeaderProps {
   recipient: string | null
   showAcceptChanges: boolean
   priceImpactWithoutFee?: Percent
+  priceImpact?: Percent
   onAcceptChanges: () => void
   LightCard: LightCardType
   HighFeeWarning: React.FC<WarningProps>
@@ -72,6 +73,7 @@ export default function SwapModalHeader({
   allowedSlippage,
   recipient,
   showAcceptChanges,
+  priceImpact,
   onAcceptChanges,
   LightCard,
   HighFeeWarning,
@@ -176,10 +178,7 @@ SwapModalHeaderProps) {
               <Trans>To</Trans>
             </TYPE.body>
             <TYPE.body fontSize={14} color={theme.text3}>
-              <FiatValue
-                fiatValue={fiatValueOutput}
-                priceImpact={computeFiatValuePriceImpact(fiatValueInput, fiatValueOutput)}
-              />
+              <FiatValue fiatValue={fiatValueOutput} priceImpact={priceImpact} />
             </TYPE.body>
           </RowBetween>
           <RowBetween align="flex-end">
@@ -293,7 +292,7 @@ SwapModalHeaderProps) {
       {/* High Fee Warning */}
       <HighFeeWarning trade={trade} />
       {/* No Impact Warning */}
-      <NoImpactWarning margin="0" />
+      {!priceImpact && <NoImpactWarning margin="0" />}
     </AutoColumn>
   )
 }

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -545,6 +545,7 @@ export default function Swap({
             txHash={txHash}
             recipient={recipient}
             allowedSlippage={allowedSlippage}
+            priceImpact={priceImpact}
             onConfirm={handleSwap}
             swapErrorMessage={swapErrorMessage}
             onDismiss={handleConfirmDismiss}


### PR DESCRIPTION
# Summary

- Fixes https://github.com/gnosis/cowswap/pull/1953#issuecomment-984459188 addressed by @elena-zh 
- Fixes price impact showing fiat in modal
- softer message as outlined by @anxolin here: https://github.com/gnosis/cowswap/pull/1953#issuecomment-984826260

  # To Test

1. picka token pair and make a valid trade
2. make sure there is price impact
3. check confirmation modal
4. should be all good