### PR TITLE
[Rebranding] Update Explorer FE and BE api URLs

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -56,9 +56,9 @@ REACT_APP_PATH_REGEX_ENS="/ipfs"
 #REACT_APP_SENTRY_AUTH_TOKEN='<sentry_auth_token>'
 
 # API
-#REACT_APP_API_URL_PROD_MAINNET=https://api.cow.fi/mainnet
-#REACT_APP_API_URL_PROD_RINKEBY=https://api.cow.fi/rinkeby
-#REACT_APP_API_URL_PROD_XDAI=https://api.cow.fi/xdai
+#REACT_APP_API_URL_PROD_MAINNET=https://api.cow.fi/mainnet/api
+#REACT_APP_API_URL_PROD_RINKEBY=https://api.cow.fi/rinkeby/api
+#REACT_APP_API_URL_PROD_XDAI=https://api.cow.fi/xdai/api
 #REACT_APP_API_URL_STAGING_MAINNET=https://protocol-mainnet.dev.gnosisdev.com/api
 #REACT_APP_API_URL_STAGING_RINKEBY=https://protocol-rinkeby.dev.gnosisdev.com/api
 #REACT_APP_API_URL_STAGING_XDAI=https://protocol-xdai.dev.gnosisdev.com/api

--- a/.env.production
+++ b/.env.production
@@ -66,8 +66,8 @@ REACT_APP_PATH_REGEX_ENS="/ipfs"
 # EXPLORER
 #REACT_APP_EXPLORER_URL_DEV=https://protocol-explorer.dev.gnosisdev.com
 #REACT_APP_EXPLORER_URL_STAGING=https://protocol-explorer.staging.gnosisdev.com
-#REACT_APP_EXPLORER_URL_PROD=https://gnosis-protocol.io
-#REACT_APP_EXPLORER_URL_BARN=https://barn.gnosis-protocol.io
+#REACT_APP_EXPLORER_URL_PROD=https://explorer.cow.fi
+#REACT_APP_EXPLORER_URL_BARN=https://barn.explorer.cow.fi
 
 # Enables mock mode (default = false)
 REACT_APP_MOCK=false

--- a/.env.production
+++ b/.env.production
@@ -59,9 +59,9 @@ REACT_APP_PATH_REGEX_ENS="/ipfs"
 #REACT_APP_API_URL_PROD_MAINNET=https://api.cow.fi/mainnet
 #REACT_APP_API_URL_PROD_RINKEBY=https://api.cow.fi/rinkeby
 #REACT_APP_API_URL_PROD_XDAI=https://api.cow.fi/xdai
-#REACT_APP_API_URL_STAGING_MAINNET=https://barn.api.cow.fi/mainnet
-#REACT_APP_API_URL_STAGING_RINKEBY=https://barn.api.cow.fi/rinkeby
-#REACT_APP_API_URL_STAGING_XDAI=https://barn.api.cow.fi/xdai
+#REACT_APP_API_URL_STAGING_MAINNET=https://protocol-mainnet.dev.gnosisdev.com/api
+#REACT_APP_API_URL_STAGING_RINKEBY=https://protocol-rinkeby.dev.gnosisdev.com/api
+#REACT_APP_API_URL_STAGING_XDAI=https://protocol-xdai.dev.gnosisdev.com/api
 
 # EXPLORER
 #REACT_APP_EXPLORER_URL_DEV=https://protocol-explorer.dev.gnosisdev.com

--- a/.env.production
+++ b/.env.production
@@ -56,12 +56,12 @@ REACT_APP_PATH_REGEX_ENS="/ipfs"
 #REACT_APP_SENTRY_AUTH_TOKEN='<sentry_auth_token>'
 
 # API
