### PR TITLE
Update header button and misc styling.

### DIFF
--- a/src/custom/components/CowClaimButton/index.tsx
+++ b/src/custom/components/CowClaimButton/index.tsx
@@ -1,0 +1,100 @@
+import { Trans } from '@lingui/macro'
+import { Dots } from 'components/swap/styleds'
+import styled, { css } from 'styled-components/macro'
+import CowProtocolLogo from 'components/CowProtocolLogo'
+import { useUserHasSubmittedClaim } from 'state/transactions/hooks'
+
+export const Wrapper = styled.div<{ isClaimPage?: boolean | null }>`
+  ${({ theme }) => theme.card.boxShadow};
+  color: ${({ theme }) => theme.text1};
+  padding: 0 12px;
+  font-size: 15px;
+  font-weight: 500;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  position: relative;
+  border-radius: 12px;
+  pointer-events: auto;
+
+  > b {
+    margin: 0 0 0 5px;
+    color: inherit;
+    font-weight: inherit;
+    white-space: nowrap;
+
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    left: -1px;
+    top: -1px;
+    background: ${({ theme }) =>
+      `linear-gradient(45deg, ${theme.primary1}, ${theme.primary2}, ${theme.primary3}, ${theme.bg4}, ${theme.primary1}, ${theme.primary2})`};
+    background-size: 800%;
+    width: calc(100% + 2px);
+    height: calc(100% + 2px);
+    z-index: -1;
+    animation: glow 50s linear infinite;
+    transition: background-position 0.3s ease-in-out;
+    border-radius: 12px;
+  }
+
+  &::after {
+    filter: blur(8px);
+  }
+
+  &:hover::before,
+  &:hover::after {
+    animation: glow 12s linear infinite;
+  }
+
+  // Stop glowing effect on claim page
+  ${({ isClaimPage }) =>
+    isClaimPage &&
+    css`
+      &::before,
+      &::after {
+        content: none;
+      }
+    `};
+
+  @keyframes glow {
+    0% {
+      background-position: 0 0;
+    }
+    50% {
+      background-position: 300% 0;
+    }
+    100% {
+      background-position: 0 0;
+    }
+  }
+`
+
+interface CowClaimButtonProps {
+  isClaimPage?: boolean | null | undefined
+  account?: string | null | undefined
+  handleOnClickClaim?: () => void
+}
+
+export default function CowClaimButton({ isClaimPage, account, handleOnClickClaim }: CowClaimButtonProps) {
+  const { claimTxn } = useUserHasSubmittedClaim(account ?? undefined)
+
+  return (
+    <Wrapper isClaimPage={isClaimPage} onClick={handleOnClickClaim}>
+      {claimTxn && !claimTxn?.receipt ? (
+        <Dots>
+          <Trans>Claiming vCOW...</Trans>
+        </Dots>
+      ) : (
+        <>
+          <CowProtocolLogo />
+          <b>
+            <Trans>vCOW</Trans>
+          </b>
+        </>
+      )}
+    </Wrapper>
+  )
+}

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -4,7 +4,7 @@ import { SupportedChainId as ChainId } from 'constants/chains'
 import { Dots } from 'components/swap/styleds'
 import Web3Status from 'components/Web3Status'
 import { ExternalLink } from 'theme'
