### PR TITLE
Change label for claim for another account

### DIFF
--- a/src/custom/pages/Claim/ClaimNav.tsx
+++ b/src/custom/pages/Claim/ClaimNav.tsx
@@ -33,7 +33,7 @@ export default function ClaimNav({ account, handleChangeAccount }: ClaimNavProps
           )}
 
           <ButtonSecondary disabled={isAttempting} onClick={handleChangeAccount}>
-            Change account
+            Claim for another account
           </ButtonSecondary>
         </ClaimAccountButtons>
       </ClaimAccount>


### PR DESCRIPTION
# Summary
Chage label for claim for someone else

Before:
![image](https://user-images.githubusercontent.com/2352112/149937728-4bd486a2-5fd1-433e-935f-9bc7c41ff6e9.png)


After:
![image](https://user-images.githubusercontent.com/2352112/149937605-d756768e-f907-4893-a1a4-a9b46d541340.png)


The reason, im affraid people will think that is for changing the connected wallet, so they might think is the same of: 
![image](https://user-images.githubusercontent.com/2352112/149937831-a2c83b82-cd5b-4ecd-87c4-071f9f56c793.png)
