### PR TITLE
Rename constants

### DIFF
--- a/src/custom/pages/Claim/CanUserClaimMessage.tsx
+++ b/src/custom/pages/Claim/CanUserClaimMessage.tsx
@@ -14,16 +14,7 @@ export default function CanUserClaimMessage({ hasClaims, isAirdropOnly }: ClaimI
   const { activeClaimAccount, claimStatus } = useClaimState()
   const { setActiveClaimAccount } = useClaimDispatchers()
 
-  const { airdropDeadline, deployment, investmentDeadline, isAirdropWindowOpen, isInvestmentWindowOpen } =
-    useClaimTimeInfo()
-  // console.log('Deadlines', {
-  //   airdropDeadline: airdropDeadline && new Date(airdropDeadline).toISOString(),
-  //   deployment: deployment && new Date(deployment).toISOString(),
-  //   investmentDeadline: investmentDeadline && new Date(investmentDeadline).toISOString(),
-
-  //   isAirdropWindowOpen,
-  //   isInvestmentWindowOpen,
-  // })
+  const { airdropDeadline } = useClaimTimeInfo()
 
   // only show when active claim account
   if (!activeClaimAccount || claimStatus !== ClaimStatus.DEFAULT) return null

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -74,8 +74,8 @@ export const GNO_PRICE = '375000000000000' // '0.000375' GNO (18 decimals) per v
 export const USDC_PRICE = '150000' // '0.15' USDC (6 decimals) per vCOW, in atoms
 
 // Constants regarding investment time windows
-const TWO_WEEKS = ms`2 weeks`
-const SIX_WEEKS = ms`6 weeks`
+const INVESTMENT_TIME = ms`2 weeks`
+const AIRDROP_TIME = ms`6 weeks`
 
 // For native token price calculation
 const DENOMINATOR = JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18))
@@ -328,8 +328,8 @@ type ClaimTimeInfo = {
  */
 export function useClaimTimeInfo(): ClaimTimeInfo {
   const deployment = useDeploymentTimestamp()
-  const investmentDeadline = deployment && deployment + TWO_WEEKS
-  const airdropDeadline = deployment && deployment + SIX_WEEKS
+  const investmentDeadline = deployment && deployment + INVESTMENT_TIME
+  const airdropDeadline = deployment && deployment + AIRDROP_TIME
 
   const isInvestmentWindowOpen = Boolean(investmentDeadline && investmentDeadline > Date.now())
   const isAirdropWindowOpen = Boolean(airdropDeadline && airdropDeadline > Date.now())


### PR DESCRIPTION
# Summary

Tiny rename of constants so they don't have their value in their own name

i had to shorten the times and it was a bit unnatural to just say `const TWO_WEEKS = ms'30 minutes'`