### PR TITLE
Claim last investment page

### DIFF
--- a/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
@@ -122,14 +122,10 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
     }
   }, [approveCallback, handleCloseError, handleSetError, token?.symbol])
 
-  const vCowAmount = useMemo(() => {
-    if (!token || !price || !investedAmount) {
-      return
-    }
-
-    const investA = CurrencyAmount.fromRawAmount(token, investedAmount)
-    return price.quote(investA)
-  }, [investedAmount, price, token])
+  const vCowAmount = useMemo(
+    () => calculateInvestmentAmounts(claim, investedAmount)?.vCowAmount,
+    [claim, investedAmount]
+  )
 
   // if its claiming for someone else we will set values to max
   // if there is not enough balance then we will set an error

--- a/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo, useState, useEffect } from 'react'
-import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 
 import CowProtocolLogo from 'components/CowProtocolLogo'
 import { InvestTokenGroup, TokenLogo, InvestSummary, InvestInput, InvestAvailableBar } from '../styled'
@@ -18,8 +17,7 @@ import { ButtonSize } from 'theme'
 import Loader from 'components/Loader'
 import { useErrorModal } from 'hooks/useErrorMessageAndModal'
 import { tryParseAmount } from 'state/swap/hooks'
-import { ONE_HUNDRED_PERCENT, ZERO_PERCENT } from 'constants/misc'
-import { PERCENTAGE_PRECISION } from 'constants/index'
+import { calculateInvestmentAmounts, calculatePercentage } from 'state/claim/hooks/utils'
 
 enum ErrorMsgs {
   Initial = 'Insufficient balance to cover the selected investment amount. Either modify the investment amount or unselect the investment option to move forward',
@@ -61,7 +59,7 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
     setTypedValue(value.toExact() || '')
     setInputError('')
 
-    setPercentage(_calculatePercentage(balance, maxCost))
+    setPercentage(calculatePercentage(balance, maxCost))
   }, [balance, maxCost, noBalance, optionIndex, updateInvestAmount])
 
   // on input field change handler
@@ -96,7 +94,7 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
       updateInvestAmount({ index: optionIndex, amount: parsedAmount.quotient.toString() })
 
       // update the local state with percentage value
-      setPercentage(_calculatePercentage(parsedAmount, maxCost))
+      setPercentage(calculatePercentage(parsedAmount, maxCost))
     },
     [balance, maxCost, optionIndex, token, updateInvestAmount]
   )
@@ -255,17 +253,4 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
       </span>
     </InvestTokenGroup>
   )
-}
-
-function _calculatePercentage<C1 extends Currency, C2 extends Currency>(
-  numerator: CurrencyAmount<C1>,
-  denominator: CurrencyAmount<C2>
-): string {
-  let percentage = denominator.equalTo(ZERO_PERCENT)
-    ? ZERO_PERCENT
-    : new Percent(numerator.quotient, denominator.quotient)
-  if (percentage.greaterThan(ONE_HUNDRED_PERCENT)) {
-    percentage = ONE_HUNDRED_PERCENT
-  }
-  return formatSmart(percentage, PERCENTAGE_PRECISION) || '0'
 }

--- a/src/custom/pages/Claim/InvestmentFlow/InvestSummaryRow.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestSummaryRow.tsx
@@ -1,0 +1,67 @@
+import { ClaimType } from 'state/claim/hooks'
+import { TokenLogo } from 'pages/Claim/styled'
+import { EnhancedUserClaimData } from 'pages/Claim/types'
+import CowProtocolLogo from 'components/CowProtocolLogo'
+import { formatSmart } from 'utils/format'
+
+export type Props = { claim: EnhancedUserClaimData }
+
+export function InvestSummaryRow(props: Props): JSX.Element | null {
+  const { claim } = props
+
+  const { isFree, type, price, claimAmount, currencyAmount } = claim
+
+  const symbol = isFree ? '' : (currencyAmount?.currency?.symbol as string)
+
+  return (
+    <tr>
+      <td>
+        {isFree ? (
+          <b>{ClaimType[type]}</b>
+        ) : (
+          <>
+            <TokenLogo symbol={symbol} size={32} />
+            <CowProtocolLogo size={32} />
+            <span>
+              <b>Buy vCOW</b>
+              <i>with {symbol}</i>
+            </span>
+          </>
+        )}
+      </td>
+
+      <td>
+        {!isFree && (
+          <span>
+            {/* TODO: get investment amount and calculate percentage of maxCost */}
+            <b>Investment amount:</b> <i>1343 {symbol} (50% of available investing opportunity)</i>
+          </span>
+        )}
+        <span>
+          <b>Amount to receive:</b>
+          {/* TODO: claimAmount only for free claims, need to calculate for paid claims */}
+          <i>{formatSmart(claimAmount) || '0'} vCOW</i>
+        </span>
+      </td>
+
+      <td>
+        {!isFree && (
+          <span>
+            <b>Price:</b>{' '}
+            <i>
+              {formatSmart(price) || '0'} vCoW per {symbol}
+            </i>
+          </span>
+        )}
+        <span>
+          {/* TODO: calculate proper cost */}
+          <b>Cost:</b> <i>{isFree ? 'Free!' : `${formatSmart(currencyAmount) || '0'} ${symbol}`}</i>
+        </span>
+        <span>
+          <b>Vesting:</b>
+          <i>{type === ClaimType.Airdrop ? 'No' : '4 years (linear)'}</i>
+        </span>
+      </td>
+    </tr>
+  )
+}

