### PR TITLE
2120/claim countdowns

### DIFF
--- a/src/custom/pages/Claim/ClaimsTable.tsx
+++ b/src/custom/pages/Claim/ClaimsTable.tsx
@@ -1,5 +1,11 @@
+import {
+  ClaimType,
+  useAirdropDeadline,
+  useClaimState,
+  useDeploymentTimestamp,
+  useInvestmentDeadline,
+} from 'state/claim/hooks'
 import styled from 'styled-components/macro'
-import { ClaimType, useClaimState } from 'state/claim/hooks'
 import { ClaimTable, ClaimBreakdown, TokenLogo } from 'pages/Claim/styled'
 import CowProtocolLogo from 'components/CowProtocolLogo'
 import { ClaimStatus } from 'state/claim/actions'
@@ -9,6 +15,7 @@ import { EnhancedUserClaimData } from './types'
 import { useAllClaimingTransactionIndices } from 'state/enhancedTransactions/hooks'
 import { CustomLightSpinner } from 'theme'
 import Circle from 'assets/images/blue-loader.svg'
+import { Countdown } from 'pages/Claim/Countdown'
 
 type ClaimsTableProps = {
   handleSelectAll: (event: React.ChangeEvent<HTMLInputElement>) => void
@@ -22,6 +29,8 @@ type ClaimsTableProps = {
 type ClaimsTableRowProps = EnhancedUserClaimData &
   Pick<ClaimsTableProps, 'handleSelect'> & {
     selected: number[]
+    start: number | null
+    end: number | null
     isPendingClaim: boolean
   }
 
@@ -50,6 +59,8 @@ const ClaimsTableRow = ({
   cost,
   handleSelect,
   selected,
+  start,
+  end,
 }: ClaimsTableRowProps) => {
   return (
     <ClaimTr key={index} isPending={isPendingClaim}>
@@ -99,7 +110,7 @@ const ClaimsTableRow = ({
           Vesting: <b>{type === ClaimType.Airdrop ? 'No' : '4 years (linear)'}</b>
         </span>
         <span>
-          Ends in: <b>28 days, 10h, 50m</b>
+          Ends in: <b>{start && end && <Countdown start={start} end={end} />}</b>
         </span>
       </td>
     </ClaimTr>
@@ -118,6 +129,10 @@ export default function ClaimsTable({
 
   const hideTable =
     isAirdropOnly || !hasClaims || !activeClaimAccount || claimStatus !== ClaimStatus.DEFAULT || isInvestFlowActive
+
+  const start = useDeploymentTimestamp()
+  const investmentEnd = useInvestmentDeadline()
+  const airdropEnd = useAirdropDeadline()
 
   if (hideTable) return null
 
@@ -146,6 +161,8 @@ export default function ClaimsTable({
                 isPendingClaim={pendingClaimsSet.has(claim.index)}
                 selected={selected}
                 handleSelect={handleSelect}
+                start={start}
+                end={claim.isFree ? airdropEnd : investmentEnd}
               />
             ))}
           </tbody>

--- a/src/custom/pages/Claim/Countdown.tsx
+++ b/src/custom/pages/Claim/Countdown.tsx
@@ -1,8 +1,6 @@
 // Sort of a mod of but not quite from src/pages/Earn/Countdown.tsx
 import { useEffect, useState } from 'react'
 
-import { TYPE } from 'theme'
-
 const MINUTE = 60
 const HOUR = MINUTE * 60
 const DAY = HOUR * 24
@@ -62,14 +60,8 @@ export function Countdown({ start, end }: Props) {
   }
 
   return (
-    <TYPE.black fontWeight={400}>
-      {Number.isFinite(timeRemaining) && (
-        <code>
-          {`${days} days, ${hours.toString().padStart(2, '0')}h, ${minutes.toString().padStart(2, '0')}m, ${seconds
-            .toString()
-            .padStart(2, '0')}s`}
-        </code>
-      )}
-    </TYPE.black>
+    <>{`${days} days, ${hours.toString().padStart(2, '0')}h, ${minutes.toString().padStart(2, '0')}m, ${seconds
+      .toString()
+      .padStart(2, '0')}s`}</>
   )
 }

--- a/src/custom/pages/Claim/Countdown.tsx
+++ b/src/custom/pages/Claim/Countdown.tsx
@@ -65,9 +65,9 @@ export function Countdown({ start, end }: Props) {
     <TYPE.black fontWeight={400}>
       {Number.isFinite(timeRemaining) && (
         <code>
-          {`${days}:${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds
+          {`${days} days, ${hours.toString().padStart(2, '0')}h, ${minutes.toString().padStart(2, '0')}m, ${seconds
             .toString()
-            .padStart(2, '0')}`}
+            .padStart(2, '0')}s`}
         </code>
       )}
     </TYPE.black>

--- a/src/custom/pages/Claim/Countdown.tsx
+++ b/src/custom/pages/Claim/Countdown.tsx
@@ -55,13 +55,13 @@ export function Countdown({ start, end }: Props) {
   timeRemaining -= minutes * MINUTE
   const seconds = timeRemaining
 
-  if (!Number.isFinite(timeRemaining)) {
-    return null
-  }
-
   return (
-    <>{`${days} days, ${hours.toString().padStart(2, '0')}h, ${minutes.toString().padStart(2, '0')}m, ${seconds
-      .toString()
-      .padStart(2, '0')}s`}</>
+    <>
+      {Number.isFinite(timeRemaining)
+        ? `${days} days, ${hours.toString().padStart(2, '0')}h, ${minutes.toString().padStart(2, '0')}m, ${seconds
+            .toString()
+            .padStart(2, '0')}s`
+        : 'No longer claimable'}
+    </>
   )
 }

--- a/src/custom/pages/Claim/Countdown.tsx
+++ b/src/custom/pages/Claim/Countdown.tsx
@@ -1,0 +1,75 @@
+// Sort of a mod of but not quite from src/pages/Earn/Countdown.tsx
+import { useEffect, useState } from 'react'
+
+import { TYPE } from 'theme'
+
+const MINUTE = 60
+const HOUR = MINUTE * 60
+const DAY = HOUR * 24
+
+export type Props = {
+  start: number
+  end: number
+}
+
+/**
+ * Copied over from src/pages/Earn/Countdown.tsx and heavily modified it
+ *
+ * If current time is past end time, returns null
+ *
+ * @param start start time in ms
+ * @param end end time in ms
+ */
+export function Countdown({ start, end }: Props) {
+  // get current time, store as seconds because 🤷
+  const [time, setTime] = useState(() => Math.floor(Date.now() / 1000))
+
+  useEffect((): (() => void) | void => {
+    // we only need to tick if not ended yet
+    if (time <= end / 1000) {
+      const timeout = setTimeout(() => setTime(Math.floor(Date.now() / 1000)), 1000)
+      return () => {
+        clearTimeout(timeout)
+      }
+    }
+  }, [time, end])
+
+  const timeUntilGenesis = start / 1000 - time
+  const timeUntilEnd = end / 1000 - time
+
+  let timeRemaining: number
+  if (timeUntilGenesis >= 0) {
+    timeRemaining = timeUntilGenesis
+  } else {
+    const ongoing = timeUntilEnd >= 0
+    if (ongoing) {
+      timeRemaining = timeUntilEnd
+    } else {
+      timeRemaining = Infinity
+    }
+  }
+
+  const days = (timeRemaining - (timeRemaining % DAY)) / DAY
+  timeRemaining -= days * DAY
+  const hours = (timeRemaining - (timeRemaining % HOUR)) / HOUR
+  timeRemaining -= hours * HOUR
+  const minutes = (timeRemaining - (timeRemaining % MINUTE)) / MINUTE
+  timeRemaining -= minutes * MINUTE
+  const seconds = timeRemaining
+
+  if (!Number.isFinite(timeRemaining)) {
+    return null
+  }
+
+  return (
+    <TYPE.black fontWeight={400}>
+      {Number.isFinite(timeRemaining) && (
+        <code>
+          {`${days}:${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds
+            .toString()
+            .padStart(2, '0')}`}
+        </code>
+      )}
+    </TYPE.black>
+  )
+}

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -282,7 +282,7 @@ const createMockTx = (data: number[]) => ({
  *
  * Returns null if in there's no network or vCowContract doesn't exist
  */
-function useDeploymentTimestamp(): number | null {
+export function useDeploymentTimestamp(): number | null {
   const { chainId } = useActiveWeb3React()
   const vCowContract = useVCowContract()
   const [timestamp, setTimestamp] = useState<number | null>(null)


### PR DESCRIPTION
# Summary

Closes #2120 

Wiring up the countdown in the Claim table

<img width="721" alt="Screen Shot 2022-01-14 at 12 09 56" src="https://user-images.githubusercontent.com/43217/149578800-82a1f3a2-2a35-4f97-a8e7-97ff30f10e71.png">

Seconds is a bonus that I can remove if it doesn't look good.

Anywhere else we should have a countdown?

  # To Test

1. Check an address which has claims
* Watch the count going down

  # Background

*Optional: Give background information for changes you've made, that might be difficult to explain via comments*

