### PR TITLE
[CLAIM - Approve] Wire new approve logic into app (fixes broken merge stuff also)

### DIFF
--- a/src/custom/hooks/useApproveCallback/index.ts
+++ b/src/custom/hooks/useApproveCallback/index.ts
@@ -12,7 +12,7 @@ export { ApprovalState, useApproveCallback } from './useApproveCallbackMod'
 import { ClaimType } from 'state/claim/hooks'
 import { supportedChainId } from 'utils/supportedChainId'
 import { tryAtomsToCurrency } from 'state/swap/extension'
-import { EnhancedUserClaimData } from '@src/custom/pages/Claim/types'
+import { EnhancedUserClaimData } from 'pages/Claim/types'
 
 type ApproveCallbackFromTradeParams = Pick<
   ApproveCallbackParams,

--- a/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
@@ -58,7 +58,7 @@ export default function InvestOption({ claim, optionIndex, openModal, closeModal
   const [approveState, approveCallback] = useApproveCallbackFromClaim({
     openTransactionConfirmationModal: () => openModal(_claimApproveMessageMap(claim.type), OperationType.APPROVE_TOKEN),
     closeModals: closeModal,
-    claimType: claim.type,
+    claim,
     investmentAmount,
   })
 

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo } from 'react'
-import { CurrencyAmount, MaxUint256 } from '@uniswap/sdk-core'
 import { useActiveWeb3React } from 'hooks/web3'
 import { useUserEnhancedClaimData, useUserUnclaimedAmount, useClaimCallback, ClaimInput } from 'state/claim/hooks'
 import { PageWrapper } from 'pages/Claim/styled'
@@ -21,21 +20,15 @@ import InvestmentFlow from './InvestmentFlow'
 import { useClaimDispatchers, useClaimState } from 'state/claim/hooks'
 import { ClaimStatus } from 'state/claim/actions'
 
-import { useApproveCallbackFromClaim } from 'hooks/useApproveCallback'
 import { OperationType } from 'components/TransactionConfirmationModal'
 import useTransactionConfirmationModal from 'hooks/useTransactionConfirmationModal'
 
-import { GNO, USDC_BY_CHAIN } from 'constants/tokens'
-import { isSupportedChain } from 'utils/supportedChainId'
 import { useErrorModal } from 'hooks/useErrorMessageAndModal'
 import { EnhancedUserClaimData } from './types'
 import FooterNavButtons from './FooterNavButtons'
 
-const GNO_CLAIM_APPROVE_MESSAGE = 'Approving GNO for investing in vCOW'
-const USDC_CLAIM_APPROVE_MESSAGE = 'Approving USDC for investing in vCOW'
-
 export default function Claim() {
-  const { account, chainId } = useActiveWeb3React()
+  const { account } = useActiveWeb3React()
 
   const {
     // address/ENS address
@@ -184,26 +177,6 @@ export default function Claim() {
     OperationType.APPROVE_TOKEN
   )
 
-  const [gnoApproveState, gnoApproveCallback] = useApproveCallbackFromClaim({
-    openTransactionConfirmationModal: () => openModal(GNO_CLAIM_APPROVE_MESSAGE, OperationType.APPROVE_TOKEN),
-    closeModals: closeModal,
-    // approve max unit256 amount
-    amountToApprove: isSupportedChain(chainId) ? CurrencyAmount.fromRawAmount(GNO[chainId], MaxUint256) : undefined,
-    // TODO: enable, fix this
-    // amountToCheckAgainstAllowance: investmentAmountAsCurrency,
-  })
-
-  const [usdcApproveState, usdcApproveCallback] = useApproveCallbackFromClaim({
-    openTransactionConfirmationModal: () => openModal(USDC_CLAIM_APPROVE_MESSAGE, OperationType.APPROVE_TOKEN),
-    closeModals: closeModal,
-    // approve max unit256 amount
-    amountToApprove: isSupportedChain(chainId)
-      ? CurrencyAmount.fromRawAmount(USDC_BY_CHAIN[chainId], MaxUint256)
-      : undefined,
-    // TODO: enable, fix this
-    // amountToCheckAgainstAllowance: investmentAmountAsCurrency,
-  })
-
   return (
     <PageWrapper>
       {/* Approve confirmation modal */}
@@ -229,18 +202,7 @@ export default function Claim() {
       {/* IS Airdrop + investing (advanced) */}
       <ClaimsTable isAirdropOnly={isAirdropOnly} hasClaims={hasClaims} />
       {/* Investing vCOW flow (advanced) */}
-      <InvestmentFlow
-        isAirdropOnly={isAirdropOnly}
-        hasClaims={hasClaims}
-        gnoApproveData={{
-          approveCallback: gnoApproveCallback,
-          approveState: gnoApproveState,
-        }}
-        usdcApproveData={{
-          approveCallback: usdcApproveCallback,
-          approveState: usdcApproveState,
-        }}
-      />
+      <InvestmentFlow isAirdropOnly={isAirdropOnly} hasClaims={hasClaims} modalCbs={{ openModal, closeModal }} />
 
       <FooterNavButtons
         handleCheckClaim={handleCheckClaim}

--- a/src/custom/state/claim/hooks/utils.ts
+++ b/src/custom/state/claim/hooks/utils.ts
@@ -164,17 +164,32 @@ export type PaidClaimTypeToPriceMap = {
   [type in ClaimType]: { token: Token; amount: string } | undefined
 }
 
+export function claimTypeToToken(type: ClaimType, chainId: SupportedChainId) {
+  switch (type) {
+    case ClaimType.GnoOption:
+      return GNO[chainId]
+    case ClaimType.Investor:
+      return USDC_BY_CHAIN[chainId]
+    case ClaimType.UserOption:
+      return GpEther.onChain(chainId)
+    case ClaimType.Advisor:
+    case ClaimType.Airdrop:
+    case ClaimType.Team:
+      return undefined
+  }
+}
+
 /**
  * Helper function to get vCow price based on claim type and chainId
  */
 export function claimTypeToTokenAmount(type: ClaimType, chainId: SupportedChainId, prices: VCowPrices) {
   switch (type) {
     case ClaimType.GnoOption:
-      return { token: GNO[chainId], amount: prices.gno as string }
+      return { token: claimTypeToToken(ClaimType.GnoOption, chainId) as Token, amount: prices.gno as string }
     case ClaimType.Investor:
-      return { token: USDC_BY_CHAIN[chainId], amount: prices.usdc as string }
+      return { token: claimTypeToToken(ClaimType.Investor, chainId) as Token, amount: prices.usdc as string }
     case ClaimType.UserOption:
-      return { token: GpEther.onChain(chainId), amount: prices.native as string }
+      return { token: claimTypeToToken(ClaimType.UserOption, chainId) as GpEther, amount: prices.native as string }
     default:
       return undefined
   }

--- a/src/custom/state/swap/extension.ts
+++ b/src/custom/state/swap/extension.ts
@@ -15,6 +15,12 @@ interface TradeParams {
 export const stringToCurrency = (amount: string, currency: Currency) =>
   CurrencyAmount.fromRawAmount(currency, JSBI.BigInt(amount))
 
+export const tryAtomsToCurrency = (atoms: string | undefined, currency: Currency | undefined) => {
+  if (!atoms || !currency) return undefined
+
+  return stringToCurrency(atoms, currency)
+}
+
 /**
  * useTradeExactInWithFee
  * @description wraps useTradeExactIn and returns an extended trade object with the fee adjusted values


### PR DESCRIPTION
# Summary

Wires in the new `useApproveCallbackFromClaim` - which has been tweaked to better handle how the claim flow works.

## Testing
1. Use an account that has GNO/USDC & NO APPROVALS
2. Using same account, approve GNO/USDC and note that in MM the approve amount is huge
3. reload app, see that it is approved
4. Using same connected account, hit "Change account" and paste an account with paid claims GNO/USDC (fresh address that doesn't have approvals)
5. See that tokens are approved because you are using the connected account from step 1 which is approved
6. ETH is already approved