### PR TITLE
Claim hooks 3

### DIFF
--- a/src/custom/abis/types/VCow.d.ts
+++ b/src/custom/abis/types/VCow.d.ts
@@ -25,6 +25,10 @@ interface VCowInterface extends ethers.utils.Interface {
     "claimMany(uint256[],uint8[],address[],uint256[],uint256[],bytes32[][],uint256[])": FunctionFragment;
     "isClaimed(uint256)": FunctionFragment;
     "merkleRoot()": FunctionFragment;
+    "deploymentTimestamp()": FunctionFragment;
+    "gnoPrice()": FunctionFragment;
+    "usdcPrice()": FunctionFragment;
+    "wethPrice()": FunctionFragment;
   };
 
   encodeFunctionData(
@@ -58,11 +62,25 @@ interface VCowInterface extends ethers.utils.Interface {
     functionFragment: "merkleRoot",
     values?: undefined
   ): string;
+  encodeFunctionData(
+    functionFragment: "deploymentTimestamp",
+    values?: undefined
+  ): string;
+  encodeFunctionData(functionFragment: "gnoPrice", values?: undefined): string;
+  encodeFunctionData(functionFragment: "usdcPrice", values?: undefined): string;
+  encodeFunctionData(functionFragment: "wethPrice", values?: undefined): string;
 
   decodeFunctionResult(functionFragment: "claim", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "claimMany", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "isClaimed", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "merkleRoot", data: BytesLike): Result;
+  decodeFunctionResult(
+    functionFragment: "deploymentTimestamp",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(functionFragment: "gnoPrice", data: BytesLike): Result;
+  decodeFunctionResult(functionFragment: "usdcPrice", data: BytesLike): Result;
+  decodeFunctionResult(functionFragment: "wethPrice", data: BytesLike): Result;
 
   events: {
     "Claimed(uint256,uint8,address,uint256,uint256)": EventFragment;
@@ -152,6 +170,14 @@ export class VCow extends BaseContract {
     ): Promise<[boolean]>;
 
     merkleRoot(overrides?: CallOverrides): Promise<[string]>;
+
+    deploymentTimestamp(overrides?: CallOverrides): Promise<[BigNumber]>;
+
+    gnoPrice(overrides?: CallOverrides): Promise<[BigNumber]>;
+
+    usdcPrice(overrides?: CallOverrides): Promise<[BigNumber]>;
+
+    wethPrice(overrides?: CallOverrides): Promise<[BigNumber]>;
   };
 
   claim(
@@ -179,6 +205,14 @@ export class VCow extends BaseContract {
 
   merkleRoot(overrides?: CallOverrides): Promise<string>;
 
+  deploymentTimestamp(overrides?: CallOverrides): Promise<BigNumber>;
+
+  gnoPrice(overrides?: CallOverrides): Promise<BigNumber>;
+
+  usdcPrice(overrides?: CallOverrides): Promise<BigNumber>;
+
+  wethPrice(overrides?: CallOverrides): Promise<BigNumber>;
+
   callStatic: {
     claim(
       index: BigNumberish,
@@ -204,6 +238,14 @@ export class VCow extends BaseContract {
     isClaimed(index: BigNumberish, overrides?: CallOverrides): Promise<boolean>;
 
     merkleRoot(overrides?: CallOverrides): Promise<string>;
+
+    deploymentTimestamp(overrides?: CallOverrides): Promise<BigNumber>;
+
+    gnoPrice(overrides?: CallOverrides): Promise<BigNumber>;
+
+    usdcPrice(overrides?: CallOverrides): Promise<BigNumber>;
+
+    wethPrice(overrides?: CallOverrides): Promise<BigNumber>;
   };
 
   filters: {
@@ -270,6 +312,14 @@ export class VCow extends BaseContract {
     ): Promise<BigNumber>;
 
     merkleRoot(overrides?: CallOverrides): Promise<BigNumber>;
+
+    deploymentTimestamp(overrides?: CallOverrides): Promise<BigNumber>;
+
+    gnoPrice(overrides?: CallOverrides): Promise<BigNumber>;
+
+    usdcPrice(overrides?: CallOverrides): Promise<BigNumber>;
+
+    wethPrice(overrides?: CallOverrides): Promise<BigNumber>;
   };
 
   populateTransaction: {
@@ -300,5 +350,15 @@ export class VCow extends BaseContract {
     ): Promise<PopulatedTransaction>;
 
     merkleRoot(overrides?: CallOverrides): Promise<PopulatedTransaction>;
+
+    deploymentTimestamp(
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
+
+    gnoPrice(overrides?: CallOverrides): Promise<PopulatedTransaction>;
+
+    usdcPrice(overrides?: CallOverrides): Promise<PopulatedTransaction>;
+
+    wethPrice(overrides?: CallOverrides): Promise<PopulatedTransaction>;
   };
 }

--- a/src/custom/abis/types/factories/VCow__factory.ts
+++ b/src/custom/abis/types/factories/VCow__factory.ts
@@ -157,6 +157,58 @@ const _abi = [
     stateMutability: "view",
     type: "function",
   },
+  {
+    inputs: [],
+    name: "deploymentTimestamp",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "gnoPrice",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "usdcPrice",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "wethPrice",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
 ];
 
 export class VCow__factory {

--- a/src/custom/abis/vCow.json
+++ b/src/custom/abis/vCow.json
@@ -148,5 +148,57 @@
     ],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "deploymentTimestamp",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "gnoPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "usdcPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "wethPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -90,7 +90,7 @@ export default function Claim() {
   const [claimConfirmed, setClaimConfirmed] = useState<boolean>(false)
   const [claimAttempting, setClaimAttempting] = useState<boolean>(false)
   const [claimSubmitted, setClaimSubmitted] = useState<boolean>(false)
-  const [claimedAmmount, setClaimedAmmount] = useState<number>(0)
+  const [claimedAmount, setClaimedAmount] = useState<number>(0)
 
   // investment
   const [isInvestFlowActive, setIsInvestFlowActive] = useState<boolean>(false)
@@ -364,7 +364,7 @@ export default function Claim() {
                 <h3>You have successfully claimed</h3>
               </Trans>
               <Trans>
-                <p>{claimedAmmount} vCOW</p>
+                <p>{claimedAmount} vCOW</p>
               </Trans>
               <Trans>
                 <span role="img" aria-label="party-hat">

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -9,6 +9,8 @@ import {
   FREE_CLAIM_TYPES,
   ClaimType,
   useClaimCallback,
+  useInvestmentStillAvailable,
+  useAirdropStillAvailable,
 } from 'state/claim/hooks'
 import { ButtonPrimary, ButtonSecondary } from 'components/Button'
 import Circle from 'assets/images/blue-loader.svg'
@@ -124,6 +126,10 @@ export default function Claim() {
   const typeToCurrencyMap = useMemo(() => getTypeToCurrencyMap(chainId), [chainId])
   const typeToPriceMap = useMemo(() => getTypeToPriceMap(), [])
 
+  // checks regarding investment time window
+  const isInvestmentStillAvailable = useInvestmentStillAvailable()
+  const isAirdropStillAvailable = useAirdropStillAvailable()
+
   // claim callback
   const { claimCallback } = useClaimCallback(activeClaimAccount)
 
@@ -202,6 +208,15 @@ export default function Claim() {
       setIsInvestFlowActive(true)
     }
   }
+  console.log(
+    `Claim/index::`,
+    `[unclaimedAmount ${unclaimedAmount?.toFixed(2)}]`,
+    `[hasClaims ${hasClaims}]`,
+    `[activeClaimAccount ${activeClaimAccount}]`,
+    `[isAirdropOnly ${isAirdropOnly}]`,
+    `[isInvestmentStillAvailable ${isInvestmentStillAvailable}]`,
+    `[isAirdropStillAvailable ${isAirdropStillAvailable}]`
+  )
 
   // on account change
   useEffect(() => {
@@ -320,16 +335,21 @@ export default function Claim() {
 
       {/* START -- IS Airdrop only (simple)  ----------------------------------------------------- */}
       {!!activeClaimAccount && !!hasClaims && !!isAirdropOnly && !claimAttempting && !claimConfirmed && (
-        <IntroDescription>
-          <p>
-            <Trans>
-              Thank you for being a supporter of CowSwap and the CoW protocol. As an important member of the CowSwap
-              Community you may claim vCOW to be used for voting and governance. You can claim your tokens until{' '}
-              <i>[XX-XX-XXXX - XX:XX GMT]</i>
-              <ExternalLink href="https://cow.fi/">Read more about vCOW</ExternalLink>
-            </Trans>
-          </p>
-        </IntroDescription>
+        <>
+          <IntroDescription>
+            <p>
+              <Trans>
+                Thank you for being a supporter of CowSwap and the CoW protocol. As an important member of the CowSwap
+                Community you may claim vCOW to be used for voting and governance. You can claim your tokens until{' '}
+                <i>[XX-XX-XXXX - XX:XX GMT]</i>
+                <ExternalLink href="https://cow.fi/">Read more about vCOW</ExternalLink>
+              </Trans>
+            </p>
+          </IntroDescription>
+
+          {/* TODO: this is temporary to show the flag, find a better way to show it */}
+          {!isAirdropStillAvailable && <h3>WARNING: investment window is over!!!</h3>}
+        </>
       )}
       {/* END -- IS Airdrop only (simple)  ---------------------------------------- */}
 
@@ -406,6 +426,10 @@ export default function Claim() {
         !(claimAttempting || claimConfirmed) && (
           <ClaimBreakdown>
             <h2>vCOW claim breakdown</h2>
+
+            {/* TODO: this is temporary to show the flag, find a better way to show it */}
+            {!isInvestmentStillAvailable && <h3>WARNING: investment window is over!!!</h3>}
+
             <ClaimTable>
               <table>
                 <thead>
@@ -620,6 +644,7 @@ export default function Claim() {
       )}
       {/* END -- Investing vCOW flow (advanced) ----------------------------------------------------- */}
 
+      {/* START -- CLAIM button OR other actions */}
       <FooterNavButtons>
         {/* General claim vCOW button  (no invest) */}
         {!!activeClaimAccount && !!hasClaims && !isInvestFlowActive && !claimAttempting && !claimConfirmed ? (
@@ -668,6 +693,7 @@ export default function Claim() {
           </>
         )}
       </FooterNavButtons>
+      {/* END -- CLAIM button OR other actions */}
     </PageWrapper>
   )
 }

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -113,7 +113,7 @@ export default function Claim() {
   // get total unclaimed ammount
   const unclaimedAmount = useUserUnclaimedAmount(activeClaimAccount)
 
-  const hasClaims = useMemo(() => userClaimData.length, [userClaimData])
+  const hasClaims = useMemo(() => userClaimData.length > 0, [userClaimData])
   const isAirdropOnly = useMemo(() => !hasPaidClaim(userClaimData), [userClaimData])
 
   // handle table select change

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -23,6 +23,10 @@ export { useUserClaimData } from '@src/state/claim/hooks'
 const CLAIMS_REPO_BRANCH = 'main'
 export const CLAIMS_REPO = `https://raw.githubusercontent.com/gnosis/cow-merkle-drop/${CLAIMS_REPO_BRANCH}/`
 
+// TODO: these values came from the test contract, might be different on real deployment
+export const WETH_PRICE = '37500000000000' // '0.0000375' WETH (18 decimals) per vCOW
+export const GNO_PRICE = '375000000000000' // '0.000375' GNO (18 decimals) per vCOW
+export const USDC_PRICE = '150000' // '0.15' USDC (6 decimals) per vCOW
 export enum ClaimType {
   Airdrop, // free, no vesting, can be available on both mainnet and gchain
   GnoOption, // paid, with vesting, must use GNO, can be available on both mainnet and gchain

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import JSBI from 'jsbi'
+import ms from 'ms.macro'
 import { CurrencyAmount, Token } from '@uniswap/sdk-core'
 import { TransactionResponse } from '@ethersproject/providers'
 
@@ -29,9 +30,8 @@ export const GNO_PRICE = '375000000000000' // '0.000375' GNO (18 decimals) per v
 export const USDC_PRICE = '150000' // '0.15' USDC (6 decimals) per vCOW, in atoms
 
 // Constants regarding investment time windows
-const ONE_WEEK = 7 * 24 * 60 * 60 * 1000 // in ms
-const TWO_WEEKS = 2 * ONE_WEEK // in ms
-const SIX_WEEKS = 6 * ONE_WEEK // in ms
+const TWO_WEEKS = ms`2 weeks`
+const SIX_WEEKS = ms`6 weeks`
 
 const TEN_TO_EIGHTEENTH_POWER = JSBI.exponentiate(JSBI.BigInt('10'), JSBI.BigInt('18'))
 

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -27,6 +27,12 @@ export const CLAIMS_REPO = `https://raw.githubusercontent.com/gnosis/cow-merkle-
 export const WETH_PRICE = '37500000000000' // '0.0000375' WETH (18 decimals) per vCOW
 export const GNO_PRICE = '375000000000000' // '0.000375' GNO (18 decimals) per vCOW
 export const USDC_PRICE = '150000' // '0.15' USDC (6 decimals) per vCOW
+
+// Constants regarding investment time windows
+const ONE_WEEK = 7 * 24 * 60 * 60 * 1000 // in ms
+const TWO_WEEKS = 2 * ONE_WEEK // in ms
+const SIX_WEEKS = 6 * ONE_WEEK // in ms
+
 export enum ClaimType {
   Airdrop, // free, no vesting, can be available on both mainnet and gchain
   GnoOption, // paid, with vesting, must use GNO, can be available on both mainnet and gchain
@@ -196,6 +202,30 @@ function useDeploymentTimestamp(): number | null {
   }, [chainId, vCowContract])
 
   return timestamp
+}
+
+/**
+ * Returns whether vCOW contract is still open for investments
+ * Null when not applicable
+ *
+ * That is, there has been less than 2 weeks since it was deployed
+ */
+export function useInvestmentStillAvailable(): boolean | null {
+  const deploymentTimestamp = useDeploymentTimestamp()
+
+  return deploymentTimestamp ? deploymentTimestamp + TWO_WEEKS > Date.now() : null
+}
+
+/**
+ * Returns whether vCOW contract is still open for airdrops
+ * Null when not applicable
+ *
+ * That is, there has been less than 6 weeks since it was deployed
+ */
+export function useAirdropStillAvailable(): boolean | null {
+  const deploymentTimestamp = useDeploymentTimestamp()
+
+  return deploymentTimestamp ? deploymentTimestamp + SIX_WEEKS > Date.now() : null
 }
 
 /**

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -3,6 +3,7 @@ import JSBI from 'jsbi'
 import ms from 'ms.macro'
 import { CurrencyAmount, Token } from '@uniswap/sdk-core'
 import { TransactionResponse } from '@ethersproject/providers'
+import { parseUnits } from '@ethersproject/units'
 
 import { VCow as VCowType } from 'abis/types'
 
@@ -32,8 +33,6 @@ export const USDC_PRICE = '150000' // '0.15' USDC (6 decimals) per vCOW, in atom
 // Constants regarding investment time windows
 const TWO_WEEKS = ms`2 weeks`
 const SIX_WEEKS = ms`6 weeks`
-
-const TEN_TO_EIGHTEENTH_POWER = JSBI.exponentiate(JSBI.BigInt('10'), JSBI.BigInt('18'))
 
 export enum ClaimType {
   Airdrop, // free, no vesting, can be available on both mainnet and gchain
@@ -443,10 +442,10 @@ function _getClaimValue(claim: UserClaimData, vCowAmount: string): string {
   if (claim.type !== ClaimType.UserOption) {
     return '0'
   }
-  return JSBI.divide(
-    JSBI.multiply(JSBI.BigInt(vCowAmount), JSBI.BigInt(WETH_PRICE)),
-    TEN_TO_EIGHTEENTH_POWER
-  ).toString()
+
+  const claimValueInAtoms = JSBI.multiply(JSBI.BigInt(vCowAmount), JSBI.BigInt(WETH_PRICE))
+
+  return parseUnits(claimValueInAtoms.toString(), 18).toString()
 }
 
 type LastAddress = string

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -23,7 +23,7 @@ export { useUserClaimData } from '@src/state/claim/hooks'
 const CLAIMS_REPO_BRANCH = 'main'
 export const CLAIMS_REPO = `https://raw.githubusercontent.com/gnosis/cow-merkle-drop/${CLAIMS_REPO_BRANCH}/`
 
-export const enum ClaimType {
+export enum ClaimType {
   Airdrop, // free, no vesting, can be available on both mainnet and gchain
   GnoOption, // paid, with vesting, must use GNO, can be available on both mainnet and gchain
   UserOption, // paid, with vesting, must use Native currency, can be available on both mainnet and gchain
@@ -33,16 +33,6 @@ export const enum ClaimType {
 }
 
 type RepoClaimType = keyof typeof ClaimType
-
-// TODO: also, is there a smarter way of doing this?
-export const REVERSE_CLAIM_TYPE_MAPPING: Record<RepoClaimType, ClaimType> = {
-  Airdrop: ClaimType.Airdrop,
-  GnoOption: ClaimType.GnoOption,
-  UserOption: ClaimType.UserOption,
-  Investor: ClaimType.Investor,
-  Team: ClaimType.Team,
-  Advisor: ClaimType.Advisor,
-}
 
 export const FREE_CLAIM_TYPES: ClaimType[] = [ClaimType.Airdrop, ClaimType.Team, ClaimType.Advisor]
 export const PAID_CLAIM_TYPES: ClaimType[] = [ClaimType.GnoOption, ClaimType.UserOption, ClaimType.Investor]

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -24,9 +24,9 @@ const CLAIMS_REPO_BRANCH = 'main'
 export const CLAIMS_REPO = `https://raw.githubusercontent.com/gnosis/cow-merkle-drop/${CLAIMS_REPO_BRANCH}/`
 
 // TODO: these values came from the test contract, might be different on real deployment
-export const WETH_PRICE = '37500000000000' // '0.0000375' WETH (18 decimals) per vCOW
-export const GNO_PRICE = '375000000000000' // '0.000375' GNO (18 decimals) per vCOW
-export const USDC_PRICE = '150000' // '0.15' USDC (6 decimals) per vCOW
+export const WETH_PRICE = '37500000000000' // '0.0000375' WETH (18 decimals) per vCOW, in wei
+export const GNO_PRICE = '375000000000000' // '0.000375' GNO (18 decimals) per vCOW, in atoms
+export const USDC_PRICE = '150000' // '0.15' USDC (6 decimals) per vCOW, in atoms
 
 // Constants regarding investment time windows
 const ONE_WEEK = 7 * 24 * 60 * 60 * 1000 // in ms

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -211,10 +211,10 @@ function useDeploymentTimestamp(): number | null {
  *
  * That is, there has been less than 2 weeks since it was deployed
  */
-export function useInvestmentStillAvailable(): boolean | null {
+export function useInvestmentStillAvailable(): boolean {
   const deploymentTimestamp = useDeploymentTimestamp()
 
-  return deploymentTimestamp ? deploymentTimestamp + TWO_WEEKS > Date.now() : null
+  return Boolean(deploymentTimestamp && deploymentTimestamp + TWO_WEEKS > Date.now())
 }
 
 /**
@@ -223,10 +223,10 @@ export function useInvestmentStillAvailable(): boolean | null {
  *
  * That is, there has been less than 6 weeks since it was deployed
  */
-export function useAirdropStillAvailable(): boolean | null {
+export function useAirdropStillAvailable(): boolean {
   const deploymentTimestamp = useDeploymentTimestamp()
 
-  return deploymentTimestamp ? deploymentTimestamp + SIX_WEEKS > Date.now() : null
+  return Boolean(deploymentTimestamp && deploymentTimestamp + SIX_WEEKS > Date.now())
 }
 
 /**

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -175,6 +175,30 @@ export function useUserClaims(account: Account): UserClaims | null {
 }
 
 /**
+ * Fetches from contract the deployment timestamp in ms
+ *
+ * Returns null if in there's no network or vCowContract doesn't exist
+ */
+function useDeploymentTimestamp(): number | null {
+  const { chainId } = useActiveWeb3React()
+  const vCowContract = useVCowContract()
+  const [timestamp, setTimestamp] = useState<number | null>(null)
+
+  useEffect(() => {
+    if (!chainId || !vCowContract) {
+      return
+    }
+
+    vCowContract.deploymentTimestamp().then((ts) => {
+      console.log(`Deployment timestamp in seconds: ${ts.toString()}`)
+      setTimestamp(ts.mul('1000').toNumber())
+    })
+  }, [chainId, vCowContract])
+
+  return timestamp
+}
+
+/**
  * Hook that returns the claimCallback
  *
  * Different from the original version, the returned callback takes as input a list of ClaimInputs,

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -325,7 +325,17 @@ export function useClaimCallback(account: string | null | undefined): {
         })
       })
     },
-    [account, addTransaction, chainId, claims, connectedAccount, vCowContract, vCowToken]
+    [
+      account,
+      addTransaction,
+      chainId,
+      claims,
+      connectedAccount,
+      isAirdropStillAvailable,
+      isInvestmentStillAvailable,
+      vCowContract,
+      vCowToken,
+    ]
   )
 
   return { claimCallback }

--- a/src/custom/state/claim/hooks/utils.ts
+++ b/src/custom/state/claim/hooks/utils.ts
@@ -7,7 +7,6 @@ import {
   FREE_CLAIM_TYPES,
   PAID_CLAIM_TYPES,
   RepoClaims,
-  REVERSE_CLAIM_TYPE_MAPPING,
   UserClaims,
 } from 'state/claim/hooks/index'
 
@@ -36,7 +35,7 @@ export function hasFreeClaim(claims: UserClaims | null): boolean {
  * Airdrop -> 0
  */
 export function transformRepoClaimsToUserClaims(repoClaims: RepoClaims): UserClaims {
-  return repoClaims.map((claim) => ({ ...claim, type: REVERSE_CLAIM_TYPE_MAPPING[claim.type] }))
+  return repoClaims.map((claim) => ({ ...claim, type: ClaimType[claim.type] }))
 }
 
 /**


### PR DESCRIPTION
# Summary

Several things in this PR

1. New contract methods
2. New hooks using those methods
3. Checking whether investment is open for investment/airdrop and showing it on the claim page
<img width="516" alt="Screen Shot 2022-01-05 at 18 15 27" src="https://user-images.githubusercontent.com/43217/148318382-d2b278c7-3581-4a0f-b2fd-afdfab8b5e64.png">

4. Added prices
5. Calculating ETH when investment type is `UserOption` -- can't test it as investment window is closed on the contract

  # To Test

1. On claim page, check for an address that has airdrop only
* Should see no warning
2. Then check for account that has at least 1 investment option
* Should see warning as investment window is closed


  # Background

*Optional: Give background information for changes you've made, that might be difficult to explain via comments*

