### PR TITLE
Change redux store on success claiming

### DIFF
--- a/src/custom/state/claim/middleware.ts
+++ b/src/custom/state/claim/middleware.ts
@@ -1,6 +1,7 @@
 import { Middleware, isAnyOf } from '@reduxjs/toolkit'
 import { AppState } from 'state'
 import { finalizeTransaction } from '../enhancedTransactions/actions'
+import { setClaimStatus, ClaimStatus } from './actions'
 
 const isFinalizeTransaction = isAnyOf(finalizeTransaction)
 
@@ -9,13 +10,12 @@ export const claimMinedMiddleware: Middleware<Record<string, unknown>, AppState>
   const result = next(action)
 
   if (isFinalizeTransaction(action)) {
-    const { chainId, hash, receipt, safeTransaction } = action.payload
+    const { chainId, hash } = action.payload
     const transaction = store.getState().transactions[chainId][hash]
 
-    console.log('[stat:claim:middleware] Transaction finalized', transaction, receipt, safeTransaction)
     if (transaction.claim) {
-      // TODO: Update state
-      console.log('[stat:claim:middleware] It is a CLAIM transaction')
+      console.log('[stat:claim:middleware] Claim transaction finalized', transaction.hash, transaction.claim)
+      store.dispatch(setClaimStatus(ClaimStatus.CONFIRMED))
     }
   }
 

--- a/src/custom/state/claim/middleware.ts
+++ b/src/custom/state/claim/middleware.ts
@@ -5,7 +5,7 @@ import { setClaimStatus, ClaimStatus } from './actions'
 
 const isFinalizeTransaction = isAnyOf(finalizeTransaction)
 
-// On each Pending, Expired, Fulfilled order action a corresponding sound is dispatched
+// Watch for claim tx being finalized and triggers a change of status
 export const claimMinedMiddleware: Middleware<Record<string, unknown>, AppState> = (store) => (next) => (action) => {
   const result = next(action)
 
@@ -14,7 +14,7 @@ export const claimMinedMiddleware: Middleware<Record<string, unknown>, AppState>
     const transaction = store.getState().transactions[chainId][hash]
 
     if (transaction.claim) {
-      console.log('[stat:claim:middleware] Claim transaction finalized', transaction.hash, transaction.claim)
+      console.debug('[stat:claim:middleware] Claim transaction finalized', transaction.hash, transaction.claim)
       store.dispatch(setClaimStatus(ClaimStatus.CONFIRMED))
     }
   }


### PR DESCRIPTION
Just small continuation of https://github.com/gnosis/cowswap/pull/2126

As promise, this one adds the mutation of the state.
If i new it would be so little, i wouldn't have done 2 PRs :) 


![image](https://user-images.githubusercontent.com/2352112/149399936-99643785-b7af-45c9-a1ea-f43417f88ef5.png)

Notes, as expected, the success window show 0 vCOW. I assume is because now it's consumed the opportunity. This should be fixed, but in another PR.

# To Test

1. Same as  https://github.com/gnosis/cowswap/pull/2126
2. Watch for that confeti
