### PR TITLE
[CLEANUP] useUSDCPrice speedup + logs clean

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,9 @@
+queue_rules:
+  - name: default
+    conditions:
+      - check-success=Deploy
+      - check-success=Cypress
+
 pull_request_rules:
   - name: Merge approved and green PRs when tagged with 'Auto-merge'
     conditions:
@@ -6,10 +12,11 @@ pull_request_rules:
       - check-success=Deploy
       - check-success=Cypress
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart+fasttrack
+        name: default
         commit_message: title+body
+  # DEPENDABOT PRs
   - name: automatic merge for Dependabot pull requests
     conditions:
       - author~=^dependabot(|-preview)\[bot\]$
@@ -18,7 +25,7 @@ pull_request_rules:
       - check-success=Deploy
       - base=develop
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart+fasttrack
+        name: default
         commit_message: title+body

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "CowSwap - Gnosis Protocol",
   "homepage": ".",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.7.0-rc.0",
   "engines": {
     "node": ">=14.0.0"
   },

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -76,7 +76,7 @@ import { computeSlippageAdjustedAmounts } from 'utils/prices'
 import FeeInformationTooltip from 'components/swap/FeeInformationTooltip'
 import { useWalletInfo } from 'hooks/useWalletInfo'
 import { HashLink } from 'react-router-hash-link'
-import { logTradeDetails } from 'state/swap/utils'
+// import { logTradeDetails } from 'state/swap/utils'
 import { useGetQuoteAndStatus } from 'state/price/hooks'
 import { SwapProps, ButtonError, ButtonPrimary } from '.' // mod
 import TradeGp from 'state/swap/TradeGp'
@@ -189,7 +189,7 @@ export default function Swap({
   const { quote, isGettingNewQuote } = useGetQuoteAndStatus({ token: INPUT.currencyId, chainId })
 
   // Log all trade information
-  logTradeDetails(v2Trade, allowedSlippage)
+  // logTradeDetails(v2Trade, allowedSlippage)
 
   // Checks if either currency is native ETH
   // MOD: adds this hook


### PR DESCRIPTION
# Summary

Cleans up the `useUsdcPrice` hook and `SwapMod` use of `logTradeDetails` to do 2 things:
1. clean up the logs (waaaay too much noise)
2. less re-rendering/re-running of logic in `useUsdcPrice` hook due to dependencies and nested objects

Cleaner