### PR TITLE
WIP: new components and stuff

### DIFF
--- a/src/custom/pages/Claim/InvestmentFlow.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow.tsx
@@ -12,13 +12,14 @@ import {
   TokenLogo,
 } from 'pages/Claim/styled'
 import CowProtocolLogo from 'components/CowProtocolLogo'
-import { useClaimState } from 'state/claim/hooks'
+import { useClaimState, useUserEnhancedClaimData } from 'state/claim/hooks'
 import { ClaimCommonTypes } from './types'
 import { ClaimStatus } from 'state/claim/actions'
 import { useActiveWeb3React } from 'hooks/web3'
 import { ApprovalState } from 'hooks/useApproveCallback'
 import { CheckCircle } from 'react-feather'
 import Row from 'components/Row'
+import { InvestmentTokenGroup } from 'pages/Claim/InvestmentTokenGroup'
 
 type InvestmentFlowProps = Pick<ClaimCommonTypes, 'hasClaims'> & {
   isAirdropOnly: boolean
@@ -35,6 +36,7 @@ export default function InvestmentFlow({
   const { account } = useActiveWeb3React()
 
   const { activeClaimAccount, claimStatus, isInvestFlowActive, investFlowStep } = useClaimState()
+  const claimData = useUserEnhancedClaimData(activeClaimAccount)
 
   if (
     !activeClaimAccount || // no connected account
@@ -69,62 +71,14 @@ export default function InvestmentFlow({
             Your account can participate in the investment of vCOW. Each investment opportunity will allow you to invest
             up to a predefined maximum amount of tokens{' '}
           </p>
-          <InvestTokenGroup>
-            <div>
-              <span>
-                <TokenLogo symbol={'GNO'} size={72} />
-                <CowProtocolLogo size={72} />
-              </span>
-              <h3>Buy vCOW with GNO</h3>
-            </div>
-
-            <span>
-              <InvestSummary>
-                <span>
-                  <b>Price</b> <i>16.66 vCoW per GNO</i>
-                </span>
-                <span>
-                  <b>Token approval</b>
-                  <i>
-                    {approveState === ApprovalState.NOT_APPROVED ? (
-                      'GNO not approved'
-                    ) : (
-                      <Row>
-                        GNO approved <CheckCircle color="lightgreen" style={{ marginLeft: 5 }} />
-                      </Row>
-                    )}
-                  </i>
-                  {approveState === ApprovalState.NOT_APPROVED && (
-                    <button onClick={approveCallback}>Approve GNO</button>
-                  )}
-                </span>
-                <span>
-                  <b>Max. investment available</b> <i>2,500.04 GNO</i>
-                </span>
-                <span>
-                  <b>Available investment used</b> <InvestAvailableBar percentage={50} />
-                </span>
-              </InvestSummary>
-              <InvestInput>
-                <div>
-                  <span>
-                    <b>Balance:</b> <i>10,583.34 GNO</i>
-                    {/* Button should use the max possible amount the user can invest, considering their balance + max investment allowed */}
-                    <button>Invest max. possible</button>
-                  </span>
-                  <label>
-                    <b>GNO</b>
-                    <input placeholder="0" />
-                  </label>
-                  <i>Receive: 32,432.54 vCOW</i>
-                  {/* Insufficient balance validation error */}
-                  <small>
-                    Insufficient balance to invest. Adjust the amount or go back to remove this investment option.
-                  </small>
-                </div>
-              </InvestInput>
-            </span>
-          </InvestTokenGroup>
+          {claimData.map((cd) => (
+            <InvestmentTokenGroup
+              key={cd.index}
+              claim={cd}
+              approveState={approveState}
+              approveCallback={approveCallback}
+            />
+          ))}
 
           <InvestTokenGroup>
             <div>
@@ -207,7 +161,7 @@ export default function InvestmentFlow({
           </p>
           <p>
             <b>Can I modify the invested amounts or invest partial amounts later?</b> No. Once you send the transaction,
-            you cannot increase or reduce the investment. Investment oportunities can only be exercised once.
+            you cannot increase or reduce the investment. Investment opportunities can only be exercised once.
           </p>
         </InvestContent>
       ) : null}

--- a/src/custom/pages/Claim/InvestmentTokenGroup.tsx
+++ b/src/custom/pages/Claim/InvestmentTokenGroup.tsx
@@ -1,0 +1,143 @@
+import { useCallback, useMemo, useState } from 'react'
+import { CheckCircle } from 'react-feather'
+import { CurrencyAmount } from '@uniswap/sdk-core'
+import { formatUnits, parseUnits } from '@ethersproject/units'
+
+import Row from 'components/Row'
+import { InvestAvailableBar, InvestInput, InvestSummary, InvestTokenGroup, TokenLogo } from 'pages/Claim/styled'
+import CowProtocolLogo from 'components/CowProtocolLogo'
+import { ApprovalState } from 'hooks/useApproveCallback'
+import { EnhancedUserClaimData } from 'pages/Claim/types'
+import { formatSmart } from 'utils/format'
+import { FULL_PRICE_PRECISION } from 'constants/index'
+import { useCurrencyBalance } from 'state/wallet/hooks'
+import { useActiveWeb3React } from 'hooks/web3'
+
+export type Props = { claim: EnhancedUserClaimData; approveState: ApprovalState; approveCallback: () => void }
+
+export function InvestmentTokenGroup(props: Props): JSX.Element | null {
+  const { claim, approveCallback, approveState } = props
+
+  const { account } = useActiveWeb3React()
+
+  const { currencyAmount, price, cost: maxCost } = claim
+  const token = currencyAmount?.currency
+
+  const balance = useCurrencyBalance(account || undefined, token)
+
+  // TODO: move it to global state or something
+  const [investmentAmount, setInvestmentAmount] = useState('0')
+
+  const onMaxClick = useCallback(() => {
+    if (!maxCost || !balance) {
+      return
+    }
+
+    const amount = maxCost.greaterThan(balance) ? balance : maxCost
+    // store the value as a string to prevent unnecessary re-renders
+    setInvestmentAmount(formatUnits(amount.quotient.toString(), balance.currency.decimals))
+  }, [balance, maxCost])
+
+  const onInputChange = useCallback(
+    (event) => {
+      // TODO: validate input, etc, etc
+      // TODO: valid number
+      // TODO: 0 or more
+      // TODO: up to min(max balance, max invesment)
+      if (!token || isNaN(+event.target.value)) {
+        return
+      }
+
+      setInvestmentAmount(event.target.value)
+    },
+    [token]
+  )
+
+  const vCowAmount = useMemo(() => {
+    if (!token || !price) {
+      return
+    }
+
+    const investA = CurrencyAmount.fromRawAmount(token, parseUnits(investmentAmount, token.decimals).toString())
+    return investA.multiply(price)
+  }, [investmentAmount, price, token])
+
+  if (!token?.symbol) {
+    // It'll be set by this point, but of course TS is a pain and doesn't know about that
+    // Thus, we go with the nuke option and return null to make it happy
+    return null
+  }
+
+  const symbol = token.symbol
+  const isNative = token.isNative
+
+  return (
+    <InvestTokenGroup>
+      <div>
+        <span>
+          <TokenLogo symbol={symbol} size={72} />
+          <CowProtocolLogo size={72} />
+        </span>
+        <h3>Buy vCOW with {symbol}</h3>
+      </div>
+
+      <span>
+        <InvestSummary>
+          <span>
+            <b>Price</b>{' '}
+            <i>
+              {formatSmart(price, FULL_PRICE_PRECISION)} vCoW per {symbol}
+            </i>
+          </span>
+          <span>
+            <b>Token approval</b>
+            <i>
+              {isNative ? (
+                <Row>
+                  {symbol} doesn&apos;t need approvals <CheckCircle color="lightgreen" style={{ marginLeft: 5 }} />
+                </Row>
+              ) : approveState === ApprovalState.NOT_APPROVED ? (
+                `{symbol} not approved`
+              ) : (
+                <Row>
+                  {symbol} approved <CheckCircle color="lightgreen" style={{ marginLeft: 5 }} />
+                </Row>
+              )}
+            </i>
+            {approveState === ApprovalState.NOT_APPROVED && <button onClick={approveCallback}>Approve {symbol}</button>}
+          </span>
+          <span>
+            <b>Max. investment available</b>{' '}
+            <i>
+              {formatSmart(maxCost) || '0'} {symbol}
+            </i>
+          </span>
+          <span>
+            <b>Available investment used</b> <InvestAvailableBar percentage={50} />
+          </span>
+        </InvestSummary>
+        <InvestInput>
+          <div>
+            <span>
+              <b>Balance:</b>{' '}
+              <i>
+                {formatSmart(balance)} {symbol}
+              </i>
+              {/* Button should use the max possible amount the user can invest, considering their balance + max investment allowed */}
+              <button onClick={onMaxClick}>Invest max. possible</button>
+            </span>
+            <label>
+              <b>{symbol}</b>
+              <input placeholder="0" value={investmentAmount} onChange={onInputChange} />
+            </label>
+            <i>Receive: {formatSmart(vCowAmount) || '0'} vCOW</i>
+            {/* Insufficient balance validation error */}
+            <small>
+              Insufficient balance to invest. Adjust the amount or go back to remove this investment option.
+            </small>
+          </div>
+        </InvestInput>
+      </span>
+    </InvestTokenGroup>
+  )
+}


### PR DESCRIPTION
# Summary

This is still WIP
<img width="721" alt="Screen Shot 2022-01-13 at 16 50 46" src="https://user-images.githubusercontent.com/43217/149432477-3d660ed1-e82b-4ba7-a481-240c8c01708c.png">

Everything is mostly wired.

Missing:
- [ ] Show ETH instead of WETH - maybe that's on token selection
- [ ] Add selected values to global state
- [ ] Make it all nice and fancy

  # To Test

1. <<Step one>> Open the page `about`
- [ ] <<What to expect?>> Verify it contains about information...
- [ ] Checkbox Style list of things a QA person could verify, i.e.
- [ ] Should display Text Input our storybook
- [ ] Input should not accept Numbers
2. <<Step two>> ...

  # Background

Nice accounts which have all 3 paid claims for you to observe and enjoy:
-  0xD5e900280Eb1aDe4E583c2bF2414be247E298435
-  0x7946Fce94A2350a1076a8F97105262c9E07e2a9d
-  0xd46C95581Ac035Bc10D80DD2a121D444e63C2E24
-  0xe93BDEe77cea1aFa9c891C78dca51A16fA287630
-  0x0280a0D231bc48B6A5EcEc3E1dc653Aae6abFf29
-  0x7E5966fFfa6092c6A9b4685A61969C44fa77C18A
-  0xA624B88Bb6A2e752fbe590266a56B940D0206cA4
-  0xa6Caab2e5b5cB306af5ee06a3E4d3b56d9D3B73e
-  0xd0ef9fD6b5795DF8add90E1dc0A16D66e2C5C1E6
-  0x2C8CbbbfEB7E116Cc27e7Ac6cC44958427D0bBA2
-  0xb04d950C9146BAd8263677A2A8DD0Ebd096Fab17
-  0xcc32131FdB8345996402e816B91A85cDf033f017
-  0xE568be91c612302E049F3A7c52Aec76E77E8DBB6
-  0xF507BD42B239E805d4Fa5551D82577D9113830a3
-  0xAbc20633c1c375854251daec0b13033da5D3949d
-  0x34FB768EB3941F308a08526C7d9ec4587291E26a
-  0x69EB8bcEf34c2Fac01ae054B1A77E6b3689e4730
-  0xB15bFBF5E4A111f1dC54546D35221065F12CC285
-  0x912b14277279156dd1f2501B0900982fA04f02D1
-  0xC387532B652C0FeA259Ed4272754c5C0F969aA24