--- a/src/custom/pages/Claim/InvestmentFlow/InvestSummaryRow.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestSummaryRow.tsx
@@ -1,17 +1,23 @@
 import { ClaimType } from 'state/claim/hooks'
+import { calculatePercentage } from 'state/claim/hooks/utils'
 import { TokenLogo } from 'pages/Claim/styled'
-import { EnhancedUserClaimData } from 'pages/Claim/types'
+import { ClaimWithInvestmentData } from 'pages/Claim/types'
 import CowProtocolLogo from 'components/CowProtocolLogo'
 import { formatSmart } from 'utils/format'
+import { AMOUNT_PRECISION } from 'constants/index'
 
-export type Props = { claim: EnhancedUserClaimData }
+export type Props = { claim: ClaimWithInvestmentData }
 
 export function InvestSummaryRow(props: Props): JSX.Element | null {
   const { claim } = props
 
-  const { isFree, type, price, claimAmount, currencyAmount } = claim
+  const { isFree, type, price, currencyAmount, vCowAmount, cost, investmentCost } = claim
 
   const symbol = isFree ? '' : (currencyAmount?.currency?.symbol as string)
+
+  const formattedCost =
+    formatSmart(investmentCost, AMOUNT_PRECISION, { thousandSeparator: true, isLocaleAware: true }) || '0'
+  const percentage = investmentCost && cost && calculatePercentage(investmentCost, cost)
 
   return (
     <tr>
@@ -33,14 +39,15 @@ export function InvestSummaryRow(props: Props): JSX.Element | null {
       <td>
         {!isFree && (
           <span>
-            {/* TODO: get investment amount and calculate percentage of maxCost */}
-            <b>Investment amount:</b> <i>1343 {symbol} (50% of available investing opportunity)</i>
+            <b>Investment amount:</b>{' '}
+            <i>
+              {formattedCost} {symbol} ({percentage}% of available investing opportunity)
+            </i>
           </span>
         )}
         <span>
           <b>Amount to receive:</b>
-          {/* TODO: claimAmount only for free claims, need to calculate for paid claims */}
-          <i>{formatSmart(claimAmount) || '0'} vCOW</i>
+          <i>{formatSmart(vCowAmount) || '0'} vCOW</i>
         </span>
       </td>
 
@@ -54,8 +61,7 @@ export function InvestSummaryRow(props: Props): JSX.Element | null {
           </span>
         )}
         <span>
-          {/* TODO: calculate proper cost */}
-          <b>Cost:</b> <i>{isFree ? 'Free!' : `${formatSmart(currencyAmount) || '0'} ${symbol}`}</i>
+          <b>Cost:</b> <i>{isFree ? 'Free!' : `${formattedCost} ${symbol}`}</i>
         </span>
         <span>
           <b>Vesting:</b>

--- a/src/custom/pages/Claim/InvestmentFlow/index.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/index.tsx
@@ -187,7 +187,7 @@ export default function InvestmentFlow({ hasClaims, isAirdropOnly, ...tokenAppro
           </p>
           <p>
             <b>Can I modify the invested amounts or invest partial amounts later?</b> No. Once you send the transaction,
-            you cannot increase or reduce the investment. Investment oportunities can only be exercised once.
+            you cannot increase or reduce the investment. Investment opportunities can only be exercised once.
           </p>
           <p>
             <b>Important!</b> Please make sure you intend to claim and send vCOW to the mentioned receiving account(s)

--- a/src/custom/pages/Claim/InvestmentFlow/index.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/index.tsx
@@ -55,8 +55,18 @@ export default function InvestmentFlow({ hasClaims, isAirdropOnly, ...tokenAppro
   const { initInvestFlowData } = useClaimDispatchers()
   const claimData = useUserEnhancedClaimData(activeClaimAccount)
 
-  const selectedClaims = useMemo(() => {
-    return claimData.filter(({ index }) => selected.includes(index))
+  const [freeClaims, paidClaims] = useMemo(() => {
+    const paid: EnhancedUserClaimData[] = []
+    const free: EnhancedUserClaimData[] = []
+
+    claimData.forEach((claim) => {
+      if (claim.isFree) {
+        free.push(claim)
+      } else if (selected.includes(claim.index)) {
+        paid.push(claim)
+      }
+    })
+    return [free, paid]
   }, [claimData, selected])
 
   useEffect(() => {
@@ -98,7 +108,7 @@ export default function InvestmentFlow({ hasClaims, isAirdropOnly, ...tokenAppro
             up to a predefined maximum amount of tokens{' '}
           </p>
 
-          {selectedClaims.map((claim, index) => (
+          {paidClaims.map((claim, index) => (
             <InvestOption
               key={claim.index}
               optionIndex={index}

--- a/src/custom/pages/Claim/InvestmentFlow/index.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/index.tsx
@@ -57,7 +57,7 @@ export default function InvestmentFlow({ hasClaims, isAirdropOnly, ...tokenAppro
   const claimData = useUserEnhancedClaimData(activeClaimAccount)
 
   // filtering and splitting claims into free and selected paid claims
-  const [_freeClaims, _paidClaims] = useMemo(() => {
+  const [_freeClaims, _selectedClaims] = useMemo(() => {
     const paid: EnhancedUserClaimData[] = []
     const free: EnhancedUserClaimData[] = []
 
@@ -79,17 +79,17 @@ export default function InvestmentFlow({ hasClaims, isAirdropOnly, ...tokenAppro
 
   // Adding investment data for paid claims
   // It's separated from free claims because this depends on `investmentFlowData`, while free claims do not
-  const paidClaims = useMemo(
+  const selectedClaims = useMemo(
     () =>
-      _paidClaims.map<ClaimWithInvestmentData>((claim) => {
+      _selectedClaims.map<ClaimWithInvestmentData>((claim) => {
         const investmentAmount = investFlowData.find(({ index }) => index === claim.index)?.investedAmount
 
         return { ...claim, ...calculateInvestmentAmounts(claim, investmentAmount) }
       }),
-    [_paidClaims, investFlowData]
+    [_selectedClaims, investFlowData]
   )
 
-  const allClaims = useMemo(() => freeClaims.concat(paidClaims), [freeClaims, paidClaims])
+  const allClaims = useMemo(() => freeClaims.concat(selectedClaims), [freeClaims, selectedClaims])
   useEffect(() => {
     initInvestFlowData()
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -129,7 +129,7 @@ export default function InvestmentFlow({ hasClaims, isAirdropOnly, ...tokenAppro
             up to a predefined maximum amount of tokens{' '}
           </p>
 
-          {paidClaims.map((claim, index) => (
+          {selectedClaims.map((claim, index) => (
             <InvestOption
               key={claim.index}
               optionIndex={index}

--- a/src/custom/pages/Claim/InvestmentFlow/index.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/index.tsx
@@ -8,15 +8,14 @@ import {
   Steps,
   ClaimTable,
   AccountClaimSummary,
-  TokenLogo,
 } from 'pages/Claim/styled'
+import { InvestSummaryRow } from 'pages/Claim/InvestmentFlow/InvestSummaryRow'
 import { ClaimType, useClaimState, useUserEnhancedClaimData, useClaimDispatchers } from 'state/claim/hooks'
 import { ClaimCommonTypes, EnhancedUserClaimData } from '../types'
 import { ClaimStatus } from 'state/claim/actions'
 import { useActiveWeb3React } from 'hooks/web3'
 import { ApprovalState, OptionalApproveCallbackParams } from 'hooks/useApproveCallback'
 import InvestOption from './InvestOption'
-import CowProtocolLogo from 'components/CowProtocolLogo'
 
 export type InvestOptionProps = {
   claim: EnhancedUserClaimData
@@ -156,62 +155,9 @@ export default function InvestmentFlow({ hasClaims, isAirdropOnly, ...tokenAppro
                 </tr>
               </thead>
               <tbody>
-                <tr>
-                  <td>
-                    <b>Airdrop</b>
-                  </td>
-                  <td>
-                    <span>
-                      <b>Amount to receive:</b>
-                      <i>13,120.50 vCOW</i>
-                    </span>
-                  </td>
-
-                  <td>
-                    <span>
-                      <b>Cost:</b> <i>Free!</i>
-                    </span>
-                    <span>
-                      <b>Vesting:</b>
-                      <i>No</i>
-                    </span>
-                  </td>
-                </tr>
-
-                <tr>
-                  <td>
-                    {' '}
-                    <TokenLogo symbol="GNO" size={32} />
-                    <CowProtocolLogo size={32} />
-                    <span>
-                      <b>Buy vCOW</b>
-                      <i>with GNO</i>
-                    </span>
-                  </td>
-
-                  <td>
-                    <span>
-                      <b>Investment amount:</b> <i>1343 GNO (50% of available investing opportunity)</i>
-                    </span>
-                    <span>
-                      <b>Amount to receive:</b>
-                      <i>13,120.50 vCOW</i>
-                    </span>
-                  </td>
-
-                  <td>
-                    <span>
-                      <b>Price:</b> <i>2666.6666 vCoW per GNO</i>
-                    </span>
-                    <span>
-                      <b>Cost:</b> <i>0.783375 GNO</i>
-                    </span>
-                    <span>
-                      <b>Vesting:</b>
-                      <i>4 years (linear)</i>
-                    </span>
-                  </td>
-                </tr>
+                {freeClaims.concat(paidClaims).map((claim) => (
+                  <InvestSummaryRow claim={claim} key={claim.index} />
+                ))}
               </tbody>
             </table>
           </ClaimTable>

--- a/src/custom/pages/Claim/styled.ts
+++ b/src/custom/pages/Claim/styled.ts
@@ -191,11 +191,23 @@ export const TokenLogo = styled.div<{ symbol: string; size: number }>`
   width: ${({ size }) => `${size}px`};
   height: ${({ size }) => `${size}px`};
   border-radius: ${({ size }) => `${size}px`};
-  background: ${({ symbol, theme }) =>
-    `url(${
-      symbol === 'GNO' ? LogoGNO : symbol === 'ETH' ? LogoETH : symbol === 'USDC' ? LogoUSDC : theme.blueShade3
-    }) no-repeat center/contain`};
+  background: ${({ symbol, theme }) => `url(${_getLogo(symbol) || theme.blueShade3}) no-repeat center/contain`};
 `
+
+function _getLogo(symbol: string) {
+  switch (symbol.toUpperCase()) {
+    case 'GNO':
+      return LogoGNO
+    case 'USDC':
+      return LogoUSDC
+    case 'ETH':
+      return LogoETH
+    // TODO: add xDai token logo after merging to develop
+    // case 'XDAI': return LogoXDAI
+    default:
+      return undefined
+  }
+}
 
 export const ClaimSummary = styled.div`
   display: flex;

--- a/src/custom/pages/Claim/types.ts
+++ b/src/custom/pages/Claim/types.ts
@@ -18,3 +18,10 @@ export type EnhancedUserClaimData = UserClaimData & {
   price?: Price<Currency, Currency> | undefined
   cost?: CurrencyAmount<Currency> | undefined
 }
+
+export type InvestmentAmounts = {
+  vCowAmount?: CurrencyAmount<Currency>
+  investmentCost?: CurrencyAmount<Currency>
+}
+
+export type ClaimWithInvestmentData = EnhancedUserClaimData & InvestmentAmounts

--- a/src/custom/state/claim/hooks/utils.ts
+++ b/src/custom/state/claim/hooks/utils.ts
@@ -1,7 +1,9 @@
-import { CurrencyAmount, Token } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount, Percent, Token } from '@uniswap/sdk-core'
 
 import { SupportedChainId } from 'constants/chains'
 import { GNO, GpEther, USDC_BY_CHAIN, V_COW } from 'constants/tokens'
+import { ONE_HUNDRED_PERCENT, ZERO_PERCENT } from 'constants/misc'
+import { PERCENTAGE_PRECISION } from 'constants/index'
 
 import {
   CLAIMS_REPO,
@@ -15,6 +17,7 @@ import {
   VCowPrices,
 } from 'state/claim/hooks/index'
 
+import { formatSmart } from 'utils/format'
 /**
  * Helper function to check whether any claim is an investment option
  *
@@ -173,4 +176,20 @@ export function claimTypeToTokenAmount(type: ClaimType, chainId: SupportedChainI
     default:
       return undefined
   }
+}
+
+/**
+ * Helper function to calculate and return the percentage between 2 CurrencyAmount instances
+ */
+export function calculatePercentage<C1 extends Currency, C2 extends Currency>(
+  numerator: CurrencyAmount<C1>,
+  denominator: CurrencyAmount<C2>
+): string {
+  let percentage = denominator.equalTo(ZERO_PERCENT)
+    ? ZERO_PERCENT
+    : new Percent(numerator.quotient, denominator.quotient)
+  if (percentage.greaterThan(ONE_HUNDRED_PERCENT)) {
+    percentage = ONE_HUNDRED_PERCENT
+  }
+  return formatSmart(percentage, PERCENTAGE_PRECISION) || '0'
 }

--- a/src/custom/state/claim/hooks/utils.ts
+++ b/src/custom/state/claim/hooks/utils.ts
@@ -18,6 +18,8 @@ import {
 } from 'state/claim/hooks/index'
 
 import { formatSmart } from 'utils/format'
+import { EnhancedUserClaimData, InvestmentAmounts } from 'pages/Claim/types'
+
 /**
  * Helper function to check whether any claim is an investment option
  *
@@ -192,4 +194,24 @@ export function calculatePercentage<C1 extends Currency, C2 extends Currency>(
     percentage = ONE_HUNDRED_PERCENT
   }
   return formatSmart(percentage, PERCENTAGE_PRECISION) || '0'
+}
+
+/**
+ * Helper function that calculates vCowAmount (in vCOW) and investedAmount (in investing token)
+ */
+export function calculateInvestmentAmounts(
+  claim: Pick<EnhancedUserClaimData, 'isFree' | 'price' | 'currencyAmount' | 'claimAmount'>,
+  investedAmount?: string
+): InvestmentAmounts {
+  const { isFree, price, currencyAmount, claimAmount } = claim
+
+  if (isFree || !investedAmount) {
+    // default to 100% when no investment amount is set
+    return { vCowAmount: claimAmount, investmentCost: currencyAmount }
+  } else if (!currencyAmount || !price) {
+    return {}
+  }
+
+  const amount = CurrencyAmount.fromRawAmount(currencyAmount.currency, investedAmount)
+  return { vCowAmount: price.quote(amount), investmentCost: amount }
 }


### PR DESCRIPTION
# Summary

Wire up last investment step, the investment summary

![Screen Shot 2022-01-19 at 16 29 13](https://user-images.githubusercontent.com/43217/150240406-12769584-8544-4c98-ae30-581a3f28eb2c.png)

  # To Test

1. Open the claim page and check one account that has at least one paid claim. At the bottom there are a couple with multiple claims
1. Select at least one paid claim and go all the way to the review page
* All the selected claims (including all free claims) should be visible
* The amounts must match what was selected and shown in the previous step

# Accounts

-  0xfD40fcF9AD20C8fe4936E552833696496EA88E01
-  0xC9A49b13A88Bd25E133AA1A709E5c31a2fc61591
-  0x5239d4A1ff381f089D990Cd50B441cC9EFfE0ba3
-  0x9470a102B9d6a3a00103537C2bC35ac0587Bd436
-  0x2F144ff590C94871f118583E61fdDd06b98120e4
-  0x42cE50b0387A081b51DAAE489DD4129CEc5a78f1
-  0x6f14181e316377f683a9AE331B244717d38E619b
-  0x05A1b71BF498d4A3930BA1f940E2D58C2150b399
-  0x525Aa961cb6A422F325445F4529d58A5df3d19cc
-  0x059E927e96079AffCC63583399641d1Da33e9Dd2