### PR TITLE
Claim pending icon spinner and show timezone.

### DIFF
--- a/src/custom/pages/Claim/CanUserClaimMessage.tsx
+++ b/src/custom/pages/Claim/CanUserClaimMessage.tsx
@@ -26,7 +26,10 @@ export default function CanUserClaimMessage({ hasClaims, isAirdropOnly }: ClaimI
           <Trans>
             Thank you for being a supporter of CowSwap and the CoW protocol. As an important member of the CowSwap
             Community you may claim vCOW to be used for voting and governance. You can claim your tokens until{' '}
-            <i>{airdropDeadline && new Date(airdropDeadline).toLocaleString()}</i>
+            <i>
+              {airdropDeadline && new Date(airdropDeadline).toLocaleString()} (
+              {Intl.DateTimeFormat().resolvedOptions().timeZone})
+            </i>
             <ExternalLink href="https://cow.fi/">Read more about vCOW</ExternalLink>
           </Trans>
         </p>

--- a/src/custom/pages/Claim/ClaimingStatus.tsx
+++ b/src/custom/pages/Claim/ClaimingStatus.tsx
@@ -1,11 +1,10 @@
 import { Trans } from '@lingui/macro'
-import { ConfirmOrLoadingWrapper, ConfirmedIcon, AttemptFooter } from 'pages/Claim/styled'
-import { ExternalLink, CustomLightSpinner } from 'theme'
+import { ConfirmOrLoadingWrapper, ConfirmedIcon, AttemptFooter, CowSpinner } from 'pages/Claim/styled'
+import { ExternalLink } from 'theme'
 import { ClaimStatus } from 'state/claim/actions'
 import { useClaimState } from 'state/claim/hooks'
 import { useActiveWeb3React } from 'hooks/web3'
 import CowProtocolLogo from 'components/CowProtocolLogo'
-import Circle from 'assets/images/blue-loader.svg'
 import { ExplorerDataType, getExplorerLink } from 'utils/getExplorerLink'
 import { useAllClaimingTransactions } from 'state/enhancedTransactions/hooks'
 import { useMemo } from 'react'
@@ -31,7 +30,13 @@ export default function ClaimingStatus() {
   return (
     <ConfirmOrLoadingWrapper activeBG={true}>
       <ConfirmedIcon>
-        {!isConfirmed ? <CustomLightSpinner src={Circle} alt="loader" size={'90px'} /> : <CowProtocolLogo size={100} />}
+        {!isConfirmed ? (
+          <CowSpinner>
+            <CowProtocolLogo />
+          </CowSpinner>
+        ) : (
+          <CowProtocolLogo size={100} />
+        )}
       </ConfirmedIcon>
       <h3>{isConfirmed ? 'Claimed!' : 'Claiming'}</h3>
       {/* TODO: fix this in new pr */}

--- a/src/custom/pages/Claim/styled.ts
+++ b/src/custom/pages/Claim/styled.ts
@@ -476,7 +476,7 @@ export const ConfirmOrLoadingWrapper = styled.div<{ activeBG: boolean }>`
     font-weight: 600;
     line-height: 1.2;
     text-align: center;
-    margin: 0 0 24px;
+    margin: 0 0 12px;
     color: ${({ theme }) => theme.text1};
   }
 `
@@ -486,10 +486,12 @@ export const AttemptFooter = styled.div`
   width: 100%;
   justify-content: center;
   align-items: center;
+  margin: 24px 0 0;
 
   > p {
     font-size: 14px;
     opacity: 0.7;
+    margin: 0;
   }
 `
 
@@ -1107,5 +1109,66 @@ export const AccountClaimSummary = styled.div`
   > span > i {
     font-style: normal;
     break-word: break-all;
+  }
+`
+
+export const CowSpinner = styled.div`
+  --circle-size: 120px;
+  --border-radius: 100%;
+  --border-size: 2px;
+  border-radius: var(--circle-size);
+  height: var(--circle-size);
+  width: var(--circle-size);
+  margin: 0 auto 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: var(--border-size);
+    right: var(--border-size);
+    bottom: var(--border-size);
+    left: var(--border-size);
+    z-index: 0;
+    border-radius: calc(var(--border-radius) - var(--border-size));
+    box-shadow: inset 0 1px 1px 0 hsl(0deg 0% 100% / 10%), 0 10px 40px -20px #000000;
+  }
+
+  &::before {
+    content: '';
+    ${({ theme }) => theme.iconGradientBorder};
+    display: block;
+    width: var(--circle-size);
+    padding: 0;
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    margin: auto;
+    border-radius: 100%;
+    z-index: 0;
+    animation: spin 1.5s linear infinite;
+  }
+
+  > span {
+    height: 94%;
+    width: 94%;
+    padding: 0;
+    stroke: ${({ theme }) => theme.text1};
+    border-radius: var(--circle-size);
+    z-index: 1;
+  }
+
+  @keyframes spin {
+    from {
+      transform: rotate(0);
+    }
+    to {
+      transform: rotate(360deg);
+    }
   }
 `


### PR DESCRIPTION
# Summary

- Show a pending spinner with the cow token

https://user-images.githubusercontent.com/31534717/150393215-87956fb7-a3ed-491f-843f-f78745204f37.mov

- Show the time zone explicitly (we could also show the offset time instead, e.g. GMT+1)
<img width="852" alt="Screen Shot 2022-01-20 at 18 44 03" src="https://user-images.githubusercontent.com/31534717/150393289-efc18c14-5eaa-4ba0-aeb1-0aa2443b2859.png">

