### PR TITLE
Claim available on profile

### DIFF
--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -205,7 +205,7 @@ const UniIcon = styled.div`
   }
 `
 
-const VCowAmount = styled(UNIAmountMod)`
+export const VCowButton = styled(UNIAmountMod)`
   ${({ theme }) => theme.cowToken.background};
   ${({ theme }) => theme.cowToken.boxShadow};
   color: white;
@@ -265,7 +265,7 @@ export default function Header() {
           <NetworkCard />
           <HeaderElement>
             <UNIWrapper onClick={handleOnClickClaim}>
-              <VCowAmount active={!!account} style={{ pointerEvents: 'auto' }}>
+              <VCowButton active={!!account} style={{ pointerEvents: 'auto' }}>
                 {claimTxn && !claimTxn?.receipt ? (
                   <Dots>
                     <Trans>Claiming vCOW...</Trans>
@@ -276,7 +276,7 @@ export default function Header() {
                     <Trans>vCOW</Trans>
                   </>
                 )}
-              </VCowAmount>
+              </VCowButton>
             </UNIWrapper>
             <AccountElement active={!!account} style={{ pointerEvents: 'auto' }}>
               {account && userEthBalance && (

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -23,7 +23,7 @@ import { HelpCircle, RefreshCcw } from 'react-feather'
 import Web3Status from 'components/Web3Status'
 import useReferralLink from 'hooks/useReferralLink'
 import useFetchProfile from 'hooks/useFetchProfile'
-import { formatSmart, numberFormatter } from 'utils/format'
+import { formatMax, formatSmart, numberFormatter } from 'utils/format'
 import { getExplorerAddressLink } from 'utils/explorer'
 import useTimeAgo from 'hooks/useTimeAgo'
 import { MouseoverTooltipContent } from 'components/Tooltip'
@@ -74,7 +74,7 @@ export default function Profile() {
               <CowProtocolLogo size={46} />
               <ProfileFlexCol>
                 <Txt fs={14}>Balance</Txt>
-                <Txt fs={18}>
+                <Txt fs={18} title={`${formatMax(vCowBalance)} vCOW`}>
                   <strong>{formatSmart(vCowBalance, AMOUNT_PRECISION)} vCOW</strong>
                 </Txt>
               </ProfileFlexCol>

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -23,7 +23,7 @@ import { HelpCircle, RefreshCcw } from 'react-feather'
 import Web3Status from 'components/Web3Status'
 import useReferralLink from 'hooks/useReferralLink'
 import useFetchProfile from 'hooks/useFetchProfile'
-import { numberFormatter } from 'utils/format'
+import { formatSmart, numberFormatter } from 'utils/format'
 import { getExplorerAddressLink } from 'utils/explorer'
 import useTimeAgo from 'hooks/useTimeAgo'
 import { MouseoverTooltipContent } from 'components/Tooltip'
@@ -33,6 +33,9 @@ import AffiliateStatusCheck from 'components/AffiliateStatusCheck'
 import { useHasOrders } from 'api/gnosisProtocol/hooks'
 import CowProtocolLogo from 'components/CowProtocolLogo'
 import { Title } from 'components/Page'
+import { useTokenBalance } from 'state/wallet/hooks'
+import { V_COW } from 'constants/tokens'
+import { AMOUNT_PRECISION } from 'constants/index'
 
 export default function Profile() {
   const referralLink = useReferralLink()
@@ -41,6 +44,8 @@ export default function Profile() {
   const lastUpdated = useTimeAgo(profileData?.lastUpdated)
   const isTradesTooltipVisible = account && chainId == 1 && !!profileData?.totalTrades
   const hasOrders = useHasOrders(account)
+
+  const vCowBalance = useTokenBalance(account || undefined, chainId ? V_COW[chainId] : undefined)
 
   const renderNotificationMessages = (
     <>
@@ -64,15 +69,17 @@ export default function Profile() {
           <CardHead>
             <Title>Profile</Title>
           </CardHead>
-          <VCOWBalance>
-            <CowProtocolLogo size={46} />
-            <ProfileFlexCol>
-              <Txt fs={14}>Balance</Txt>
-              <Txt fs={18}>
-                <strong>102,02 vCOW</strong>
-              </Txt>
-            </ProfileFlexCol>
-          </VCOWBalance>
+          {vCowBalance && (
+            <VCOWBalance>
+              <CowProtocolLogo size={46} />
+              <ProfileFlexCol>
+                <Txt fs={14}>Balance</Txt>
+                <Txt fs={18}>
+                  <strong>{formatSmart(vCowBalance, AMOUNT_PRECISION)} vCOW</strong>
+                </Txt>
+              </ProfileFlexCol>
+            </VCOWBalance>
+          )}
         </ProfileGridWrap>
       </ProfileWrapper>
       {chainId && chainId === ChainId.MAINNET && <AffiliateStatusCheck />}

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -75,7 +75,7 @@ export default function Profile() {
               <ProfileFlexCol>
                 <Txt fs={14}>Balance</Txt>
                 <Txt fs={18} title={`${formatMax(vCowBalance)} vCOW`}>
-                  <strong>{formatSmart(vCowBalance, AMOUNT_PRECISION)} vCOW</strong>
+                  <strong>{formatSmart(vCowBalance, AMOUNT_PRECISION) || '0'} vCOW</strong>
                 </Txt>
               </ProfileFlexCol>
             </VCOWBalance>

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -1,3 +1,6 @@
+import { useHistory } from 'react-router-dom'
+import { Trans } from '@lingui/macro'
+
 import { Txt } from 'assets/styles/styled'
 import {
   FlexCol,
@@ -36,6 +39,9 @@ import { Title } from 'components/Page'
 import { useTokenBalance } from 'state/wallet/hooks'
 import { V_COW } from 'constants/tokens'
 import { AMOUNT_PRECISION } from 'constants/index'
+import { useUserUnclaimedAmount } from 'state/claim/hooks'
+import { UNIWrapper } from 'components/Header/HeaderMod'
+import { VCowButton } from 'components/Header'
 
 export default function Profile() {
   const referralLink = useReferralLink()
@@ -46,6 +52,10 @@ export default function Profile() {
   const hasOrders = useHasOrders(account)
 
   const vCowBalance = useTokenBalance(account || undefined, chainId ? V_COW[chainId] : undefined)
+  const availableClaim = useUserUnclaimedAmount(account)
+
+  const history = useHistory()
+  const handleOnClickClaim = () => history.push('/claim')
 
   const renderNotificationMessages = (
     <>
@@ -65,10 +75,24 @@ export default function Profile() {
   return (
     <Container>
       <ProfileWrapper>
-        <ProfileGridWrap horizontal>
+        {/* TODO: please fix this horrible thing I did */}
+        <ProfileGridWrap horizontal style={{ display: 'flex' }}>
           <CardHead>
             <Title>Profile</Title>
           </CardHead>
+          {availableClaim?.greaterThan('0') && (
+            <VCOWBalance>
+              You have {formatSmart(availableClaim)} vCOW unclaimed
+              <UNIWrapper onClick={handleOnClickClaim}>
+                <VCowButton active>
+                  <>
+                    <CowProtocolLogo />
+                    <Trans>Claim</Trans>
+                  </>
+                </VCowButton>
+              </UNIWrapper>
+            </VCOWBalance>
+          )}
           {vCowBalance && (
             <VCOWBalance>
               <CowProtocolLogo size={46} />


### PR DESCRIPTION
# Summary

Depends on #2062 

Shows Claimable amount on Profile page
<img width="929" alt="Screen Shot 2022-01-07 at 15 19 09" src="https://user-images.githubusercontent.com/43217/148619501-94e08fa6-7f73-4184-9c20-86a487b50b78.png">

# To Test

1. Load this test PK on Rinkeby `0xdd0cd0b5ab9055ca8b4ac7fcc6c54d179f38e9c9f59b52d22b4022fbb672187a`
2. Go to profile page 
* It should show you how much this account can claim
* It should show you a button to the claim page
* If you don't have anything to claim, it won't be visible (duh)
* Networks where vCOW is not deployed (anything but Rinkeby) will not show you anything

**Note** horrible styled, meant to only connect the dots. Styling work desperately needed