### PR TITLE
Use airdrop claim end date

### DIFF
--- a/src/custom/pages/Claim/CanUserClaimMessage.tsx
+++ b/src/custom/pages/Claim/CanUserClaimMessage.tsx
@@ -3,7 +3,7 @@ import { ButtonSecondary } from 'components/Button'
 import { ExternalLink } from 'theme'
 import { IntroDescription } from './styled'
 import { ClaimCommonTypes } from './types'
-import { useClaimDispatchers, useClaimState } from 'state/claim/hooks'
+import { useAirdropDeadline, useClaimDispatchers, useClaimState } from 'state/claim/hooks'
 import { ClaimStatus } from 'state/claim/actions'
 
 type ClaimIntroductionProps = Pick<ClaimCommonTypes, 'hasClaims'> & {
@@ -13,6 +13,8 @@ type ClaimIntroductionProps = Pick<ClaimCommonTypes, 'hasClaims'> & {
 export default function CanUserClaimMessage({ hasClaims, isAirdropOnly }: ClaimIntroductionProps) {
   const { activeClaimAccount, claimStatus } = useClaimState()
   const { setActiveClaimAccount } = useClaimDispatchers()
+
+  const end = useAirdropDeadline()
 
   // only show when active claim account
   if (!activeClaimAccount || claimStatus !== ClaimStatus.DEFAULT) return null
@@ -24,7 +26,7 @@ export default function CanUserClaimMessage({ hasClaims, isAirdropOnly }: ClaimI
           <Trans>
             Thank you for being a supporter of CowSwap and the CoW protocol. As an important member of the CowSwap
             Community you may claim vCOW to be used for voting and governance. You can claim your tokens until{' '}
-            <i>XX-XX-XXXX - XX:XX GMT</i>
+            <i>{end && new Date(end).toLocaleString()}</i>
             <ExternalLink href="https://cow.fi/">Read more about vCOW</ExternalLink>
           </Trans>
         </p>


### PR DESCRIPTION
# Summary

Follow up to https://github.com/gnosis/cowswap/pull/2158 adding the claim deadline to airdrop only claims
<img width="717" alt="Screen Shot 2022-01-17 at 14 21 46" src="https://user-images.githubusercontent.com/43217/149843084-0124d21b-13f5-497f-83da-9389ced1db11.png">

@biocom please style as you see fit. Feel free to adjust also the format used, or if you want to show the countdown here or not

  # To Test

1. Load one account that has no PAID claims and has not been claimed yet (list at the bottom)
2. The claim time deadline should be shown (see pic)

# Accounts

-  0xa4848704A3B3f61bDC42c40CA964eA7295eD101C
-  0x22F54D79ba28A31686eB22E1b0d7Cf5B9A4D5e99
-  0x43fe583631F9DDd118f904E4897ede77b698E0b0
-  0x96514697A5d343e75AA19eb72594030945f9c25a
-  0x146Ab012B49fAFeD35B4FF645fC48C50fD53eAD6
-  0x8CCbC8E2A82Aa7D7AbE95E455482Df5f197722f0
-  0xE82AA47bAedbE3B2453350f559068e0377dC504b
-  0x7340F8a2601FEeeB51cdED50a47ed7e06C258618
-  0x8E467C5D9a6C388A8AA27D6AA0411d50601409C4
-  0x122671322dd9Cf0F4da2d61F51729C50a6263f55