### PR TITLE
[Claim-Approve] Hook optional amountToCheckAgainstAllowance param

### DIFF
--- a/src/custom/hooks/useApproveCallback/index.ts
+++ b/src/custom/hooks/useApproveCallback/index.ts
@@ -1,22 +1,30 @@
-import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
+import { Percent } from '@uniswap/sdk-core'
 import { useActiveWeb3React } from '@src/hooks/web3'
 import { Field } from '@src/state/swap/actions'
 import { computeSlippageAdjustedAmounts } from 'utils/prices'
 import { useMemo } from 'react'
 import { GP_VAULT_RELAYER, V_COW_CONTRACT_ADDRESS } from 'constants/index'
 import TradeGp from 'state/swap/TradeGp'
-import { ZERO_PERCENT } from 'constants/misc'
 
-import { useApproveCallback } from './useApproveCallbackMod'
+import { ApproveCallbackParams, useApproveCallback } from './useApproveCallbackMod'
 export { ApprovalState, useApproveCallback } from './useApproveCallbackMod'
 
+type ApproveCallbackFromTradeParams = Pick<
+  ApproveCallbackParams,
+  'openTransactionConfirmationModal' | 'closeModals' | 'amountToCheckAgainstAllowance'
+> & {
+  trade: TradeGp | undefined
+  allowedSlippage: Percent
+}
+
 // export function useApproveCallbackFromTrade(trade?: Trade, allowedSlippage = 0) {
