### PR TITLE
[Release] 1.8.0-rc.1

### DIFF
--- a/src/custom/api/gnosisProtocol/errors/OperatorError.ts
+++ b/src/custom/api/gnosisProtocol/errors/OperatorError.ts
@@ -3,6 +3,7 @@ type ApiActionType = 'get' | 'create' | 'delete'
 export interface ApiErrorObject {
   errorType: ApiErrorCodes
   description: string
+  data?: any
 }
 
 // Conforms to backend API

--- a/src/custom/api/gnosisProtocol/errors/QuoteError.ts
+++ b/src/custom/api/gnosisProtocol/errors/QuoteError.ts
@@ -3,6 +3,7 @@ import { ApiErrorCodes, ApiErrorObject } from './OperatorError'
 export interface GpQuoteErrorObject {
   errorType: GpQuoteErrorCodes
   description: string
+  data?: any
 }
 
 // Conforms to backend API
@@ -36,6 +37,7 @@ export function mapOperatorErrorToQuoteError(error?: ApiErrorObject): GpQuoteErr
       return {
         errorType: GpQuoteErrorCodes.FeeExceedsFrom,
         description: GpQuoteErrorDetails.FeeExceedsFrom,
+        data: error?.data,
       }
 
     case ApiErrorCodes.UnsupportedToken:
@@ -57,6 +59,8 @@ export default class GpQuoteError extends Error {
   name = 'QuoteErrorObject'
   type: GpQuoteErrorCodes
   description: string
+  // any data attached
+  data?: any
 
   // Status 400 errors
   // https://github.com/gnosis/gp-v2-services/blob/9014ae55412a356e46343e051aefeb683cc69c41/orderbook/openapi.yml#L563
@@ -101,6 +105,7 @@ export default class GpQuoteError extends Error {
     this.type = quoteError.errorType
     this.description = quoteError.description
     this.message = GpQuoteError.quoteErrorDetails[quoteError.errorType]
+    this.data = quoteError?.data
   }
 }
 

--- a/src/custom/hooks/usePriceImpact/useFallbackPriceImpact.ts
+++ b/src/custom/hooks/usePriceImpact/useFallbackPriceImpact.ts
@@ -11,8 +11,6 @@ import { QuoteInformationObject } from 'state/price/reducer'
 import { QuoteError } from 'state/price/actions'
 import { useQuote } from 'state/price/hooks'
 import { useActiveWeb3React } from 'hooks/web3'
-import { TYPED_VALUE_DEBOUNCE_TIME } from 'state/price/updater'
-import useDebounceWithForceUpdate from 'hooks/useDebounceWithForceUpdate'
 
 type SwapParams = { abTrade?: TradeGp; sellToken?: string | null; buyToken?: string | null }
 
@@ -43,18 +41,11 @@ function _getBaTradeParsedAmount(abTrade: TradeGp | undefined, shouldCalculate: 
   return abTrade?.outputAmountWithoutFee
 }
 
-export default function useFallbackPriceImpact({ abTrade: rawAbTrade, isWrapping }: FallbackPriceImpactParams) {
+export default function useFallbackPriceImpact({ abTrade, isWrapping }: FallbackPriceImpactParams) {
   const {
     INPUT: { currencyId: sellToken },
     OUTPUT: { currencyId: buyToken },
   } = useSwapState()
-
-  // debounce trade creation and force update when tradeType changes
-  const abTrade = useDebounceWithForceUpdate(rawAbTrade, TYPED_VALUE_DEBOUNCE_TIME, [
-    rawAbTrade?.tradeType,
-    sellToken,
-    buyToken,
-  ])
 
   const { chainId } = useActiveWeb3React()
   const lastQuote = useQuote({ token: sellToken, chainId })

--- a/src/custom/state/swap/utils.ts
+++ b/src/custom/state/swap/utils.ts
@@ -8,9 +8,10 @@ export function isWrappingTrade(
   buyCurrency: Currency | null | undefined,
   chainId?: SupportedChainId
 ): boolean {
+  const wethByChain = WETH9_EXTENDED[chainId || SupportedChainId.MAINNET]
   return Boolean(
-    (sellCurrency?.isNative && buyCurrency?.wrapped.equals(WETH9_EXTENDED[chainId || SupportedChainId.MAINNET])) ||
-      (sellCurrency?.wrapped.equals(WETH9_EXTENDED[chainId || SupportedChainId.MAINNET]) && buyCurrency?.isNative)
+    (sellCurrency?.isNative && buyCurrency?.wrapped.equals(wethByChain)) ||
+      (buyCurrency?.isNative && sellCurrency?.wrapped.equals(wethByChain))
   )
 }
 


### PR DESCRIPTION
## ⚠️ DO NOT SQUASH ⚠️ 
![u_shall_not](https://user-images.githubusercontent.com/21335563/146360053-95e5e23e-4311-4c1f-8668-2180f444c7fd.gif)

--

# 🌵 Release v1.8.0-rc.1 🧬 

## Description
Adds the new Quote endpoint `v1/quote` for atomically calculating the price quote & fee. Checks a backend source for which best price strategy to use (`COWSWAP` (one quote request) or `LEGACY` (multiple price source request + competition)). 

## Latest // Incoming (since `rc.0`)
1. #2039

## TODO:
- [X] Query actual endpoint for price strategy - currently mocked using a false async function
- [X] Review https://gnosisinc.slack.com/archives/CPZA1AGKY/p1639652242155600 
![image](https://user-images.githubusercontent.com/21335563/146360750-f10052cb-4dcb-4deb-9070-2fde8f5ac54c.png)

