### PR TITLE
[Claim] Fixes Claimtable pending highlight (lost in merge) + fixes transaction summary

### DIFF
--- a/src/custom/hooks/useApproveCallback/index.ts
+++ b/src/custom/hooks/useApproveCallback/index.ts
@@ -32,6 +32,10 @@ export function useApproveCallbackFromTrade(
   return useApproveCallback(openTransactionConfirmationModal, closeModals, amountToApprove, vaultRelayer)
 }
 
+export type OptionalApproveCallbackParams = {
+  transactionSummary: string
+}
+
 export function useApproveCallbackFromClaim(
   openTransactionConfirmationModal: (message: string) => void,
   closeModals: () => void,

--- a/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
@@ -75,13 +75,13 @@ export default function InvestOption({ approveData, updateInvestAmount, claim }:
     try {
       // for pending state pre-BC
       setApproving(true)
-      await approveCallback()
+      await approveCallback({ transactionSummary: `Approve ${token?.symbol || 'token'} for investing in vCOW` })
     } catch (error) {
       console.error('[InvestOption]: Issue approving.', error)
     } finally {
       setApproving(false)
     }
-  }, [approveCallback])
+  }, [approveCallback, token?.symbol])
 
   const vCowAmount = useMemo(() => {
     if (!token || !price) {

--- a/src/custom/pages/Claim/InvestmentFlow/index.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/index.tsx
@@ -11,7 +11,7 @@ import { ClaimType, useClaimState, useUserEnhancedClaimData } from 'state/claim/
 import { ClaimCommonTypes, EnhancedUserClaimData } from '../types'
 import { ClaimStatus } from 'state/claim/actions'
 import { useActiveWeb3React } from 'hooks/web3'
-import { ApprovalState } from 'hooks/useApproveCallback'
+import { ApprovalState, OptionalApproveCallbackParams } from 'hooks/useApproveCallback'
 import InvestOption from './InvestOption'
 
 export type InvestmentClaimProps = EnhancedUserClaimData & {
@@ -21,7 +21,9 @@ export type InvestmentClaimProps = EnhancedUserClaimData & {
 export type InvestOptionProps = {
   claim: InvestmentClaimProps
   updateInvestAmount: (idx: number, investAmount: string) => void
-  approveData: { approveState: ApprovalState; approveCallback: () => void } | undefined
+  approveData:
+    | { approveState: ApprovalState; approveCallback: (optionalParams?: OptionalApproveCallbackParams) => void }
+    | undefined
 }
 
 type InvestmentFlowProps = Pick<ClaimCommonTypes, 'hasClaims'> & {

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -271,8 +271,7 @@ export function useUserClaims(account: Account): UserClaims | null {
 const createMockTx = (data: number[]) => ({
   hash: '0x' + Math.round(Math.random() * 10).toString() + 'AxAFjAhG89G89AfnLK3CCxAfnLKQffQ782G89AfnLK3CCxxx123FF',
   summary: `Claimed ${Math.random() * 3337} vCOW`,
-  claim: { recipient: '0x97EC4fcD5F78cA6f6E4E1EAC6c0Ec8421bA518B7' },
-  data, // add the claim indices to state
+  claim: { recipient: '0x97EC4fcD5F78cA6f6E4E1EAC6c0Ec8421bA518B7', indices: data },
 })
 
 /**
@@ -446,8 +445,7 @@ export function useClaimCallback(account: string | null | undefined): {
           addTransaction({
             hash: response.hash,
             summary: `Claimed ${formatSmart(vCowAmount)} vCOW`,
-            claim: { recipient: account },
-            data: args[0], // add the claim indices to state
+            claim: { recipient: account, indices: args[0] as number[] },
           })
           return response.hash
         })

--- a/src/custom/state/enhancedTransactions/hooks/index.ts
+++ b/src/custom/state/enhancedTransactions/hooks/index.ts
@@ -131,9 +131,9 @@ export function useAllClaimingTransactions() {
 export function useAllClaimingTransactionIndices() {
   const claimingTransactions = useAllClaimingTransactions()
   return useMemo(() => {
-    const flattenedClaimingTransactions = claimingTransactions.reduce<number[]>((acc, { data }) => {
-      if (data) {
-        acc.push(...data)
+    const flattenedClaimingTransactions = claimingTransactions.reduce<number[]>((acc, { claim }) => {
+      if (claim) {
+        acc.push(...claim.indices)
       }
       return acc
     }, [])

--- a/src/custom/state/enhancedTransactions/reducer.ts
+++ b/src/custom/state/enhancedTransactions/reducer.ts
@@ -35,7 +35,7 @@ export interface EnhancedTransactionDetails {
   // Operations
   approval?: { tokenAddress: string; spender: string }
   presign?: { orderId: string }
-  claim?: { recipient: string; cowAmountRaw?: string }
+  claim?: { recipient: string; cowAmountRaw?: string; indices: number[] }
 
   // Wallet specific
   safeTransaction?: SafeMultisigTransactionResponse // Gnosis Safe transaction info


### PR DESCRIPTION
# Summary

1. Adds an OPTIONAL param to useApproveCallback to allow us custom `transactionSummary` as seen below:
![image](https://user-images.githubusercontent.com/21335563/149577893-3034444e-9dce-4073-8ac5-dd171a48dcb0.png)
2. Fixes the styled highlighting of "pending" claims that was lost in a merge to `claim` 
3. `claims` prop in `redux` now gets `indices` prop which is passed the current claiming `indices` properly