### PR TITLE
Fix free claims

### DIFF
--- a/src/custom/pages/Claim/ClaimsTable.tsx
+++ b/src/custom/pages/Claim/ClaimsTable.tsx
@@ -90,8 +90,6 @@ const ClaimsTableRow = ({
           Ends in: <b>28 days, 10h, 50m</b>
         </span>
       </td>
-      <td>{type === ClaimType.Airdrop ? 'No' : '4 years (linear)'}</td>
-      <td>28 days, 10h, 50m</td>
     </ClaimTr>
   )
 }

--- a/src/custom/pages/Claim/types.ts
+++ b/src/custom/pages/Claim/types.ts
@@ -12,9 +12,9 @@ export type ClaimCommonTypes = {
 
 // Enhanced UserClaimData with useful additional properties
 export type EnhancedUserClaimData = UserClaimData & {
-  currencyAmount: CurrencyAmount<Token | GpEther> | undefined
-  claimAmount: CurrencyAmount<Token> | undefined
-  price: Price<Currency, Currency> | undefined
-  cost: CurrencyAmount<Currency> | undefined
+  currencyAmount?: CurrencyAmount<Token | GpEther> | undefined
+  claimAmount?: CurrencyAmount<Token> | undefined
+  price?: Price<Currency, Currency> | undefined
+  cost?: CurrencyAmount<Currency> | undefined
   isFree: boolean
 }

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -781,5 +781,5 @@ export function useUserEnhancedClaimData(account: Account): EnhancedUserClaimDat
 }
 
 function _sortTypes(a: UserClaimData, b: UserClaimData): number {
-  return Number(isFreeClaim(a.type)) - Number(isFreeClaim(b.type))
+  return Number(isFreeClaim(b.type)) - Number(isFreeClaim(a.type))
 }

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -749,34 +749,33 @@ export function useUserEnhancedClaimData(account: Account): EnhancedUserClaimDat
     const chainId = supportedChainId(preCheckChainId)
     if (!chainId) return []
 
-    return sorted.reduce<EnhancedUserClaimData[]>((acc, claim) => {
-      const tokenAndAmount = claimTypeToTokenAmount(claim.type, chainId)
-
-      if (!tokenAndAmount) return acc
-
-      const price = new Price({
-        baseAmount: ONE_VCOW,
-        quoteAmount: CurrencyAmount.fromRawAmount(tokenAndAmount.token, tokenAndAmount.amount),
-      }).invert()
-
-      // get the currency amount using the price base currency (remember price was inverted) and claim amount
-      const currencyAmount = CurrencyAmount.fromRawAmount(price.baseCurrency, claim.amount)
+    return sorted.map<EnhancedUserClaimData>((claim) => {
       const claimAmount = CurrencyAmount.fromRawAmount(ONE_VCOW.currency, claim.amount)
 
-      // e.g 1000 vCow / 20 GNO = 50 GNO cost
-      const cost = currencyAmount.divide(price)
+      const tokenAndAmount = claimTypeToTokenAmount(claim.type, chainId)
 
-      acc.push({
+      const data: EnhancedUserClaimData = {
         ...claim,
         isFree: isFreeClaim(claim.type),
-        currencyAmount,
         claimAmount,
-        price,
-        cost,
-      })
+      }
 
-      return acc
-    }, [])
+      if (!tokenAndAmount) {
+        return data
+      } else {
+        data.price = new Price({
+          baseAmount: ONE_VCOW,
+          quoteAmount: CurrencyAmount.fromRawAmount(tokenAndAmount.token, tokenAndAmount.amount),
+        }).invert()
+        // get the currency amount using the price base currency (remember price was inverted) and claim amount
+        data.currencyAmount = CurrencyAmount.fromRawAmount(data.price.baseCurrency, claim.amount)
+
+        // e.g 1000 vCow / 20 GNO = 50 GNO cost
+        data.cost = data.currencyAmount.divide(data.price)
+
+        return data
+      }
+    })
   }, [preCheckChainId, sorted])
 }
 


### PR DESCRIPTION
# Summary

Fixes issue preventing free claims from being listed in the details table

<img width="732" alt="Screen Shot 2022-01-14 at 15 45 02" src="https://user-images.githubusercontent.com/43217/149599140-9111b3f9-d746-41b8-af5e-d6ec8893ac03.png">

  # To Test

1. Open the app on claim page, check any account that has both free and paid claims. There's a list a the bottom with some
* Both free and paid claims are displayed in the table

# Addresses

-  0xfD40fcF9AD20C8fe4936E552833696496EA88E01
-  0xC9A49b13A88Bd25E133AA1A709E5c31a2fc61591
-  0x5239d4A1ff381f089D990Cd50B441cC9EFfE0ba3
-  0x9470a102B9d6a3a00103537C2bC35ac0587Bd436
-  0x2F144ff590C94871f118583E61fdDd06b98120e4
-  0x42cE50b0387A081b51DAAE489DD4129CEc5a78f1
-  0x6f14181e316377f683a9AE331B244717d38E619b
-  0x05A1b71BF498d4A3930BA1f940E2D58C2150b399
-  0x525Aa961cb6A422F325445F4529d58A5df3d19cc
-  0x059E927e96079AffCC63583399641d1Da33e9Dd2
-  0x1Ead91ed8Fd59B0742B17D25D224dC7D01CC17b1
-  0xFA379cD1f24623eb282F007e0B7AC97eE5361657
-  0x29d28C9b5a986809cb08504B54bfAEcFF79ad0BD
-  0xEC45A4b65ddCe4da7e9D2F09Cddd31d1a38A4993
-  0x904061135b2b0E87b1B40B641eC02ff07f1EF71B
-  0x5B1bcdE24A407ce5032c1D2b59a83cf39F44604C
-  0xB9EaC144Bf2b5331C722B087c323Fb6A5e8f04a6
-  0xc6a4390A6f54a235B4Bec72236f84691A1903A25
-  0xE8eAd5e33a24e228D86401f7dC84474d686BC40a
-  0x07666F355a0E8882e92665aaFCd8241D4FDB0837

