### PR TITLE
Fixing assumption regarding data format stored on redux

### DIFF
--- a/src/custom/state/enhancedTransactions/hooks/index.ts
+++ b/src/custom/state/enhancedTransactions/hooks/index.ts
@@ -132,7 +132,7 @@ export function useAllClaimingTransactionIndices() {
   const claimingTransactions = useAllClaimingTransactions()
   return useMemo(() => {
     const flattenedClaimingTransactions = claimingTransactions.reduce<number[]>((acc, { claim }) => {
-      if (claim) {
+      if (claim && claim.indices) {
         acc.push(...claim.indices)
       }
       return acc


### PR DESCRIPTION
# Summary

Fixing this hard crash on claim

<img width="935" alt="Screen Shot 2022-01-14 at 14 29 28" src="https://user-images.githubusercontent.com/43217/149598988-9d33c7c8-ac8b-464c-bd44-2bb641ebc41f.png">

Hook assumes data will have `indices` key, which is not true for data created before this change was introduced.

  # To Test

1. Open the app on claim page
* It should not crash

**Note** It would only crash if you had performed a claim before, so not likely it'll affect everyone, and only moving forward.
Anyway, nice to check that to be safe