-#REACT_APP_API_URL_PROD_MAINNET=https://protocol-mainnet.gnosis.io/api
-#REACT_APP_API_URL_PROD_RINKEBY=https://protocol-rinkeby.gnosis.io/api
-#REACT_APP_API_URL_PROD_XDAI=https://protocol-xdai.gnosis.io/api
-#REACT_APP_API_URL_STAGING_MAINNET=https://protocol-mainnet.dev.gnosisdev.com/api
-#REACT_APP_API_URL_STAGING_RINKEBY=https://protocol-rinkeby.dev.gnosisdev.com/api
-#REACT_APP_API_URL_STAGING_XDAI=https://protocol-xdai.dev.gnosisdev.com/api
+#REACT_APP_API_URL_PROD_MAINNET=https://api.cow.fi/mainnet
+#REACT_APP_API_URL_PROD_RINKEBY=https://api.cow.fi/rinkeby
+#REACT_APP_API_URL_PROD_XDAI=https://api.cow.fi/xdai
+#REACT_APP_API_URL_STAGING_MAINNET=https://barn.api.cow.fi/mainnet
+#REACT_APP_API_URL_STAGING_RINKEBY=https://barn.api.cow.fi/rinkeby
+#REACT_APP_API_URL_STAGING_XDAI=https://barn.api.cow.fi/xdai
 
 # EXPLORER
 #REACT_APP_EXPLORER_URL_DEV=https://protocol-explorer.dev.gnosisdev.com

--- a/src/custom/api/gnosisProtocol/api.ts
+++ b/src/custom/api/gnosisProtocol/api.ts
@@ -39,9 +39,9 @@ function getGnosisProtocolUrl(): Partial<Record<ChainId, string>> {
 
   // Production, staging, ens, ...
   return {
-    [ChainId.MAINNET]: process.env.REACT_APP_API_URL_PROD_MAINNET || 'https://api.cow.fi/mainnet',
-    [ChainId.RINKEBY]: process.env.REACT_APP_API_URL_PROD_RINKEBY || 'https://api.cow.fi/rinkeby',
-    [ChainId.XDAI]: process.env.REACT_APP_API_URL_PROD_XDAI || 'https://api.cow.fi/xdai',
+    [ChainId.MAINNET]: process.env.REACT_APP_API_URL_PROD_MAINNET || 'https://api.cow.fi/mainnet/api',
+    [ChainId.RINKEBY]: process.env.REACT_APP_API_URL_PROD_RINKEBY || 'https://api.cow.fi/rinkeby/api',
+    [ChainId.XDAI]: process.env.REACT_APP_API_URL_PROD_XDAI || 'https://api.cow.fi/xdai/api',
   }
 }
 

--- a/src/custom/api/gnosisProtocol/api.ts
+++ b/src/custom/api/gnosisProtocol/api.ts
@@ -39,9 +39,9 @@ function getGnosisProtocolUrl(): Partial<Record<ChainId, string>> {
 
   // Production, staging, ens, ...
   return {
-    [ChainId.MAINNET]: process.env.REACT_APP_API_URL_PROD_MAINNET || 'https://protocol-mainnet.gnosis.io/api',
-    [ChainId.RINKEBY]: process.env.REACT_APP_API_URL_PROD_RINKEBY || 'https://protocol-rinkeby.gnosis.io/api',
-    [ChainId.XDAI]: process.env.REACT_APP_API_URL_PROD_XDAI || 'https://protocol-xdai.gnosis.io/api',
+    [ChainId.MAINNET]: process.env.REACT_APP_API_URL_PROD_MAINNET || 'https://api.cow.fi/mainnet',
+    [ChainId.RINKEBY]: process.env.REACT_APP_API_URL_PROD_RINKEBY || 'https://api.cow.fi/rinkeby',
+    [ChainId.XDAI]: process.env.REACT_APP_API_URL_PROD_XDAI || 'https://api.cow.fi/xdai',
   }
 }
 
@@ -55,8 +55,7 @@ function getProfileUrl(): Partial<Record<ChainId, string>> {
 
   // Production, staging, ens, ...
   return {
-    [ChainId.MAINNET]:
-      process.env.REACT_APP_PROFILE_API_URL_STAGING_MAINNET || 'https://protocol-affiliate.gnosis.io/api',
+    [ChainId.MAINNET]: process.env.REACT_APP_PROFILE_API_URL_STAGING_MAINNET || 'https://api.cow.fi/affiliate/api',
   }
 }
 const STRATEGY_URL_BASE = 'https://raw.githubusercontent.com/gnosis/cowswap/configuration/config/strategies'


### PR DESCRIPTION
# Summary

closes #2011
closes #2012  

- Updated Explorer URLs (only `prod` and `barn` environments).
- Updated Explorer api URLs.



