### PR TITLE
Hide claim button for claiming/claimed states

### DIFF
--- a/src/custom/pages/Claim/FooterNavButtons.tsx
+++ b/src/custom/pages/Claim/FooterNavButtons.tsx
@@ -62,7 +62,7 @@ export default function FooterNavButtons({
   }
 
   // User has no set active claim account and/or has claims, show claim account search
-  if (!activeClaimAccount || !hasClaims) {
+  if ((!activeClaimAccount || !hasClaims) && claimStatus === ClaimStatus.DEFAULT) {
     buttonContent = (
       <ButtonPrimary disabled={!isInputAddressValid} type="text" onClick={handleCheckClaim}>
         <Trans>Check claimable vCOW</Trans>


### PR DESCRIPTION
# Summary

This PR removes the claim button for all states but the `DEFAULT`, meaning, it will be hidden when:
- attempting to claim
- submitted a claim
- confirmed a claim

It was something that was confusing users in the sessions.

<img width="1105" alt="Screenshot at Jan 19 18-46-02" src="https://user-images.githubusercontent.com/2352112/150194943-a989014c-a97d-42d9-8cab-6ba9368c1fad.png">



![image](https://user-images.githubusercontent.com/2352112/150194914-d98bfec6-d7db-49ed-9d5b-e47ff708fa81.png)


# To Test

1. Do a claim of any kind
2. Make sure the button is not present while pending or in the success page
