### PR TITLE
[2002 - return Fee data to UI] - Show fee amount when SellAmountDoesNotCoverFee

### DIFF
--- a/src/custom/api/gnosisProtocol/errors/OperatorError.ts
+++ b/src/custom/api/gnosisProtocol/errors/OperatorError.ts
@@ -3,6 +3,7 @@ type ApiActionType = 'get' | 'create' | 'delete'
 export interface ApiErrorObject {
   errorType: ApiErrorCodes
   description: string
+  data?: any
 }
 
 // Conforms to backend API

--- a/src/custom/api/gnosisProtocol/errors/QuoteError.ts
+++ b/src/custom/api/gnosisProtocol/errors/QuoteError.ts
@@ -3,6 +3,7 @@ import { ApiErrorCodes, ApiErrorObject } from './OperatorError'
 export interface GpQuoteErrorObject {
   errorType: GpQuoteErrorCodes
   description: string
+  data?: any
 }
 
 // Conforms to backend API
@@ -36,6 +37,7 @@ export function mapOperatorErrorToQuoteError(error?: ApiErrorObject): GpQuoteErr
       return {
         errorType: GpQuoteErrorCodes.FeeExceedsFrom,
         description: GpQuoteErrorDetails.FeeExceedsFrom,
+        data: error?.data,
       }
 
     case ApiErrorCodes.UnsupportedToken:
@@ -57,6 +59,8 @@ export default class GpQuoteError extends Error {
   name = 'QuoteErrorObject'
   type: GpQuoteErrorCodes
   description: string
+  // any data attached
+  data?: any
 
   // Status 400 errors
   // https://github.com/gnosis/gp-v2-services/blob/9014ae55412a356e46343e051aefeb683cc69c41/orderbook/openapi.yml#L563
@@ -101,6 +105,7 @@ export default class GpQuoteError extends Error {
     this.type = quoteError.errorType
     this.description = quoteError.description
     this.message = GpQuoteError.quoteErrorDetails[quoteError.errorType]
+    this.data = quoteError?.data
   }
 }
 


### PR DESCRIPTION
# Summary

Closes #2002 

Previously, the different fee endpoint would return fee data regardless of whether the sell amount was enough to cover the fee (it didn't even throw, really)

New quote endpoint now returns that data as well as part of a `data` prop.

Seen working:
![image](https://user-images.githubusercontent.com/21335563/147247364-163742ef-b990-4e09-bd30-8ccbc4ff73fe.png)

## Testing
1. WETH <> DAI on MAINNET
2. input 0.00001 WETH 
3. Networks tab shows red quote and response has `data` prop with fee info
4. UI shows fee amount as before
5. yaaaay! 🥳 