### PR TITLE
Bump dex-js to 0.13.0 to fix issue with trailing dot

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
   "license": "GPL-3.0-or-later",
   "dependencies": {
     "@gnosis.pm/cow-runner-game": "^0.2.9",
-    "@gnosis.pm/dex-js": "^0.12.0",
+    "@gnosis.pm/dex-js": "^0.13.0",
     "@gnosis.pm/gp-v2-contracts": "^1.0.2",
     "@gnosis.pm/safe-service-client": "^0.1.1",
     "@pinata/sdk": "^1.1.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2041,10 +2041,10 @@
   dependencies:
     bn.js "^5.1.3"
 
-"@gnosis.pm/dex-js@^0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.12.0.tgz#f46fc2d131aaeec34afecd8d903f31db5673d2cc"
-  integrity sha512-1TaXtxa3e/V3O0t1ChVPvRWqxotl0yY6sbEKJXBu4WHlmxr9Iy5LIz84riyWYPrSWG+iTvjRdtFBkmTfDg7+QA==
+"@gnosis.pm/dex-js@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.13.0.tgz#e56cd9c0204577237424bed4fe1f8644c9bb301f"
+  integrity sha512-mprEDn70AEPVa9YRmMTm++F/jR0sfdPK+HPzjzefPr2WoxEiP3JfqRWfCgyw7T1zWBGaayzXlfAe++EbSJFVQg==
   dependencies:
     "@gnosis.pm/dex-contracts" "^0.5.0"
     bignumber.js "^9.0.0"


### PR DESCRIPTION
# Summary

Fixes #1316 

The actual fix was on dex-js https://github.com/gnosis/dex-js/pull/300

This change is simply bumping the lib version on CowSwap

  # To Test

1. Pick a pair and fill in an absurd high amount
2. Wait until the receive amount is something that ends in  `.0` - well, you actually won't see that because you should see instead no trailing dots nor zeros