### PR TITLE
Add claim finalized middleware

### DIFF
--- a/src/custom/state/claim/middleware.ts
+++ b/src/custom/state/claim/middleware.ts
@@ -1,0 +1,23 @@
+import { Middleware, isAnyOf } from '@reduxjs/toolkit'
+import { AppState } from 'state'
+import { finalizeTransaction } from '../enhancedTransactions/actions'
+
+const isFinalizeTransaction = isAnyOf(finalizeTransaction)
+
+// On each Pending, Expired, Fulfilled order action a corresponding sound is dispatched
+export const claimMinedMiddleware: Middleware<Record<string, unknown>, AppState> = (store) => (next) => (action) => {
+  const result = next(action)
+
+  if (isFinalizeTransaction(action)) {
+    const { chainId, hash, receipt, safeTransaction } = action.payload
+    const transaction = store.getState().transactions[chainId][hash]
+
+    console.log('[stat:claim:middleware] Transaction finalized', transaction, receipt, safeTransaction)
+    if (transaction.claim) {
+      // TODO: Update state
+      console.log('[stat:claim:middleware] It is a CLAIM transaction')
+    }
+  }
+
+  return result
+}

--- a/src/custom/state/index.ts
+++ b/src/custom/state/index.ts
@@ -26,6 +26,7 @@ import enhancedTransactions from 'state/enhancedTransactions/reducer'
 import claim from 'state/claim/reducer'
 
 import { popupMiddleware, soundMiddleware } from './orders/middleware'
+import { claimMinedMiddleware } from './claim/middleware'
 import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
 
 const UNISWAP_REDUCERS = {
@@ -65,6 +66,7 @@ const store = configureStore({
       .concat(routingApi.middleware)
       .concat(save({ states: PERSISTED_KEYS, debounce: 1000 }))
       .concat(popupMiddleware)
+      .concat(claimMinedMiddleware)
       .concat(soundMiddleware),
   preloadedState: load({ states: PERSISTED_KEYS, disableWarnings: process.env.NODE_ENV === 'test' }),
 })


### PR DESCRIPTION
# Summary

First PR out of 2 for making sure we transition to the success state once we have claimed.

In this PR I add a middleware that

![image](https://user-images.githubusercontent.com/2352112/149395778-2e544ba3-09a1-419b-b141-eea180cf6313.png)

Next PR will mutate the state

# To Test

1. Open the console, filter by `middleware`
2. Perform a airdrop claiming
3. Once the transaction is mined you should see the message in the screenshot in your console