-import { useHistory } from 'react-router-dom'
+import { useHistory, useLocation } from 'react-router-dom'
 
 import HeaderMod, {
   Title,
@@ -23,7 +23,7 @@ import HeaderMod, {
 } from './HeaderMod'
 import Menu from 'components/Menu'
 import { Moon, Sun } from 'react-feather'
-import styled from 'styled-components/macro'
+import styled, { css } from 'styled-components/macro'
 import { useActiveWeb3React } from 'hooks/web3'
 import { useETHBalances } from 'state/wallet/hooks'
 import { AMOUNT_PRECISION } from 'constants/index'
@@ -205,16 +205,77 @@ const UniIcon = styled.div`
   }
 `
 
-const VCowAmount = styled(UNIAmountMod)`
-  ${({ theme }) => theme.cowToken.background};
-  ${({ theme }) => theme.cowToken.boxShadow};
-  color: white;
-  padding: 0 16px;
+const VCowAmount = styled(UNIAmountMod)<{ isClaimPage: boolean }>`
+  ${({ theme }) => theme.card.boxShadow};
+  color: ${({ theme }) => theme.text1};
+  padding: 0 12px;
+  font-size: 15px;
+  font-weight: 500;
+  height: 38px;
   display: flex;
   align-items: center;
+  position: relative;
+  border-radius: 12px;
+
+  > b {
+    margin: 0 0 0 5px;
+    color: inherit;
+    font-weight: inherit;
+  }
+
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    left: -1px;
+    top: -1px;
+    background: ${({ theme }) =>
+      `linear-gradient(45deg, ${theme.primary1}, ${theme.primary2}, ${theme.primary3}, ${theme.bg4}, ${theme.primary1}, ${theme.primary2})`};
+    background-size: 800%;
+    width: calc(100% + 2px);
+    height: calc(100% + 2px);
+    z-index: -1;
+    animation: glow 50s linear infinite;
+    transition: background-position 0.3s ease-in-out;
+    border-radius: 12px;
+  }
+
+  &::after {
+    filter: blur(8px);
+  }
+
+  &:hover::before,
+  &:hover::after {
+    animation: glow 12s linear infinite;
+  }
+
+  // Stop glowing effect on claim page
+  ${({ isClaimPage }) =>
+    isClaimPage &&
+    css`
+      &::before,
+      &::after {
+        content: none;
+      }
+    `};
+
+  @keyframes glow {
+    0% {
+      background-position: 0 0;
+    }
+    50% {
+      background-position: 300% 0;
+    }
+    100% {
+      background-position: 0 0;
+    }
+  }
 `
 
 export default function Header() {
+  const location = useLocation()
+  const isClaimPage = location.pathname === '/claim'
+
   const { account, chainId: connectedChainId } = useActiveWeb3React()
   const chainId = supportedChainId(connectedChainId)
 
@@ -265,7 +326,7 @@ export default function Header() {
           <NetworkCard />
           <HeaderElement>
             <UNIWrapper onClick={handleOnClickClaim}>
-              <VCowAmount active={!!account} style={{ pointerEvents: 'auto' }}>
+              <VCowAmount isClaimPage={isClaimPage} active={!!account} style={{ pointerEvents: 'auto' }}>
                 {claimTxn && !claimTxn?.receipt ? (
                   <Dots>
                     <Trans>Claiming vCOW...</Trans>
@@ -273,11 +334,14 @@ export default function Header() {
                 ) : (
                   <>
                     <CowProtocolLogo />
-                    <Trans>vCOW</Trans>
+                    <b>
+                      <Trans>Claim vCOW</Trans>
+                    </b>
                   </>
                 )}
               </VCowAmount>
             </UNIWrapper>
+
             <AccountElement active={!!account} style={{ pointerEvents: 'auto' }}>
               {account && userEthBalance && (
                 <BalanceText style={{ flexShrink: 0, userSelect: 'none' }} pl="0.75rem" pr="0.5rem" fontWeight={500}>

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -1,7 +1,5 @@
-import { Trans } from '@lingui/macro'
 import { useState, useEffect } from 'react'
 import { SupportedChainId as ChainId } from 'constants/chains'
-import { Dots } from 'components/swap/styleds'
 import Web3Status from 'components/Web3Status'
 import { ExternalLink } from 'theme'
 import { useHistory, useLocation } from 'react-router-dom'
@@ -18,12 +16,11 @@ import HeaderMod, {
   StyledNavLink as StyledNavLinkUni,
   StyledMenuButton,
   HeaderFrame,
-  UNIAmount as UNIAmountMod,
   UNIWrapper,
 } from './HeaderMod'
 import Menu from 'components/Menu'
 import { Moon, Sun } from 'react-feather'
-import styled, { css } from 'styled-components/macro'
+import styled from 'styled-components/macro'
 import { useActiveWeb3React } from 'hooks/web3'
 import { useETHBalances } from 'state/wallet/hooks'
 import { AMOUNT_PRECISION } from 'constants/index'
@@ -43,12 +40,11 @@ import {
   // useToggleSelfClaimModal
 } from 'state/application/hooks'
 //import { useUserHasAvailableClaim } from 'state/claim/hooks'
-import { useUserHasSubmittedClaim } from 'state/transactions/hooks'
 
 import Modal from 'components/Modal'
 // import ClaimModal from 'components/claim/ClaimModal'
 import UniBalanceContent from 'components/Header/UniBalanceContent'
-import CowProtocolLogo from 'components/CowProtocolLogo'
+import CowClaimButton from 'components/CowClaimButton'
 
 export const NETWORK_LABELS: { [chainId in ChainId]?: string } = {
   [ChainId.RINKEBY]: 'Rinkeby',
@@ -205,71 +201,10 @@ const UniIcon = styled.div`
   }
 `
 
-const VCowAmount = styled(UNIAmountMod)<{ isClaimPage: boolean }>`
-  ${({ theme }) => theme.card.boxShadow};
-  color: ${({ theme }) => theme.text1};
-  padding: 0 12px;
-  font-size: 15px;
-  font-weight: 500;
-  height: 38px;
-  display: flex;
-  align-items: center;
-  position: relative;
-  border-radius: 12px;
-
-  > b {
-    margin: 0 0 0 5px;
-    color: inherit;
-    font-weight: inherit;
-  }
-
-  &::before,
-  &::after {
-    content: '';
-    position: absolute;
-    left: -1px;
-    top: -1px;
-    background: ${({ theme }) =>
-      `linear-gradient(45deg, ${theme.primary1}, ${theme.primary2}, ${theme.primary3}, ${theme.bg4}, ${theme.primary1}, ${theme.primary2})`};
-    background-size: 800%;
-    width: calc(100% + 2px);
-    height: calc(100% + 2px);
-    z-index: -1;
-    animation: glow 50s linear infinite;
-    transition: background-position 0.3s ease-in-out;
-    border-radius: 12px;
-  }
-
-  &::after {
-    filter: blur(8px);
-  }
-
-  &:hover::before,
-  &:hover::after {
-    animation: glow 12s linear infinite;
-  }
-
-  // Stop glowing effect on claim page
-  ${({ isClaimPage }) =>
-    isClaimPage &&
-    css`
-      &::before,
-      &::after {
-        content: none;
-      }
-    `};
-
-  @keyframes glow {
-    0% {
-      background-position: 0 0;
-    }
-    50% {
-      background-position: 300% 0;
-    }
-    100% {
-      background-position: 0 0;
-    }
-  }
+const VCowWrapper = styled(UNIWrapper)`
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    display: none;
+  `}
 `
 
 export default function Header() {
@@ -285,7 +220,6 @@ export default function Header() {
 
   // const toggleClaimModal = useToggleSelfClaimModal()
   // const availableClaim: boolean = useUserHasAvailableClaim(account)
-  const { claimTxn } = useUserHasSubmittedClaim(account ?? undefined)
   const [showUniBalanceModal, setShowUniBalanceModal] = useState(false)
   // const showClaimPopup = useShowClaimPopup()
 
@@ -325,22 +259,9 @@ export default function Header() {
         <HeaderControls>
           <NetworkCard />
           <HeaderElement>
-            <UNIWrapper onClick={handleOnClickClaim}>
-              <VCowAmount isClaimPage={isClaimPage} active={!!account} style={{ pointerEvents: 'auto' }}>
-                {claimTxn && !claimTxn?.receipt ? (
-                  <Dots>
-                    <Trans>Claiming vCOW...</Trans>
-                  </Dots>
-                ) : (
-                  <>
-                    <CowProtocolLogo />
-                    <b>
-                      <Trans>Claim vCOW</Trans>
-                    </b>
-                  </>
-                )}
-              </VCowAmount>
-            </UNIWrapper>
+            <VCowWrapper>
+              <CowClaimButton isClaimPage={isClaimPage} account={account} handleOnClickClaim={handleOnClickClaim} />
+            </VCowWrapper>
 
             <AccountElement active={!!account} style={{ pointerEvents: 'auto' }}>
               {account && userEthBalance && (
@@ -361,7 +282,7 @@ export default function Header() {
               {darkMode ? <Moon size={20} /> : <Sun size={20} />}
             </StyledMenuButton>
           </HeaderElementWrap>
-          <Menu darkMode={darkMode} toggleDarkMode={toggleDarkMode} />
+          <Menu isClaimPage={isClaimPage} darkMode={darkMode} toggleDarkMode={toggleDarkMode} />
         </HeaderControls>
         {isOrdersPanelOpen && <OrdersPanel closeOrdersPanel={closeOrdersPanel} />}
       </HeaderModWrapper>

--- a/src/custom/components/Menu/index.tsx
+++ b/src/custom/components/Menu/index.tsx
@@ -1,5 +1,4 @@
 import { Code, HelpCircle, BookOpen, PieChart, Moon, Sun, Repeat, Star, User, ExternalLink } from 'react-feather'
-import { Trans } from '@lingui/macro'
 
 import MenuMod, {
   MenuItem,
@@ -7,7 +6,6 @@ import MenuMod, {
   MenuFlyout as MenuFlyoutUni,
   MenuItemBase,
   StyledMenuButton,
-  UNIbutton,
 } from './MenuMod'
 import { useToggleModal } from 'state/application/hooks'
 import styled from 'styled-components/macro'
@@ -20,6 +18,8 @@ import ninjaCowImage from 'assets/cow-swap/ninja-cow.png'
 import { ApplicationModal } from 'state/application/actions'
 import { getExplorerAddressLink } from 'utils/explorer'
 import { useHasOrders } from 'api/gnosisProtocol/hooks'
+import { useHistory } from 'react-router-dom'
+import CowClaimButton, { Wrapper as ClaimButtonWrapper } from 'components/CowClaimButton'
 
 import twitterImage from 'assets/cow-swap/twitter.svg'
 import discordImage from 'assets/cow-swap/discord.svg'
@@ -31,7 +31,7 @@ const ResponsiveInternalMenuItem = styled(InternalMenuItem)`
   display: none;
 
   ${({ theme }) => theme.mediaWidth.upToMedium`
-      display: flex;   
+      display: flex;
   `};
 `
 
@@ -57,7 +57,7 @@ const MenuItemResponsive = styled(MenuItemResponsiveBase)`
   }
 `
 
-export const StyledMenu = styled(MenuMod)`
+export const StyledMenu = styled(MenuMod)<{ isClaimPage: boolean }>`
   hr {
     margin: 15px 0;
   }
@@ -97,9 +97,58 @@ export const StyledMenu = styled(MenuMod)`
     padding: 0 6px 0 0;
   }
 
