### PR TITLE
Claim pending update

### DIFF
--- a/src/custom/pages/Claim/ClaimSummary.tsx
+++ b/src/custom/pages/Claim/ClaimSummary.tsx
@@ -31,7 +31,7 @@ export default function ClaimSummary({ hasClaims, unclaimedAmount }: ClaimSummar
         <div>
           <ClaimTotal>
             <b>Total available to claim</b>
-            <p>{formatSmart(unclaimedAmount)} vCOW</p>
+            <p>{formatSmart(unclaimedAmount) ?? 0} vCOW</p>
           </ClaimTotal>
         </div>
       )}

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -4,7 +4,7 @@ import { useActiveWeb3React } from 'hooks/web3'
 import { ExternalLink, CustomLightSpinner } from 'theme'
 import {
   useUserAvailableClaims,
-  useUserUnclaimedAmount,
+  useUserUnclaimedCurrentAmount,
   FREE_CLAIM_TYPES,
   ClaimType,
   useClaimCallback,
@@ -114,7 +114,7 @@ export default function Claim() {
   )
 
   // get total unclaimed ammount
-  const unclaimedAmount = useUserUnclaimedAmount(activeClaimAccount)
+  const unclaimedAmount = useUserUnclaimedCurrentAmount(activeClaimAccount)
 
   const hasClaims = useMemo(() => userClaimData.length > 0, [userClaimData])
   const isAirdropOnly = useMemo(() => !hasPaidClaim(userClaimData), [userClaimData])

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -239,9 +239,6 @@ export default function Claim() {
     // setActiveClaimAccount and other dispatch fns are only here for TS. They are safe references.
   }, [account, isSearchUsed, setActiveClaimAccount, setInvestFlowStep, setIsInvestFlowActive])
 
-  const indices = useAllClaimingTransactionIndices()
-  console.log('🚀 ~ file: index.tsx ~ line 229 ~ Claim ~ indices', indices)
-
   return (
     <PageWrapper>
       {/* If claim is confirmed > trigger confetti effect */}

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -4,7 +4,7 @@ import { useActiveWeb3React } from 'hooks/web3'
 import { ExternalLink, CustomLightSpinner } from 'theme'
 import {
   useUserAvailableClaims,
-  useUserUnclaimedCurrentAmount,
+  useUserUnclaimedAmount,
   FREE_CLAIM_TYPES,
   ClaimType,
   useClaimCallback,
@@ -114,7 +114,7 @@ export default function Claim() {
   )
 
   // get total unclaimed ammount
-  const unclaimedAmount = useUserUnclaimedCurrentAmount(activeClaimAccount)
+  const unclaimedAmount = useUserUnclaimedAmount(activeClaimAccount)
 
   const hasClaims = useMemo(() => userClaimData.length > 0, [userClaimData])
   const isAirdropOnly = useMemo(() => !hasPaidClaim(userClaimData), [userClaimData])

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -239,6 +239,9 @@ export default function Claim() {
     // setActiveClaimAccount and other dispatch fns are only here for TS. They are safe references.
   }, [account, isSearchUsed, setActiveClaimAccount, setInvestFlowStep, setIsInvestFlowActive])
 
+  const indices = useAllClaimingTransactionIndices()
+  console.log('🚀 ~ file: index.tsx ~ line 229 ~ Claim ~ indices', indices)
+
   return (
     <PageWrapper>
       {/* If claim is confirmed > trigger confetti effect */}

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -25,7 +25,7 @@ import mockData, { MOCK_INDICES } from './mocks/claimData'
 import { getIndexes } from './utils'
 import { useAllClaimingTransactionIndices } from 'state/enhancedTransactions/hooks'
 
-export { useUserClaimData, useUserUnclaimedAmount } from '@src/state/claim/hooks'
+export { useUserClaimData } from '@src/state/claim/hooks'
 
 import { AppDispatch } from 'state'
 import { useSelector, useDispatch } from 'react-redux'
@@ -192,7 +192,7 @@ export function useUserHasAvailableClaim(account: Account): boolean {
   return availableClaims.length > 0
 }
 
-export function useUserUnclaimedCurrentAmount(account: string | null | undefined): CurrencyAmount<Token> | undefined {
+export function useUserUnclaimedAmount(account: string | null | undefined): CurrencyAmount<Token> | undefined {
   const { chainId } = useActiveWeb3React()
   const claims = useUserAvailableClaims(account)
   const pendingIndices = useAllClaimingTransactionIndices()
@@ -203,8 +203,10 @@ export function useUserUnclaimedCurrentAmount(account: string | null | undefined
     return CurrencyAmount.fromRawAmount(vCow, JSBI.BigInt(0))
   }
 
-  const relevant = claims.filter(({ index }) => !pendingIndices.has(index))
-  const totalAmount = relevant.reduce((acc, claim) => {
+  const totalAmount = claims.reduce((acc, claim) => {
+    // don't add pending
+    if (pendingIndices.has(claim.index)) return acc
+
     return JSBI.add(acc, JSBI.BigInt(claim.amount))
   }, JSBI.BigInt('0'))
 


### PR DESCRIPTION
# Summary

Adding on David's PR #2049, this change will exclude pending claims from the unclaimed amount calculation with the new `useUserUnclaimedCurrentAmount` hook so that in claim page UI we have the correct unclaimed amount.