-export function useApproveCallbackFromTrade(
-  openTransactionConfirmationModal: (message: string) => void,
-  closeModals: () => void,
-  trade?: TradeGp,
-  allowedSlippage = ZERO_PERCENT
-) {
+export function useApproveCallbackFromTrade({
+  openTransactionConfirmationModal,
+  closeModals,
+  trade,
+  allowedSlippage,
+  amountToCheckAgainstAllowance,
+}: ApproveCallbackFromTradeParams) {
   const { chainId } = useActiveWeb3React()
 
   const amountToApprove = useMemo(() => {
@@ -29,22 +37,37 @@ export function useApproveCallbackFromTrade(
 
   const vaultRelayer = chainId ? GP_VAULT_RELAYER[chainId] : undefined
 
-  return useApproveCallback(openTransactionConfirmationModal, closeModals, amountToApprove, vaultRelayer)
+  return useApproveCallback({
+    openTransactionConfirmationModal,
+    closeModals,
+    amountToApprove,
+    spender: vaultRelayer,
+    amountToCheckAgainstAllowance,
+  })
 }
 
 export type OptionalApproveCallbackParams = {
   transactionSummary: string
 }
 
-export function useApproveCallbackFromClaim(
-  openTransactionConfirmationModal: (message: string) => void,
-  closeModals: () => void,
-  amountToApprove: CurrencyAmount<Currency> | undefined
-) {
+type ApproveCallbackFromClaimParams = Omit<ApproveCallbackParams, 'spender'>
+
+export function useApproveCallbackFromClaim({
+  openTransactionConfirmationModal,
+  closeModals,
+  amountToApprove,
+  amountToCheckAgainstAllowance,
+}: ApproveCallbackFromClaimParams) {
   const { chainId } = useActiveWeb3React()
 
   const vCowContract = chainId ? V_COW_CONTRACT_ADDRESS[chainId] : undefined
 
   // Params: modal cbs, amountToApprove: token user is investing e.g, spender: vcow token contract
-  return useApproveCallback(openTransactionConfirmationModal, closeModals, amountToApprove, vCowContract)
+  return useApproveCallback({
+    openTransactionConfirmationModal,
+    closeModals,
+    amountToApprove,
+    spender: vCowContract,
+    amountToCheckAgainstAllowance,
+  })
 }

--- a/src/custom/hooks/useApproveCallback/index.ts
+++ b/src/custom/hooks/useApproveCallback/index.ts
@@ -1,4 +1,4 @@
-import { Percent } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount, MaxUint256, Percent } from '@uniswap/sdk-core'
 import { useActiveWeb3React } from '@src/hooks/web3'
 import { Field } from '@src/state/swap/actions'
 import { computeSlippageAdjustedAmounts } from 'utils/prices'
@@ -8,6 +8,11 @@ import TradeGp from 'state/swap/TradeGp'
 
 import { ApproveCallbackParams, useApproveCallback } from './useApproveCallbackMod'
 export { ApprovalState, useApproveCallback } from './useApproveCallbackMod'
+
+import { ClaimType } from 'state/claim/hooks'
+import { supportedChainId } from 'utils/supportedChainId'
+import { tryAtomsToCurrency } from 'state/swap/extension'
+import { EnhancedUserClaimData } from 'pages/Claim/types'
 
 type ApproveCallbackFromTradeParams = Pick<
   ApproveCallbackParams,
@@ -50,24 +55,44 @@ export type OptionalApproveCallbackParams = {
   transactionSummary: string
 }
 
-type ApproveCallbackFromClaimParams = Omit<ApproveCallbackParams, 'spender'>
+type ApproveCallbackFromClaimParams = Omit<
+  ApproveCallbackParams,
+  'spender' | 'amountToApprove' | 'amountToCheckAgainstAllowance'
+> & {
+  claim: EnhancedUserClaimData
+  investmentAmount: string | undefined
+}
 
 export function useApproveCallbackFromClaim({
   openTransactionConfirmationModal,
   closeModals,
-  amountToApprove,
-  amountToCheckAgainstAllowance,
+  claim,
+  investmentAmount,
 }: ApproveCallbackFromClaimParams) {
   const { chainId } = useActiveWeb3React()
+  const supportedChain = supportedChainId(chainId)
 
   const vCowContract = chainId ? V_COW_CONTRACT_ADDRESS[chainId] : undefined
+
+  // Claim only approves GNO and USDC (GnoOption & Investor, respectively.)
+  const approveAmounts = useMemo(() => {
+    if (supportedChain && (claim.type === ClaimType.GnoOption || claim.type === ClaimType.Investor)) {
+      const investmentCurrency = claim.currencyAmount?.currency as Currency
+      const amountToCheckAgainstAllowance = tryAtomsToCurrency(investmentAmount, investmentCurrency)
+      return {
+        amountToApprove: CurrencyAmount.fromRawAmount(investmentCurrency, MaxUint256),
+        amountToCheckAgainstAllowance,
+      }
+    }
+    return undefined
+  }, [claim, investmentAmount, supportedChain])
 
   // Params: modal cbs, amountToApprove: token user is investing e.g, spender: vcow token contract
   return useApproveCallback({
     openTransactionConfirmationModal,
     closeModals,
-    amountToApprove,
     spender: vCowContract,
-    amountToCheckAgainstAllowance,
+    amountToApprove: approveAmounts?.amountToApprove,
+    amountToCheckAgainstAllowance: approveAmounts?.amountToCheckAgainstAllowance,
   })
 }

--- a/src/custom/hooks/useApproveCallback/useApproveCallbackMod.ts
+++ b/src/custom/hooks/useApproveCallback/useApproveCallbackMod.ts
@@ -52,13 +52,15 @@ export function useApproveCallback({
     // we might not have enough data to know whether or not we need to approve
     if (!currentAllowance) return ApprovalState.UNKNOWN
 
-    // is the optionally set check amount less than current set allowance?
-    const isOptionalAmountLessThanAllowance = !!amountToCheckAgainstAllowance?.lessThan(currentAllowance)
-    // is current set allowance less than actual approving amount?
-    const isApprovingAmountLessThanAllowance = currentAllowance.lessThan(amountToApprove)
+    // is amountToCheckAgainstAllowance < allowance
+    // if TRUE = need to approve
+    const optionalAmountNeedsApproval = !!amountToCheckAgainstAllowance?.greaterThan(currentAllowance)
+    // is amountToApprove > allowance
+    // if TRUE = need to approve
+    const amountToApproveNeedsApproval = amountToApprove.greaterThan(currentAllowance)
 
     // Return approval state
-    if (isOptionalAmountLessThanAllowance || isApprovingAmountLessThanAllowance) {
+    if (optionalAmountNeedsApproval || amountToApproveNeedsApproval) {
       return pendingApproval ? ApprovalState.PENDING : ApprovalState.NOT_APPROVED
     } else {
       // Enough allowance

--- a/src/custom/hooks/useApproveCallback/useApproveCallbackMod.ts
+++ b/src/custom/hooks/useApproveCallback/useApproveCallbackMod.ts
@@ -52,8 +52,13 @@ export function useApproveCallback({
     // we might not have enough data to know whether or not we need to approve
     if (!currentAllowance) return ApprovalState.UNKNOWN
 
+    // is the optionally set check amount less than current set allowance?
+    const isOptionalAmountLessThanAllowance = !!amountToCheckAgainstAllowance?.lessThan(currentAllowance)
+    // is current set allowance less than actual approving amount?
+    const isApprovingAmountLessThanAllowance = currentAllowance.lessThan(amountToApprove)
+
     // Return approval state
-    if ((amountToCheckAgainstAllowance || currentAllowance).lessThan(amountToApprove)) {
+    if (isOptionalAmountLessThanAllowance || isApprovingAmountLessThanAllowance) {
       return pendingApproval ? ApprovalState.PENDING : ApprovalState.NOT_APPROVED
     } else {
       // Enough allowance

--- a/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
@@ -7,11 +7,11 @@ import { InvestTokenGroup, TokenLogo, InvestSummary, InvestInput, InvestAvailabl
 import { formatSmartLocaleAware } from 'utils/format'
 import Row from 'components/Row'
 import CheckCircle from 'assets/cow-swap/check.svg'
-import { InvestOptionProps } from '.'
-import { ApprovalState } from 'hooks/useApproveCallback'
+import { InvestmentFlowProps } from '.'
+import { ApprovalState, useApproveCallbackFromClaim } from 'hooks/useApproveCallback'
 import { useCurrencyBalance } from 'state/wallet/hooks'
 import { useActiveWeb3React } from 'hooks/web3'
-import { useClaimDispatchers, useClaimState } from 'state/claim/hooks'
+import { ClaimType, useClaimDispatchers, useClaimState } from 'state/claim/hooks'
 import { StyledNumericalInput } from 'components/CurrencyInputPanel/CurrencyInputPanelMod'
 
 import { ButtonConfirmed } from 'components/Button'
@@ -23,6 +23,8 @@ import { calculateInvestmentAmounts, calculatePercentage } from 'state/claim/hoo
 import { AMOUNT_PRECISION, PERCENTAGE_PRECISION } from 'constants/index'
 import { useGasPrices } from 'state/gas/hooks'
 import { AVG_APPROVE_COST_GWEI } from 'components/swap/EthWethWrap/helpers'
+import { EnhancedUserClaimData } from '../types'
+import { OperationType } from 'components/TransactionConfirmationModal'
 
 const ErrorMsgs = {
   InsufficientBalance: (symbol = '') => `Insufficient ${symbol} balance to cover investment amount`,
@@ -33,14 +35,45 @@ const ErrorMsgs = {
     `You might not have enough ${symbol} to pay for the network transaction fee (estimated ${amount} ${symbol})`,
 }
 
-export default function InvestOption({ approveData, claim, optionIndex }: InvestOptionProps) {
+type InvestOptionProps = {
+  claim: EnhancedUserClaimData
+  optionIndex: number
+  openModal: InvestmentFlowProps['modalCbs']['openModal']
+  closeModal: InvestmentFlowProps['modalCbs']['closeModal']
+}
+
+const _claimApproveMessageMap = (type: ClaimType) => {
+  switch (type) {
+    case ClaimType.GnoOption:
+      return 'Approving GNO for investing in vCOW'
+    case ClaimType.Investor:
+      return 'Approving USDC for investing in vCOW'
+    // Shouldn't happen, type safe
+    default:
+      return 'Unknown token approval. Please check configuration.'
+  }
+}
+
+export default function InvestOption({ claim, optionIndex, openModal, closeModal }: InvestOptionProps) {
   const { currencyAmount, price, cost: maxCost } = claim
+
+  const { account, chainId } = useActiveWeb3React()
   const { updateInvestAmount, updateInvestError } = useClaimDispatchers()
   const { investFlowData, activeClaimAccount, estimatedGas } = useClaimState()
 
-  const { handleSetError, handleCloseError, ErrorModal } = useErrorModal()
+  const investmentAmount = investFlowData[optionIndex].investedAmount
 
-  const { account, chainId } = useActiveWeb3React()
+  // Approve hooks
+  const [approveState, approveCallback] = useApproveCallbackFromClaim({
+    openTransactionConfirmationModal: () => openModal(_claimApproveMessageMap(claim.type), OperationType.APPROVE_TOKEN),
+    closeModals: closeModal,
+    claim,
+    investmentAmount,
+  })
+
+  const isEtherApproveState = approveState === ApprovalState.UNKNOWN
+
+  const { handleSetError, handleCloseError, ErrorModal } = useErrorModal()
 
   const [percentage, setPercentage] = useState<string>('0')
   const [typedValue, setTypedValue] = useState<string>('')
@@ -72,7 +105,7 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
   const isSelfClaiming = account === activeClaimAccount
   const noBalance = !balance || balance.equalTo('0')
 
-  const isApproved = approveData?.approveState === ApprovalState.APPROVED
+  const isApproved = approveState === ApprovalState.APPROVED
 
   const gasCost = useMemo(() => {
     if (!estimatedGas || !isNative) {
@@ -97,9 +130,6 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
     setTypedValue(value.toExact() || '')
   }, [balance, maxCost, noBalance])
 
-  // Cache approveData methods
-  const approveCallback = approveData?.approveCallback
-  const approveState = approveData?.approveState
   // Save "local" approving state (pre-BC) for rendering spinners etc
   const [approving, setApproving] = useState(false)
   const handleApprove = useCallback(async () => {
@@ -121,8 +151,8 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
   }, [approveCallback, handleCloseError, handleSetError, token?.symbol])
 
   const vCowAmount = useMemo(
-    () => calculateInvestmentAmounts(claim, investedAmount)?.vCowAmount,
-    [claim, investedAmount]
+    () => calculateInvestmentAmounts(claim, investmentAmount)?.vCowAmount,
+    [claim, investmentAmount]
   )
 
   // if there is investmentAmount in redux state for this option set it as typedValue
@@ -238,9 +268,9 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
 
           <span>
             <b>Token approval</b>
-            {approveData ? (
+            {!isEtherApproveState ? (
               <i>
-                {approveData.approveState !== ApprovalState.APPROVED ? (
+                {approveState !== ApprovalState.APPROVED ? (
                   `${currencyAmount?.currency?.symbol} not approved`
                 ) : (
                   <Row>
@@ -257,8 +287,8 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
                 </Row>
               </i>
             )}
-            {/* Approve button - @biocom styles for this found in ./styled > InputSummary > ${ButtonPrimary}*/}
-            {approveData && approveState !== ApprovalState.APPROVED && (
+            {/* Token Approve buton - not shown for ETH */}
+            {!isEtherApproveState && approveState !== ApprovalState.APPROVED && (
               <ButtonConfirmed
                 buttonSize={ButtonSize.SMALL}
                 onClick={handleApprove}
@@ -269,9 +299,9 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
               >
                 {approving || approveState === ApprovalState.PENDING ? (
                   <Loader stroke="white" />
-                ) : approveData ? (
+                ) : (
                   <span>Approve {currencyAmount?.currency?.symbol}</span>
-                ) : null}
+                )}
               </ButtonConfirmed>
             )}
           </span>

--- a/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
@@ -68,7 +68,6 @@ export default function InvestOption({ claim, optionIndex, openModal, closeModal
     openTransactionConfirmationModal: () => openModal(_claimApproveMessageMap(claim.type), OperationType.APPROVE_TOKEN),
     closeModals: closeModal,
     claim,
-    investmentAmount,
   })
 
   const isEtherApproveState = approveState === ApprovalState.UNKNOWN

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -188,19 +188,25 @@ export default function Claim() {
     OperationType.APPROVE_TOKEN
   )
 
-  const [gnoApproveState, gnoApproveCallback] = useApproveCallbackFromClaim(
-    () => openModal(GNO_CLAIM_APPROVE_MESSAGE, OperationType.APPROVE_TOKEN),
-    closeModal,
+  const [gnoApproveState, gnoApproveCallback] = useApproveCallbackFromClaim({
+    openTransactionConfirmationModal: () => openModal(GNO_CLAIM_APPROVE_MESSAGE, OperationType.APPROVE_TOKEN),
+    closeModals: closeModal,
     // approve max unit256 amount
-    isSupportedChain(chainId) ? CurrencyAmount.fromRawAmount(GNO[chainId], MaxUint256) : undefined
-  )
+    amountToApprove: isSupportedChain(chainId) ? CurrencyAmount.fromRawAmount(GNO[chainId], MaxUint256) : undefined,
+    // TODO: enable, fix this
+    // amountToCheckAgainstAllowance: investmentAmountAsCurrency,
+  })
 
-  const [usdcApproveState, usdcApproveCallback] = useApproveCallbackFromClaim(
-    () => openModal(USDC_CLAIM_APPROVE_MESSAGE, OperationType.APPROVE_TOKEN),
-    closeModal,
+  const [usdcApproveState, usdcApproveCallback] = useApproveCallbackFromClaim({
+    openTransactionConfirmationModal: () => openModal(USDC_CLAIM_APPROVE_MESSAGE, OperationType.APPROVE_TOKEN),
+    closeModals: closeModal,
     // approve max unit256 amount
-    isSupportedChain(chainId) ? CurrencyAmount.fromRawAmount(USDC_BY_CHAIN[chainId], MaxUint256) : undefined
-  )
+    amountToApprove: isSupportedChain(chainId)
+      ? CurrencyAmount.fromRawAmount(USDC_BY_CHAIN[chainId], MaxUint256)
+      : undefined,
+    // TODO: enable, fix this
+    // amountToCheckAgainstAllowance: investmentAmountAsCurrency,
+  })
 
   return (
     <PageWrapper>

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -26,9 +26,6 @@ import useTransactionConfirmationModal from 'hooks/useTransactionConfirmationMod
 import { useErrorModal } from 'hooks/useErrorMessageAndModal'
 import FooterNavButtons from './FooterNavButtons'
 
-const GNO_CLAIM_APPROVE_MESSAGE = 'Approving GNO for investing in vCOW'
-const USDC_CLAIM_APPROVE_MESSAGE = 'Approving USDC for investing in vCOW'
-
 /* TODO: Replace URLs with the actual final URL destinations */
 export const COW_LINKS = {
   vCowPost: 'https://cow.fi/',

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo } from 'react'
-import { CurrencyAmount, MaxUint256 } from '@uniswap/sdk-core'
 import { useActiveWeb3React } from 'hooks/web3'
 import { useUserEnhancedClaimData, useUserUnclaimedAmount, useClaimCallback, ClaimInput } from 'state/claim/hooks'
 import { PageWrapper } from 'pages/Claim/styled'
@@ -21,12 +20,9 @@ import InvestmentFlow from './InvestmentFlow'
 import { useClaimDispatchers, useClaimState } from 'state/claim/hooks'
 import { ClaimStatus } from 'state/claim/actions'
 
-import { useApproveCallbackFromClaim } from 'hooks/useApproveCallback'
 import { OperationType } from 'components/TransactionConfirmationModal'
 import useTransactionConfirmationModal from 'hooks/useTransactionConfirmationModal'
 
-import { GNO, USDC_BY_CHAIN } from 'constants/tokens'
-import { isSupportedChain } from 'utils/supportedChainId'
 import { useErrorModal } from 'hooks/useErrorMessageAndModal'
 import FooterNavButtons from './FooterNavButtons'
 
@@ -40,7 +36,7 @@ export const COW_LINKS = {
 }
 
 export default function Claim() {
-  const { account, chainId } = useActiveWeb3React()
+  const { account } = useActiveWeb3React()
 
   const {
     // address/ENS address
@@ -188,26 +184,6 @@ export default function Claim() {
     OperationType.APPROVE_TOKEN
   )
 
-  const [gnoApproveState, gnoApproveCallback] = useApproveCallbackFromClaim({
-    openTransactionConfirmationModal: () => openModal(GNO_CLAIM_APPROVE_MESSAGE, OperationType.APPROVE_TOKEN),
-    closeModals: closeModal,
-    // approve max unit256 amount
-    amountToApprove: isSupportedChain(chainId) ? CurrencyAmount.fromRawAmount(GNO[chainId], MaxUint256) : undefined,
-    // TODO: enable, fix this
-    // amountToCheckAgainstAllowance: investmentAmountAsCurrency,
-  })
-
-  const [usdcApproveState, usdcApproveCallback] = useApproveCallbackFromClaim({
-    openTransactionConfirmationModal: () => openModal(USDC_CLAIM_APPROVE_MESSAGE, OperationType.APPROVE_TOKEN),
-    closeModals: closeModal,
-    // approve max unit256 amount
-    amountToApprove: isSupportedChain(chainId)
-      ? CurrencyAmount.fromRawAmount(USDC_BY_CHAIN[chainId], MaxUint256)
-      : undefined,
-    // TODO: enable, fix this
-    // amountToCheckAgainstAllowance: investmentAmountAsCurrency,
-  })
-
   return (
     <PageWrapper>
       {/* Approve confirmation modal */}
@@ -237,18 +213,7 @@ export default function Claim() {
       {/* IS Airdrop + investing (advanced) */}
       <ClaimsTable isAirdropOnly={isAirdropOnly} hasClaims={hasClaims} />
       {/* Investing vCOW flow (advanced) */}
-      <InvestmentFlow
-        isAirdropOnly={isAirdropOnly}
-        hasClaims={hasClaims}
-        gnoApproveData={{
-          approveCallback: gnoApproveCallback,
-          approveState: gnoApproveState,
-        }}
-        usdcApproveData={{
-          approveCallback: usdcApproveCallback,
-          approveState: usdcApproveState,
-        }}
-      />
+      <InvestmentFlow isAirdropOnly={isAirdropOnly} hasClaims={hasClaims} modalCbs={{ openModal, closeModal }} />
 
       <FooterNavButtons
         handleCheckClaim={handleCheckClaim}

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -329,12 +329,13 @@ export default function Swap({
   const isLoadingRoute = toggledVersion === Version.v3 && V3TradeState.LOADING === v3TradeState */
 
   // check whether the user has approved the router on the input token
-  const [approvalState, approveCallback] = useApproveCallbackFromTrade(
-    (message: string) => openTransactionConfirmationModal(message, OperationType.APPROVE_TOKEN),
+  const [approvalState, approveCallback] = useApproveCallbackFromTrade({
+    openTransactionConfirmationModal: (message: string) =>
+      openTransactionConfirmationModal(message, OperationType.APPROVE_TOKEN),
     closeModals,
     trade,
-    allowedSlippage
-  )
+    allowedSlippage,
+  })
   const prevApprovalState = usePrevious(approvalState)
   const {
     state: signatureState,

--- a/src/custom/state/claim/hooks/utils.ts
+++ b/src/custom/state/claim/hooks/utils.ts
@@ -164,17 +164,32 @@ export type PaidClaimTypeToPriceMap = {
   [type in ClaimType]: { token: Token; amount: string } | undefined
 }
 
+export function claimTypeToToken(type: ClaimType, chainId: SupportedChainId) {
+  switch (type) {
+    case ClaimType.GnoOption:
+      return GNO[chainId]
+    case ClaimType.Investor:
+      return USDC_BY_CHAIN[chainId]
+    case ClaimType.UserOption:
+      return GpEther.onChain(chainId)
+    case ClaimType.Advisor:
+    case ClaimType.Airdrop:
+    case ClaimType.Team:
+      return undefined
+  }
+}
+
 /**
  * Helper function to get vCow price based on claim type and chainId
  */
 export function claimTypeToTokenAmount(type: ClaimType, chainId: SupportedChainId, prices: VCowPrices) {
   switch (type) {
     case ClaimType.GnoOption:
-      return { token: GNO[chainId], amount: prices.gno as string }
+      return { token: claimTypeToToken(ClaimType.GnoOption, chainId) as Token, amount: prices.gno as string }
     case ClaimType.Investor:
-      return { token: USDC_BY_CHAIN[chainId], amount: prices.usdc as string }
+      return { token: claimTypeToToken(ClaimType.Investor, chainId) as Token, amount: prices.usdc as string }
     case ClaimType.UserOption:
-      return { token: GpEther.onChain(chainId), amount: prices.native as string }
+      return { token: claimTypeToToken(ClaimType.UserOption, chainId) as GpEther, amount: prices.native as string }
     default:
       return undefined
   }

--- a/src/custom/state/swap/extension.ts
+++ b/src/custom/state/swap/extension.ts
@@ -15,6 +15,12 @@ interface TradeParams {
 export const stringToCurrency = (amount: string, currency: Currency) =>
   CurrencyAmount.fromRawAmount(currency, JSBI.BigInt(amount))
 
+export const tryAtomsToCurrency = (atoms: string | undefined, currency: Currency | undefined) => {
+  if (!atoms || !currency) return undefined
+
+  return stringToCurrency(atoms, currency)
+}
+
 /**
  * useTradeExactInWithFee
  * @description wraps useTradeExactIn and returns an extended trade object with the fee adjusted values


### PR DESCRIPTION
# Summary

As described in call, we need a way to check special cases where user changes alllowance outside app. So we want a new param to check against the current token allowance and use that to set approve state.

No testing yet, TBD