### PR TITLE
New claim contract abi

### DIFF
--- a/src/custom/abis/types/VCow.d.ts
+++ b/src/custom/abis/types/VCow.d.ts
@@ -28,7 +28,7 @@ interface VCowInterface extends ethers.utils.Interface {
     "deploymentTimestamp()": FunctionFragment;
     "gnoPrice()": FunctionFragment;
     "usdcPrice()": FunctionFragment;
-    "wethPrice()": FunctionFragment;
+    "nativeTokenPrice()": FunctionFragment;
   };
 
   encodeFunctionData(
@@ -68,7 +68,10 @@ interface VCowInterface extends ethers.utils.Interface {
   ): string;
   encodeFunctionData(functionFragment: "gnoPrice", values?: undefined): string;
   encodeFunctionData(functionFragment: "usdcPrice", values?: undefined): string;
-  encodeFunctionData(functionFragment: "wethPrice", values?: undefined): string;
+  encodeFunctionData(
+    functionFragment: "nativeTokenPrice",
+    values?: undefined
+  ): string;
 
   decodeFunctionResult(functionFragment: "claim", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "claimMany", data: BytesLike): Result;
@@ -80,7 +83,10 @@ interface VCowInterface extends ethers.utils.Interface {
   ): Result;
   decodeFunctionResult(functionFragment: "gnoPrice", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "usdcPrice", data: BytesLike): Result;
-  decodeFunctionResult(functionFragment: "wethPrice", data: BytesLike): Result;
+  decodeFunctionResult(
+    functionFragment: "nativeTokenPrice",
+    data: BytesLike
+  ): Result;
 
   events: {
     "Claimed(uint256,uint8,address,uint256,uint256)": EventFragment;
@@ -177,7 +183,7 @@ export class VCow extends BaseContract {
 
     usdcPrice(overrides?: CallOverrides): Promise<[BigNumber]>;
 
-    wethPrice(overrides?: CallOverrides): Promise<[BigNumber]>;
+    nativeTokenPrice(overrides?: CallOverrides): Promise<[BigNumber]>;
   };
 
   claim(
@@ -211,7 +217,7 @@ export class VCow extends BaseContract {
 
   usdcPrice(overrides?: CallOverrides): Promise<BigNumber>;
 
-  wethPrice(overrides?: CallOverrides): Promise<BigNumber>;
+  nativeTokenPrice(overrides?: CallOverrides): Promise<BigNumber>;
 
   callStatic: {
     claim(
@@ -245,7 +251,7 @@ export class VCow extends BaseContract {
 
     usdcPrice(overrides?: CallOverrides): Promise<BigNumber>;
 
-    wethPrice(overrides?: CallOverrides): Promise<BigNumber>;
+    nativeTokenPrice(overrides?: CallOverrides): Promise<BigNumber>;
   };
 
   filters: {
@@ -319,7 +325,7 @@ export class VCow extends BaseContract {
 
     usdcPrice(overrides?: CallOverrides): Promise<BigNumber>;
 
-    wethPrice(overrides?: CallOverrides): Promise<BigNumber>;
+    nativeTokenPrice(overrides?: CallOverrides): Promise<BigNumber>;
   };
 
   populateTransaction: {
@@ -359,6 +365,6 @@ export class VCow extends BaseContract {
 
     usdcPrice(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
-    wethPrice(overrides?: CallOverrides): Promise<PopulatedTransaction>;
+    nativeTokenPrice(overrides?: CallOverrides): Promise<PopulatedTransaction>;
   };
 }

--- a/src/custom/abis/types/factories/VCow__factory.ts
+++ b/src/custom/abis/types/factories/VCow__factory.ts
@@ -198,7 +198,7 @@ const _abi = [
   },
   {
     inputs: [],
-    name: "wethPrice",
+    name: "nativeTokenPrice",
     outputs: [
       {
         internalType: "uint256",

--- a/src/custom/abis/vCow.json
+++ b/src/custom/abis/vCow.json
@@ -190,7 +190,7 @@
   },
   {
     "inputs": [],
-    "name": "wethPrice",
+    "name": "nativeTokenPrice",
     "outputs": [
       {
         "internalType": "uint256",

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -57,7 +57,7 @@ export const V_COW_CONTRACT_ADDRESS: Partial<Record<number, string>> = {
   // [ChainId.MAINNET]: GPv2Settlement[ChainId.MAINNET].address,
   // [ChainId.RINKEBY]: GPv2Settlement[ChainId.RINKEBY].address,
   // [ChainId.XDAI]: GPv2Settlement[ChainId.XDAI].address,
-  [ChainId.RINKEBY]: '0x71A377EC0026A8E35AfD082d54E2f62d39AF075c',
+  [ChainId.RINKEBY]: '0x64F3A9988Af37e8d832194e4A00E4Eb94a91b764',
 }
 
 // See https://github.com/gnosis/gp-v2-contracts/commit/821b5a8da213297b0f7f1d8b17c893c5627020af#diff-12bbbe13cd5cf42d639e34a39d8795021ba40d3ee1e1a8282df652eb161a11d6R13

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -330,9 +330,7 @@ export function useClaimTimeInfo(): ClaimTimeInfo {
 }
 
 export function useNativeTokenPrice(): string | null {
-  // TODO: rename fn to `nativeTokenPrice` and revert e7197dd27287ff1460a7d7af22734cae938b8c83
-  //  when there's a new deployment
-  return _useVCowPriceForToken('wethPrice')
+  return _useVCowPriceForToken('nativeTokenPrice')
 }
 
 export function useGnoPrice(): string | null {
@@ -346,7 +344,7 @@ export function useUsdcPrice(): string | null {
 /**
  * Generic hook for fetching contract value for the many prices
  */
-function _useVCowPriceForToken(priceFnName: 'wethPrice' | 'gnoPrice' | 'usdcPrice'): string | null {
+function _useVCowPriceForToken(priceFnName: 'nativeTokenPrice' | 'gnoPrice' | 'usdcPrice'): string | null {
   const { chainId } = useActiveWeb3React()
   const vCowContract = useVCowContract()
 


### PR DESCRIPTION
# Summary

Follow up to https://github.com/gnosis/cowswap/pull/2182

- Updating contract address
- Updating ABI and related methods, replacing `wethPrice` by `nativeTokenPrice`

  # To Test

1. Open claim and check for one address that contains paid claims (pick from the list below)
* All prices should be visible and be the same as before

# Addresses

-  0xD5e900280Eb1aDe4E583c2bF2414be247E298435
-  0x7946Fce94A2350a1076a8F97105262c9E07e2a9d
-  0xd46C95581Ac035Bc10D80DD2a121D444e63C2E24
-  0xe93BDEe77cea1aFa9c891C78dca51A16fA287630
-  0x0280a0D231bc48B6A5EcEc3E1dc653Aae6abFf29
-  0x7E5966fFfa6092c6A9b4685A61969C44fa77C18A
-  0xA624B88Bb6A2e752fbe590266a56B940D0206cA4
-  0xa6Caab2e5b5cB306af5ee06a3E4d3b56d9D3B73e
-  0xd0ef9fD6b5795DF8add90E1dc0A16D66e2C5C1E6
-  0x2C8CbbbfEB7E116Cc27e7Ac6cC44958427D0bBA2