+  ${ClaimButtonWrapper} {
+    margin: 0 0 12px;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      margin: 0 12px 12px;
+      width: 100%;
+      height: 56px;
+      justify-content: center;
+      font-size: 19px;
+
+      > span {
+        height: 30px;
+        width: 30px;
+        border-radius: 30px;
+        margin: 0 5px 0 0;
+      }
+    `}
+  }
+
   ${StyledMenuButton} {
     height: 38px;
+    border-radius: 12px;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+          &::before,
+    &::after {
+      content: '';
+      position: absolute;
+      left: -1px;
+      top: -1px;
+      background: ${({ theme }) =>
+        `linear-gradient(45deg, ${theme.primary1}, ${theme.primary2}, ${theme.primary3}, ${theme.bg4}, ${theme.primary1}, ${theme.primary2})`};
+      background-size: 800%;
+      width: calc(100% + 2px);
+      height: calc(100% + 2px);
+      z-index: -1;
+      animation: glow 50s linear infinite;
+      transition: background-position 0.3s ease-in-out;
+      border-radius: 12px;
+    }
+
+    &::after {
+      filter: blur(8px);
+    }
+
+    &:hover::before,
+    &:hover::after {
+      animation: glow 12s linear infinite;
+    }
   }
+
+  `};
 `
 
 const Policy = styled(InternalMenuItem).attrs((attrs) => ({
@@ -123,10 +172,9 @@ const MenuFlyout = styled(MenuFlyoutUni)`
     width: 100%;
     border-radius: 0;
     box-shadow: none;
