### PR TITLE
[Release 1.8] Use new quote endpoint for USD estimations

### DIFF
--- a/src/custom/hooks/useDebounceWithForceUpdate.ts
+++ b/src/custom/hooks/useDebounceWithForceUpdate.ts
@@ -2,13 +2,14 @@ import useDebounce from '@src/hooks/useDebounce'
 import { useEffect, useState } from 'react'
 
 // modified from https://usehooks.com/useDebounce/
-export default function useDebounceWithForceUpdate<T>(latestValue: T, delay: number, forceUpdateRef?: any): T {
+export default function useDebounceWithForceUpdate<T>(latestValue: T, delay: number, forceUpdateRef: any[]): T {
   // const value = useRef(latestValue)
   const [value, setValue] = useState(latestValue)
   const [needToUpdate, setNeedToUpdate] = useState(false)
 
   // Force update
-  useEffect(() => setNeedToUpdate(true), [forceUpdateRef])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => setNeedToUpdate(true), [...forceUpdateRef])
   useEffect(() => {
     if (needToUpdate) {
       setNeedToUpdate(false)

--- a/src/custom/hooks/usePriceImpact/useQuoteAndSwap.ts
+++ b/src/custom/hooks/usePriceImpact/useQuoteAndSwap.ts
@@ -10,15 +10,15 @@ import { useActiveWeb3React } from 'hooks/web3'
 
 import { getPromiseFulfilledValue, isPromiseFulfilled } from 'utils/misc'
 import { supportedChainId } from 'utils/supportedChainId'
-import { FeeQuoteParams, QuoteResult } from 'utils/price'
+import { FeeQuoteParams, getBestQuote, QuoteResult } from 'utils/price'
 
 import { ZERO_ADDRESS } from 'constants/misc'
 import { SupportedChainId } from 'constants/chains'
 import { DEFAULT_DECIMALS } from 'constants/index'
 import { QuoteError } from 'state/price/actions'
 import { isWrappingTrade } from 'state/swap/utils'
-import useGetGpPriceStrategy from '../useGetGpPriceStrategy'
-import { getBestQuoteResolveOnlyLastCall as getBestQuote } from 'hooks/useRefetchPriceCallback'
+import useGetGpPriceStrategy from 'hooks/useGetGpPriceStrategy'
+import { onlyResolvesLast } from 'utils/async'
 
 type WithLoading = { loading: boolean; setLoading: (state: boolean) => void }
 
@@ -38,6 +38,8 @@ type GetQuoteParams = {
 } & WithLoading
 
 type FeeQuoteParamsWithError = FeeQuoteParams & { error?: QuoteError }
+
+const getBestQuoteResolveOnlyLastCall = onlyResolvesLast<QuoteResult>(getBestQuote)
 
 export function useCalculateQuote(params: GetQuoteParams) {
   const {
@@ -77,7 +79,7 @@ export function useCalculateQuote(params: GetQuoteParams) {
       validTo,
     }
     let quoteData: QuoteInformationObject | FeeQuoteParams = quoteParams
-    getBestQuote({
+    getBestQuoteResolveOnlyLastCall({
       strategy,
       quoteParams,
       fetchFee: true,

--- a/src/custom/hooks/useRefetchPriceCallback.tsx
+++ b/src/custom/hooks/useRefetchPriceCallback.tsx
@@ -108,7 +108,7 @@ export function handleQuoteError({ quoteData, error, addUnsupportedToken }: Hand
   }
 }
 
-export const getBestQuoteResolveOnlyLastCall = onlyResolvesLast<QuoteResult>(getBestQuote)
+const getBestQuoteResolveOnlyLastCall = onlyResolvesLast<QuoteResult>(getBestQuote)
 
 /**
  * @returns callback that fetches a new quote and update the state
@@ -150,6 +150,10 @@ export function useRefetchQuoteCallback() {
           // Get new quote
           getNewQuote(quoteParams)
         }
+
+        registerOnWindow({
+          getBestQuote: async () => getBestQuoteResolveOnlyLastCall({ ...params, strategy: priceStrategy }),
+        })
 
         // Get the quote
         // price can be null if fee > price

--- a/src/custom/hooks/useSwapCallback.ts
+++ b/src/custom/hooks/useSwapCallback.ts
@@ -23,7 +23,7 @@ import { usePresignOrder, PresignOrder } from 'hooks/usePresignOrder'
 import { Web3Provider } from '@ethersproject/providers'
 import { useAppDataHash } from 'state/affiliate/hooks'
 
-const MAX_VALID_TO_EPOCH = BigNumber.from('0xFFFFFFFF').toNumber() // Max uint32 (Feb 07 2106 07:28:15 GMT+0100)
+export const MAX_VALID_TO_EPOCH = BigNumber.from('0xFFFFFFFF').toNumber() // Max uint32 (Feb 07 2106 07:28:15 GMT+0100)
 
 export function calculateValidTo(deadline: number): number {
   // Need the timestamp in seconds

--- a/src/custom/hooks/useUSDCPrice/index.ts
+++ b/src/custom/hooks/useUSDCPrice/index.ts
@@ -28,10 +28,11 @@ export * from '@src/hooks/useUSDCPrice'
 
 const getGpUsdcPriceResolveOnlyLastCall = onlyResolvesLast(getGpUsdcPrice)
 
-const STABLECOIN_AMOUNT_OUT: { [chainId: number]: CurrencyAmount<Token> } = {
+const STABLECOIN_AMOUNT_OUT: { [chain in SupportedChainId]: CurrencyAmount<Token> } = {
   ...STABLECOIN_AMOUNT_OUT_UNI,
   // MOD: lowers threshold from 100k to 100
   [SupportedChainId.MAINNET]: CurrencyAmount.fromRawAmount(USDC, 100e6),
+  [SupportedChainId.RINKEBY]: CurrencyAmount.fromRawAmount(USDC, 100e6),
   [SupportedChainId.XDAI]: CurrencyAmount.fromRawAmount(USDC_XDAI, 10_000e6),
 }
 

--- a/src/custom/hooks/useUSDCPrice/index.ts
+++ b/src/custom/hooks/useUSDCPrice/index.ts
@@ -80,7 +80,6 @@ export default function useUSDCPrice(currency?: Currency) {
   }, [currency, stablecoin, v2USDCTrade, v3USDCTrade.trade]) 
   */
 
-  // uwc-debug
   useEffect(() => {
     const isSupportedChain = supportedChainId(chainId)
     if (!isQuoteLoading || !isSupportedChain || !sellTokenAddress || !sellTokenDecimals) return

--- a/src/custom/hooks/useUSDCPrice/index.ts
+++ b/src/custom/hooks/useUSDCPrice/index.ts
@@ -81,10 +81,10 @@ export default function useUSDCPrice(currency?: Currency) {
   */
 
   useEffect(() => {
-    const isSupportedChain = supportedChainId(chainId)
-    if (!isQuoteLoading || !isSupportedChain || !sellTokenAddress || !sellTokenDecimals) return
+    const supportedChain = supportedChainId(chainId)
+    if (!isQuoteLoading || !supportedChain || !sellTokenAddress || !sellTokenDecimals) return
 
-    const baseAmount = STABLECOIN_AMOUNT_OUT[isSupportedChain]
+    const baseAmount = STABLECOIN_AMOUNT_OUT[supportedChain]
     const stablecoin = baseAmount.currency
 
     const quoteParams = {
@@ -92,7 +92,7 @@ export default function useUSDCPrice(currency?: Currency) {
       sellToken: sellTokenAddress,
       kind: OrderKind.BUY,
       amount: baseAmount.quotient.toString(),
-      chainId: isSupportedChain,
+      chainId: supportedChain,
       fromDecimals: sellTokenDecimals,
       toDecimals: stablecoin.decimals,
       userAddress: account,

--- a/src/custom/state/price/updater.ts
+++ b/src/custom/state/price/updater.ts
@@ -21,7 +21,7 @@ import { QuoteInformationObject } from './reducer'
 import { isWrappingTrade } from 'state/swap/utils'
 import { useOrderValidTo } from 'state/user/hooks'
 
-const DEBOUNCE_TIME = 350
+export const TYPED_VALUE_DEBOUNCE_TIME = 350
 const REFETCH_CHECK_INTERVAL = 10000 // Every 10s
 const RENEW_FEE_QUOTES_BEFORE_EXPIRATION_TIME = 30000 // Will renew the quote if there's less than 30 seconds left for the quote to expire
 const WAITING_TIME_BETWEEN_EQUAL_REQUESTS = 5000 // Prevents from sending the same request to often (max, every 5s)
@@ -130,7 +130,7 @@ export default function FeesUpdater(): null {
 
   // Debounce the typed value to not refetch the fee too often
   // Fee API calculation/call
-  const typedValue = useDebounce(rawTypedValue, DEBOUNCE_TIME)
+  const typedValue = useDebounce(rawTypedValue, TYPED_VALUE_DEBOUNCE_TIME)
 
   const sellCurrency = useCurrency(sellToken)
   const buyCurrency = useCurrency(buyToken)

--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -20,7 +20,7 @@ import { GetQuoteResponse, OrderKind } from '@gnosis.pm/gp-v2-contracts'
 import { ChainId } from 'state/lists/actions'
 import { toErc20Address } from 'utils/tokens'
 import { GpPriceStrategy } from 'hooks/useGetGpPriceStrategy'
-import { MAX_VALID_TO_EPOCH } from '../hooks/useSwapCallback'
+import { MAX_VALID_TO_EPOCH } from 'hooks/useSwapCallback'
 
 const FEE_EXCEEDS_FROM_ERROR = new GpQuoteError({
   errorType: GpQuoteErrorCodes.FeeExceedsFrom,

--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -339,7 +339,7 @@ export async function getBestQuote({
     console.debug('[GP PRICE::API] getBestQuote - Attempting best quote retrieval using COWSWAP strategy, hang tight.')
 
     return getFullQuote({ quoteParams }).catch((err) => {
-      console.error(
+      console.warn(
         '[GP PRICE::API] getBestQuote - error using COWSWAP price strategy, reason: [',
         err,
         '] - trying back up price sources...'

--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -20,6 +20,7 @@ import { GetQuoteResponse, OrderKind } from '@gnosis.pm/gp-v2-contracts'
 import { ChainId } from 'state/lists/actions'
 import { toErc20Address } from 'utils/tokens'
 import { GpPriceStrategy } from 'hooks/useGetGpPriceStrategy'
+import { MAX_VALID_TO_EPOCH } from '../hooks/useSwapCallback'
 
 const FEE_EXCEEDS_FROM_ERROR = new GpQuoteError({
   errorType: GpQuoteErrorCodes.FeeExceedsFrom,
@@ -378,4 +379,32 @@ export function calculateFallbackPriceImpact(initialValue: string, finalValue: s
   console.debug(`[calculateFallbackPriceImpact]::${impact.toSignificant(2)}%`)
 
   return impact
+}
+
+export async function getGpUsdcPrice({ strategy, quoteParams }: Pick<QuoteParams, 'strategy' | 'quoteParams'>) {
+  if (strategy === 'COWSWAP') {
+    console.debug(
+      '[GP PRICE::API] getGpUsdcPrice - Attempting best USDC quote retrieval using COWSWAP strategy, hang tight.'
+    )
+    quoteParams.validTo = MAX_VALID_TO_EPOCH
+    const { quote } = await getQuote(quoteParams)
+
+    // BUY order always. We also need to add the fee to the sellAmount to get the unaffected price
+    const amountWithoutFee = new BigNumberJs(quote.feeAmount).plus(new BigNumberJs(quote.sellAmount))
+    return amountWithoutFee.toString(10)
+  } else {
+    console.debug(
+      '[GP PRICE::API] getGpUsdcPrice - Attempting best USDC quote retrieval using LEGACY strategy, hang tight.'
+    )
+    // legacy
+    const legacyParams = {
+      ...quoteParams,
+      baseToken: quoteParams.buyToken,
+      quoteToken: quoteParams.sellToken,
+    }
+
+    const quote = await getBestPrice(legacyParams)
+
+    return quote.amount
+  }
 }


### PR DESCRIPTION
Uses new quote endpoint for getting USD price against USDC

## Testing
1. check console networks tab that quote is called if price strategy is cowswap
2. price strategy can be checked in logs under filter `[useGetGpPriceStrategy::GP Price Strategy]::`