### PR TITLE
Claim instead of claimed

### DIFF
--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -496,7 +496,7 @@ export function useClaimCallback(account: string | null | undefined): {
         return vCowContract.claimMany(...extendedArgs).then((response: TransactionResponse) => {
           addTransaction({
             hash: response.hash,
-            summary: `Claimed ${formatSmart(vCowAmount)} vCOW`,
+            summary: `Claim ${formatSmart(vCowAmount)} vCOW`,
             claim: { recipient: account, indices: args[0] as number[] },
           })
           return response.hash


### PR DESCRIPTION
# Summary

Before:
![image](https://user-images.githubusercontent.com/2352112/150189393-7a3a9191-955c-41d9-947b-1f54f7dafddc.png)

We don't use `past tense` because this message is used also when it failed or when is pending.

I changed it to `Claim`, it was mentioned also as part of #2082 

# To Test

1. Just do some claiming and see the new message