### PR TITLE
Fix claim percentages

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -10,6 +10,7 @@ export const INITIAL_ALLOWED_SLIPPAGE_PERCENT = new Percent('5', '1000') // 0.5%
 export const RADIX_DECIMAL = 10
 export const RADIX_HEX = 16
 
+// TODO: remove, this is duplicated with `import { ONE_HUNDRED_PERCENT } from 'constants/misc'`
 export const ONE_HUNDRED_PERCENT = new Percent(1, 1)
 
 export const DEFAULT_DECIMALS = 18

--- a/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState, useEffect } from 'react'
-import CowProtocolLogo from 'components/CowProtocolLogo'
-import { CurrencyAmount, Percent } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 
+import CowProtocolLogo from 'components/CowProtocolLogo'
 import { InvestTokenGroup, TokenLogo, InvestSummary, InvestInput, InvestAvailableBar } from '../styled'
 import { formatSmart } from 'utils/format'
 import Row from 'components/Row'
@@ -18,7 +18,7 @@ import { ButtonSize } from 'theme'
 import Loader from 'components/Loader'
 import { useErrorModal } from 'hooks/useErrorMessageAndModal'
 import { tryParseAmount } from 'state/swap/hooks'
-import { ZERO_PERCENT } from 'constants/misc'
+import { ONE_HUNDRED_PERCENT, ZERO_PERCENT } from 'constants/misc'
 import { PERCENTAGE_PRECISION } from 'constants/index'
 
 enum ErrorMsgs {
@@ -59,7 +59,9 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
 
     updateInvestAmount({ index: optionIndex, amount })
     setTypedValue(formatSmart(value, decimals, { smallLimit: undefined }) || '')
-    setPercentage('100')
+
+    const percentage = _calculatePercentage(balance, maxCost)
+    setPercentage(formatSmart(percentage, PERCENTAGE_PRECISION) || '0')
   }, [balance, decimals, maxCost, noBalance, optionIndex, updateInvestAmount])
 
   // on input field change handler
@@ -78,11 +80,9 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
         return
       }
 
-      // calculate percent
+      // calculate percentage
+
       const maxValue = maxCost.greaterThan(balance) ? balance : maxCost
-      const percent = maxValue.equalTo(ZERO_PERCENT)
-        ? ZERO_PERCENT
-        : new Percent(parsedAmount.quotient, maxValue.quotient)
 
       if (parsedAmount.greaterThan(maxValue)) {
         setInputError(ErrorMsgs.Input)
@@ -94,8 +94,10 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
       // update redux state with new investAmount value
       updateInvestAmount({ index: optionIndex, amount: parsedAmount.quotient.toString() })
 
-      // update the local state with percent value
-      setPercentage(formatSmart(percent, PERCENTAGE_PRECISION) || '0')
+      const percentage = _calculatePercentage(parsedAmount, maxCost)
+
+      // update the local state with percentage value
+      setPercentage(formatSmart(percentage, PERCENTAGE_PRECISION) || '0')
     },
     [balance, maxCost, optionIndex, token, updateInvestAmount]
   )
@@ -253,4 +255,17 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
       </span>
     </InvestTokenGroup>
   )
+}
+
+function _calculatePercentage<C1 extends Currency, C2 extends Currency>(
+  numerator: CurrencyAmount<C1>,
+  denominator: CurrencyAmount<C2>
+): Percent {
+  let percentage = denominator.equalTo(ZERO_PERCENT)
+    ? ZERO_PERCENT
+    : new Percent(numerator.quotient, denominator.quotient)
+  if (percentage.greaterThan(ONE_HUNDRED_PERCENT)) {
+    percentage = ONE_HUNDRED_PERCENT
+  }
+  return percentage
 }

--- a/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
@@ -60,8 +60,7 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
     updateInvestAmount({ index: optionIndex, amount })
     setTypedValue(formatSmart(value, decimals, { smallLimit: undefined }) || '')
 
-    const percentage = _calculatePercentage(balance, maxCost)
-    setPercentage(formatSmart(percentage, PERCENTAGE_PRECISION) || '0')
+    setPercentage(_calculatePercentage(balance, maxCost))
   }, [balance, decimals, maxCost, noBalance, optionIndex, updateInvestAmount])
 
   // on input field change handler
@@ -94,10 +93,8 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
       // update redux state with new investAmount value
       updateInvestAmount({ index: optionIndex, amount: parsedAmount.quotient.toString() })
 
-      const percentage = _calculatePercentage(parsedAmount, maxCost)
-
       // update the local state with percentage value
-      setPercentage(formatSmart(percentage, PERCENTAGE_PRECISION) || '0')
+      setPercentage(_calculatePercentage(parsedAmount, maxCost))
     },
     [balance, maxCost, optionIndex, token, updateInvestAmount]
   )
@@ -260,12 +257,12 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
 function _calculatePercentage<C1 extends Currency, C2 extends Currency>(
   numerator: CurrencyAmount<C1>,
   denominator: CurrencyAmount<C2>
-): Percent {
+): string {
   let percentage = denominator.equalTo(ZERO_PERCENT)
     ? ZERO_PERCENT
     : new Percent(numerator.quotient, denominator.quotient)
   if (percentage.greaterThan(ONE_HUNDRED_PERCENT)) {
     percentage = ONE_HUNDRED_PERCENT
   }
-  return percentage
+  return formatSmart(percentage, PERCENTAGE_PRECISION) || '0'
 }


### PR DESCRIPTION
# Summary

Merges onto https://github.com/gnosis/cowswap/pull/2200/

Fixing percentages calculation


https://user-images.githubusercontent.com/43217/150044725-c6e301d0-ab6c-4775-a070-ed1041ea4b2f.mov

Now, when balance < maxCost and `max` button is clicked, percentage will acknowledge that not 100% of the investment is being used

  # To Test

1. Load the PK `0xa5dea1ad74d02266c73d71518eacfef55df9410dc94575efef8c3c219b96de36` on rinkeby
2. This account has claim and amounts of fake tokens for USDC that are smaller than total investment available
3. On approval page, click on max button for USDC
* It should not show 100%, but instead the proportional amount of the total investment