### PR TITLE
Claim change account

### DIFF
--- a/src/custom/pages/Claim/ClaimNav.tsx
+++ b/src/custom/pages/Claim/ClaimNav.tsx
@@ -28,7 +28,7 @@ export default function ClaimNav({ account, handleChangeAccount }: ClaimNavProps
         <ClaimAccountButtons>
           {!!account && account !== activeClaimAccount && (
             <ButtonSecondary disabled={isAttempting} onClick={() => setActiveClaimAccount(account)}>
-              Change account to connected wallet
+              Switch to connected account
             </ButtonSecondary>
           )}
 

--- a/src/custom/pages/Claim/ClaimNav.tsx
+++ b/src/custom/pages/Claim/ClaimNav.tsx
@@ -32,7 +32,11 @@ export default function ClaimNav({ account, handleChangeAccount }: ClaimNavProps
             </ButtonSecondary>
           )}
 
-          {investFlowStep < 2 && (
+          {/* Hide account changing action on:
+           * last investment step
+           * attempted claim in progress
+           */}
+          {(investFlowStep < 2 || !isAttempting) && (
             <ButtonSecondary disabled={isAttempting} onClick={handleChangeAccount}>
               Change account
             </ButtonSecondary>

--- a/src/custom/pages/Claim/ClaimNav.tsx
+++ b/src/custom/pages/Claim/ClaimNav.tsx
@@ -28,7 +28,7 @@ export default function ClaimNav({ account, handleChangeAccount }: ClaimNavProps
         <ClaimAccountButtons>
           {!!account && account !== activeClaimAccount && (
             <ButtonSecondary disabled={isAttempting} onClick={() => setActiveClaimAccount(account)}>
-              Your claims
+              Change account to connected wallet
             </ButtonSecondary>
           )}
 

--- a/src/custom/pages/Claim/ClaimNav.tsx
+++ b/src/custom/pages/Claim/ClaimNav.tsx
@@ -10,7 +10,7 @@ import Identicon from 'components/Identicon'
 type ClaimNavProps = Pick<ClaimCommonTypes, 'account' | 'handleChangeAccount'>
 
 export default function ClaimNav({ account, handleChangeAccount }: ClaimNavProps) {
-  const { activeClaimAccount, activeClaimAccountENS, claimStatus } = useClaimState()
+  const { activeClaimAccount, activeClaimAccountENS, claimStatus, investFlowStep } = useClaimState()
   const { setActiveClaimAccount } = useClaimDispatchers()
 
   const isAttempting = useMemo(() => claimStatus === ClaimStatus.ATTEMPTING, [claimStatus])
@@ -32,9 +32,11 @@ export default function ClaimNav({ account, handleChangeAccount }: ClaimNavProps
             </ButtonSecondary>
           )}
 
-          <ButtonSecondary disabled={isAttempting} onClick={handleChangeAccount}>
-            Change account
-          </ButtonSecondary>
+          {investFlowStep < 2 && (
+            <ButtonSecondary disabled={isAttempting} onClick={handleChangeAccount}>
+              Change account
+            </ButtonSecondary>
+          )}
         </ClaimAccountButtons>
       </ClaimAccount>
     </TopNav>

--- a/src/custom/pages/Claim/ClaimsTable.tsx
+++ b/src/custom/pages/Claim/ClaimsTable.tsx
@@ -121,12 +121,12 @@ export default function ClaimsTable({
   const { selectedAll, selected, activeClaimAccount, claimStatus, isInvestFlowActive } = useClaimState()
   const pendingClaimsSet = useAllClaimingTransactionIndices()
 
-  const hideTable =
-    isAirdropOnly || !hasClaims || !activeClaimAccount || claimStatus !== ClaimStatus.DEFAULT || isInvestFlowActive
-
   const { deployment: start, investmentDeadline, airdropDeadline } = useClaimTimeInfo()
 
-  if (hideTable) return null
+  const showTable =
+    !isAirdropOnly && hasClaims && activeClaimAccount && claimStatus === ClaimStatus.DEFAULT && !isInvestFlowActive
+
+  if (!showTable) return null
 
   return (
     <ClaimBreakdown>

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -121,6 +121,7 @@ export default function Claim() {
     setInputAddress('')
   }
 
+  // TODO: useCallback
   // handle submit claim
   const handleSubmitClaim = () => {
     // just to be sure
@@ -154,6 +155,7 @@ export default function Claim() {
       setIsInvestFlowActive(true)
     }
   }
+  // TODO: remove?
   console.log(
     `Claim/index::`,
     `[unclaimedAmount ${unclaimedAmount?.toFixed(2)}]`,
@@ -162,8 +164,9 @@ export default function Claim() {
     `[isAirdropOnly ${isAirdropOnly}]`
   )
 
-  // on account change
+  // on account/activeAccount/non-connected account (if claiming for someone else) change
   useEffect(() => {
+    // disconnected wallet?
     if (!account) {
       setActiveClaimAccount('')
     } else if (!isSearchUsed) {
@@ -173,21 +176,15 @@ export default function Claim() {
     // properly reset the user to the claims table and initial investment flow
     setInvestFlowStep(0)
     setIsInvestFlowActive(false)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [account])
-
-  // if wallet is disconnected
-  useEffect(() => {
-    if (!account && !isSearchUsed) {
-      setActiveClaimAccount('')
-    }
-
-    if (!account) {
-      setIsInvestFlowActive(false)
-      setInvestFlowStep(0)
-    }
-    // setActiveClaimAccount and other dispatch fns are only here for TS. They are safe references.
-  }, [account, isSearchUsed, setActiveClaimAccount, setInvestFlowStep, setIsInvestFlowActive])
+  }, [
+    account,
+    activeClaimAccount,
+    resolvedAddress,
+    isSearchUsed,
+    setActiveClaimAccount,
+    setInvestFlowStep,
+    setIsInvestFlowActive,
+  ])
 
   // Transaction confirmation modal
   const { TransactionConfirmationModal, openModal, closeModal } = useTransactionConfirmationModal(

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -164,13 +164,15 @@ export default function Claim() {
 
   // on account change
   useEffect(() => {
-    if (!isSearchUsed && account) {
+    if (!account) {
+      setActiveClaimAccount('')
+    } else if (!isSearchUsed) {
       setActiveClaimAccount(account)
     }
 
-    if (!account) {
-      setActiveClaimAccount('')
-    }
+    // properly reset the user to the claims table and initial investment flow
+    setInvestFlowStep(0)
+    setIsInvestFlowActive(false)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [account])
 

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -157,14 +157,6 @@ export default function Claim() {
       setIsInvestFlowActive(true)
     }
   }
-  // TODO: remove?
-  console.log(
-    `Claim/index::`,
-    `[unclaimedAmount ${unclaimedAmount?.toFixed(2)}]`,
-    `[hasClaims ${hasClaims}]`,
-    `[activeClaimAccount ${activeClaimAccount}]`,
-    `[isAirdropOnly ${isAirdropOnly}]`
-  )
 
   // on account/activeAccount/non-connected account (if claiming for someone else) change
   useEffect(() => {

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -68,6 +68,8 @@ export default function Claim() {
     // claim row selection
     setSelected,
     setSelectedAll,
+    // reset claim ui
+    resetClaimUi,
   } = useClaimDispatchers()
 
   const { address: resolvedAddress, name: resolvedENS } = useENS(inputAddress)
@@ -174,17 +176,8 @@ export default function Claim() {
     }
 
     // properly reset the user to the claims table and initial investment flow
-    setInvestFlowStep(0)
-    setIsInvestFlowActive(false)
-  }, [
-    account,
-    activeClaimAccount,
-    resolvedAddress,
-    isSearchUsed,
-    setActiveClaimAccount,
-    setInvestFlowStep,
-    setIsInvestFlowActive,
-  ])
+    resetClaimUi()
+  }, [account, activeClaimAccount, resolvedAddress, isSearchUsed, setActiveClaimAccount, resetClaimUi])
 
   // Transaction confirmation modal
   const { TransactionConfirmationModal, openModal, closeModal } = useTransactionConfirmationModal(

--- a/src/custom/state/claim/actions.ts
+++ b/src/custom/state/claim/actions.ts
@@ -44,3 +44,5 @@ export const setInvestFlowStep = createAction<number>('claim/setInvestFlowStep')
 // claim row selection
 export const setSelected = createAction<number[]>('claim/setSelected')
 export const setSelectedAll = createAction<boolean>('claim/setSelectedAll')
+// Claim UI reset sugar
+export const resetClaimUi = createAction('claims/resetClaimUi')

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -49,6 +49,7 @@ import {
   setSelected,
   setSelectedAll,
   ClaimStatus,
+  resetClaimUi,
 } from '../actions'
 import { EnhancedUserClaimData } from 'pages/Claim/types'
 import { supportedChainId } from 'utils/supportedChainId'
@@ -726,6 +727,8 @@ export function useClaimDispatchers() {
       // claim row selection
       setSelected: (payload: number[]) => dispatch(setSelected(payload)),
       setSelectedAll: (payload: boolean) => dispatch(setSelectedAll(payload)),
+      // reset claim ui
+      resetClaimUi: () => dispatch(resetClaimUi()),
     }),
     [dispatch]
   )

--- a/src/custom/state/claim/reducer.ts
+++ b/src/custom/state/claim/reducer.ts
@@ -10,6 +10,7 @@ import {
   setIsSearchUsed,
   setSelected,
   setSelectedAll,
+  resetClaimUi,
   ClaimStatus,
 } from './actions'
 
@@ -79,8 +80,21 @@ export default createReducer(initialState, (builder) =>
     })
     .addCase(setSelected, (state, { payload }) => {
       state.selected = payload
+
+      // toggle selected all if all indiv selected
+      if (state.selected.length === payload.length) {
+        state.selectedAll = true
+      } else {
+        state.selectedAll = false
+      }
     })
     .addCase(setSelectedAll, (state, { payload }) => {
       state.selectedAll = payload
+    })
+    .addCase(resetClaimUi, (state) => {
+      state.selected = initialState.selected
+      state.selectedAll = initialState.selectedAll
+      state.investFlowStep = initialState.investFlowStep
+      state.isInvestFlowActive = initialState.isInvestFlowActive
     })
 )


### PR DESCRIPTION
# Summary

Closes #2097 

DO NOT show "Change account" button on last investment step as seen in issue linked. 
On user account change (in wallet) reset them to the ClaimsTable and initial investment step

  # To Test
1. use an account with investment
2. get to last step
3. change account and see where ya at
4. click next after selecting an investment and see you are at step 1