-    padding: 0;
     overflow-y: auto;
     flex-flow: row wrap;
-    padding: 0 0 56px;
+    padding: 12px 0 100px;
     align-items: flex-start;
     align-content: flex-start;
   `};
@@ -193,14 +241,16 @@ export const CloseMenu = styled.button`
   border-radius: 6px;
   justify-content: center;
   padding: 0;
-  margin: 0 0 8px;
+  margin: 8px 0 0;
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
     height: 56px;
     border-radius: 0;
-    justify-content: flex-end;
     margin: 0;
     width: 100%;
+    position: fixed;
+    bottom: 0;
+    top: initial;
   `};
 
   &::after {
@@ -219,21 +269,26 @@ export const CloseMenu = styled.button`
 interface MenuProps {
   darkMode: boolean
   toggleDarkMode: () => void
+  isClaimPage: boolean
 }
 
-export function Menu({ darkMode, toggleDarkMode }: MenuProps) {
-  const close = useToggleModal(ApplicationModal.MENU)
+export function Menu({ darkMode, toggleDarkMode, isClaimPage }: MenuProps) {
   const { account, chainId } = useActiveWeb3React()
   const hasOrders = useHasOrders(account)
   const showOrdersLink = account && hasOrders
-
-  const openClaimModal = useToggleModal(ApplicationModal.ADDRESS_CLAIM)
-  const showUNIClaimOption = Boolean(!!account && !!chainId)
+  /* const showVCOWClaimOption = Boolean(!!account && !!chainId) */
+  const close = useToggleModal(ApplicationModal.MENU)
+  const history = useHistory()
+  const handleOnClickClaim = () => {
+    close()
+    history.push('/claim')
+  }
 
   return (
-    <StyledMenu>
+    <StyledMenu isClaimPage={isClaimPage}>
       <MenuFlyout>
-        <CloseMenu onClick={close} />
+        <CowClaimButton isClaimPage={isClaimPage} handleOnClickClaim={handleOnClickClaim} />
+
         <ResponsiveInternalMenuItem to="/" onClick={close}>
           <Repeat size={14} /> Swap
         </ResponsiveInternalMenuItem>
@@ -266,6 +321,9 @@ export function Menu({ darkMode, toggleDarkMode }: MenuProps) {
             Code
           </span>
         </MenuItem>
+
+        <Separator />
+
         <MenuItem id="link" href={DISCORD_LINK}>
           <span aria-hidden="true" onClick={close} onKeyDown={close}>
             <SVG src={discordImage} description="Find CowSwap on Discord!" />
@@ -278,6 +336,8 @@ export function Menu({ darkMode, toggleDarkMode }: MenuProps) {
             <SVG src={twitterImage} description="Follow CowSwap on Twitter!" /> Twitter
           </span>
         </MenuItem>
+
+        <Separator />
 
         <InternalMenuItem to="/play/mev-slicer" onClick={close}>
           <span role="img" aria-label="Play CowGame">
@@ -313,8 +373,6 @@ export function Menu({ darkMode, toggleDarkMode }: MenuProps) {
           )}
         </MenuItemResponsive>
 
-        <Separator />
-
         <Policy to="/terms-and-conditions" onClick={close} onKeyDown={close}>
           Terms and conditions
         </Policy>
@@ -322,11 +380,8 @@ export function Menu({ darkMode, toggleDarkMode }: MenuProps) {
         <Policy to="/privacy-policy">Privacy policy</Policy>
         <Policy to="/cookie-policy">Cookie policy</Policy> 
         */}
-        {showUNIClaimOption && (
-          <UNIbutton onClick={openClaimModal} padding="8px 16px" width="100%" $borderRadius="12px" mt="0.5rem">
-            <Trans>Claim vCOW</Trans>
-          </UNIbutton>
-        )}
+
+        <CloseMenu onClick={close} />
       </MenuFlyout>
     </StyledMenu>
   )

--- a/src/custom/components/TransactionConfirmationModal/index.tsx
+++ b/src/custom/components/TransactionConfirmationModal/index.tsx
@@ -205,8 +205,6 @@ const StepsIconWrapper = styled.div`
   --circle-size: 65px;
   --border-radius: 100%;
   --border-size: 2px;
-  --border-bg: conic-gradient(${({ theme }) => theme.bg3} 40grad, 80grad, ${({ theme }) => theme.primary1} 360grad);
-
   border-radius: var(--circle-size);
   height: var(--circle-size);
   width: var(--circle-size);
@@ -265,8 +263,8 @@ const StepsWrapper = styled.div`
     ${StepsIconWrapper} {
       &::before {
         content: '';
+        ${({ theme }) => theme.iconGradientBorder};
         display: block;
-        background: var(--border-bg);
         width: var(--circle-size);
         padding: 0;
         position: absolute;

--- a/src/custom/pages/Claim/CanUserClaimMessage.tsx
+++ b/src/custom/pages/Claim/CanUserClaimMessage.tsx
@@ -24,7 +24,7 @@ export default function CanUserClaimMessage({ hasClaims, isAirdropOnly }: ClaimI
           <Trans>
             Thank you for being a supporter of CowSwap and the CoW protocol. As an important member of the CowSwap
             Community you may claim vCOW to be used for voting and governance. You can claim your tokens until{' '}
-            <i>[XX-XX-XXXX - XX:XX GMT]</i>
+            <i>XX-XX-XXXX - XX:XX GMT</i>
             <ExternalLink href="https://cow.fi/">Read more about vCOW</ExternalLink>
           </Trans>
         </p>

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -322,10 +322,7 @@ export default function Claim() {
                     </th>
                     <th>Type of Claim</th>
                     <th>Amount</th>
-                    <th>Price</th>
-                    <th>Cost</th>
-                    <th>Vesting</th>
-                    <th>Ends in</th>
+                    <th>Details</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -354,10 +351,21 @@ export default function Claim() {
                         <td width="150px">
                           <CowProtocolLogo size={16} /> {parsedAmount?.toFixed(0, { groupSeparator: ',' })} vCOW
                         </td>
-                        <td>{isFree ? '-' : `${vCowPrice} vCoW per ${currency}`}</td>
-                        <td>{isFree ? <span className="green">Free!</span> : `${cost} ${currency}`}</td>
-                        <td>{type === ClaimType.Airdrop ? 'No' : '4 years (linear)'}</td>
-                        <td>28 days, 10h, 50m</td>
+
+                        <td>
+                          <span>
+                            Price: <b>{isFree ? '-' : `${vCowPrice} vCoW per ${currency}`}</b>
+                          </span>
+                          <span>
+                            Cost: <b>{isFree ? <span className="green">Free!</span> : `${cost} ${currency}`}</b>
+                          </span>
+                          <span>
+                            Vesting: <b>{type === ClaimType.Airdrop ? 'No' : '4 years (linear)'}</b>
+                          </span>
+                          <span>
+                            Ends in: <b>28 days, 10h, 50m</b>
+                          </span>
+                        </td>
                       </tr>
                     )
                   })}

--- a/src/custom/pages/Claim/styled.ts
+++ b/src/custom/pages/Claim/styled.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components/macro'
 import { CheckCircle, Frown } from 'react-feather'
 import { Icon } from 'components/CowProtocolLogo'
 import { ButtonPrimary, ButtonSecondary } from 'components/Button'
+import { transparentize } from 'polished'
 
 export const PageWrapper = styled.div`
   --color-tl: #141722;
@@ -12,6 +13,7 @@ export const PageWrapper = styled.div`
   --color-container-bg2: rgb(255 255 255 / 12%);
   --color-container-bg3: rgb(255 255 255 / 25%);
   --border-radius: 56px;
+  --border-radius-small: 16px;
 
   display: flex;
   flex-flow: column wrap;
@@ -24,8 +26,12 @@ export const PageWrapper = styled.div`
   box-shadow: ${({ theme }) => theme.appBody.boxShadow};
   background: ${({ theme }) => theme.bg1};
 
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    border-radius: var(--border-radius-small);
+  `};
+
   a {
-    color: ${({ theme }) => theme.primary1};
+    color: ${({ theme }) => theme.primary4};
   }
 
   p {
@@ -64,7 +70,7 @@ export const PageWrapper = styled.div`
 
   ${ButtonSecondary} {
     background: 0;
-    color: ${({ theme }) => theme.primary1};
+    color: ${({ theme }) => theme.primary4};
     border: none;
 
     &:hover {
@@ -72,7 +78,8 @@ export const PageWrapper = styled.div`
       box-shadow: none;
       transform: none;
       background: 0;
-      color: inherit;
+      color: ${({ theme }) => theme.primary4};
+      text-decoration: underline;
     }
   }
 `
@@ -121,6 +128,12 @@ export const IntroDescription = styled.div<{ center?: boolean }>`
 
   > p {
     margin: 8px auto 24px;
+  }
+
+  > p > i {
+    color: ${({ theme }) => theme.text1};
+    font-weight: 600;
+    font-style: normal;
   }
 
   > button {
@@ -229,6 +242,7 @@ export const ClaimTotal = styled.div`
     font-size: 14px;
     font-weight: normal;
     margin: 0 0 2px;
+    opacity: 0.7;
   }
 
   > p {
@@ -246,7 +260,8 @@ export const ConfirmOrLoadingWrapper = styled.div<{ activeBG: boolean }>`
   display: flex;
   flex-direction: column;
   align-items: center;
-  background: linear-gradient(315deg, #000000 0%, #000000 55%, #202020 100%);
+  font-size: 26px;
+  font-weight: 300;
 
   h3 {
     font-size: 26px;
@@ -266,6 +281,7 @@ export const AttemptFooter = styled.div`
 
   > p {
     font-size: 14px;
+    opacity: 0.7;
   }
 `
 
@@ -295,10 +311,11 @@ export const EligibleBanner = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  background: rgba(237, 104, 52, 0.1);
-  color: color: ${({ theme }) => theme.primary1};
+  background: ${({ theme }) => transparentize(0.9, theme.attention)};
+  color: ${({ theme }) => theme.attention};
   text-align: center;
   margin: 0 auto 16px;
+  font-weight: 600;
 `
 
 export const InputField = styled.div`
@@ -408,7 +425,7 @@ export const FooterNavButtons = styled.div`
     transition: color 0.2s ease-in-out;
 
     &:hover {
-      color: color: ${({ theme }) => theme.primary1};
+      color: ${({ theme }) => theme.primary1};
       text-decoration: underline;
     }
 
@@ -497,8 +514,6 @@ export const InvestTokenGroup = styled.div`
   display: flex;
   flex-flow: row;
   width: 100%;
-  background: var(--color-container-bg);
-  border-radius: var(--border-radius);
   padding: 24px;
   margin: 0 0 24px;
   border: 1px solid #3a3a3a;
@@ -607,7 +622,7 @@ export const InvestAvailableBar = styled.div<{ percentage?: number }>`
     content: ${({ percentage }) => (percentage ? `'${percentage}%'` : '0%')};
     display: inline-block;
     font-size: 13px;
-    color: color: ${({ theme }) => theme.primary1};
+    color: ${({ theme }) => theme.primary1};
   }
 `
 

--- a/src/custom/pages/Claim/styled.ts
+++ b/src/custom/pages/Claim/styled.ts
@@ -152,8 +152,8 @@ export const ClaimTable = styled.div`
     display: grid;
     border-collapse: collapse;
     min-width: 100%;
-    font-size: 14px;
-    grid-template-columns: repeat(7, auto);
+    font-size: 16px;
+    grid-template-columns: repeat(4, auto);
   }
 
   thead,
@@ -192,6 +192,28 @@ export const ClaimTable = styled.div`
   tr > td {
     background: var(--color-container-bg);
     margin: 0 0 12px;
+  }
+
+  /* 3rd row - amount */
+  tr > td:nth-of-type(3) {
+    font-size: 21px;
+    font-weight: 500;
+  }
+
+  tr > td:nth-of-type(4) {
+    font-size: 13px;
+    display: flex;
+    flex-flow: column wrap;
+  }
+
+  tr > td:first-of-type {
+    border-top-left-radius: 12px;
+    border-bottom-left-radius: 12px;
+  }
+
+  tr > td:last-of-type {
+    border-top-right-radius: 12px;
+    border-bottom-right-radius: 12px;
   }
 `
 
@@ -320,9 +342,10 @@ export const EligibleBanner = styled.div`
 
 export const InputField = styled.div`
   padding: 18px;
-  border-radius: 16px;
-  border: 1px solid rgba(151, 151, 151, 0.4);
-  background: rgba(151, 151, 151, 0.1);
+  border-radius: var(--border-radius);
+  ${({ theme }) => theme.currencyInput?.color};
+  color: ${({ theme }) => theme.text1};
+  background: ${({ theme }) => theme.currencyInput?.background};
   width: 100%;
   margin: 0 0 24px;
 
@@ -330,20 +353,21 @@ export const InputField = styled.div`
     background: transparent;
     border: 0;
     font-size: 24px;
-    color: ${({ theme }) => theme.text1};
+    color: inherit
     outline: 0;
+    color: ${({ theme }) => theme.text1};
     width: 100%;
   }
 
   > input::placeholder {
-    color: rgba(151, 151, 151, 0.4);
+    color: inherit;
+    opacity: 0.7;
   }
 
   > b {
     display: block;
     margin: 0 0 12px;
     font-weight: normal;
-    color: #979797;
   }
 
   > div {
@@ -375,7 +399,8 @@ export const InputFieldTitle = styled.div`
   align-items: center;
   margin: 0 0 12px;
   font-weight: normal;
-  color: #979797;
+  color: inherit;
+
   > b {
     margin-right: 10px;
   }
@@ -456,7 +481,7 @@ export const TopNav = styled.div`
 export const Demo = styled(ClaimTable)`
   background: #3e0c46;
   > table {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: min-content auto max-content auto;
   }
 
   > table tr td:first-of-type {

--- a/src/custom/theme/baseTheme.tsx
+++ b/src/custom/theme/baseTheme.tsx
@@ -180,6 +180,9 @@ export function themeVariables(darkMode: boolean, colorsTheme: Colors) {
         box-shadow: inset 0 1px 1px 0 hsl(0deg 0% 100% / 10%), 0 10px 40px -20px #000000;
       `,
     },
+    iconGradientBorder: css`
+      background: conic-gradient(${colorsTheme.bg3} 40grad, 80grad, ${colorsTheme.primary1} 360grad);
+    `,
     header: {
       border: 'none',
       menuFlyout: {

--- a/src/custom/theme/styled.d.ts
+++ b/src/custom/theme/styled.d.ts
@@ -85,6 +85,7 @@ declare module 'styled-components' {
       background: FlattenSimpleInterpolation
       boxShadow: FlattenSimpleInterpolation
     },
+    iconGradientBorder: FlattenSimpleInterpolation
     card: {
       background: FlattenSimpleInterpolation
       background2: string


### PR DESCRIPTION
# Summary

- Further styling of initital claim page
- Restyled header claim button. Glowing effect stops when on the `/claim` page (opted for totally removing the claim button when _on_ the claim page, but for consistency purposes I think it's better to keep it at all times).


https://user-images.githubusercontent.com/31534717/149330431-6420cf8c-01bc-48bb-848c-5faaf499008a.mov


https://user-images.githubusercontent.com/31534717/149330450-b7495683-64ab-40d7-932c-d2128d9fb822.mov




Pending
- Further styling
- Mobile responsive solution for claim button in header.

 