### PR TITLE
Total vcow on investment summary

### DIFF
--- a/src/custom/pages/Claim/ClaimSummary.tsx
+++ b/src/custom/pages/Claim/ClaimSummary.tsx
@@ -1,16 +1,18 @@
 import { Trans } from '@lingui/macro'
+import { CurrencyAmount, Currency } from '@uniswap/sdk-core'
 import CowProtocolLogo from 'components/CowProtocolLogo'
 import { formatSmart } from 'utils/format'
 import { useClaimState } from 'state/claim/hooks'
 import { ClaimSummary as ClaimSummaryWrapper, ClaimSummaryTitle, ClaimTotal } from './styled'
 import { ClaimCommonTypes } from './types'
 import { ClaimStatus } from 'state/claim/actions'
+import { AMOUNT_PRECISION } from 'constants/index'
 
 type ClaimSummaryProps = Pick<ClaimCommonTypes, 'hasClaims'> & {
   unclaimedAmount: ClaimCommonTypes['tokenCurrencyAmount'] | undefined
 }
 
-export default function ClaimSummary({ hasClaims, unclaimedAmount }: ClaimSummaryProps) {
+export function ClaimSummary({ hasClaims, unclaimedAmount }: ClaimSummaryProps) {
   const { activeClaimAccount, claimStatus, isInvestFlowActive } = useClaimState()
 
   const hasClaimSummary = claimStatus === ClaimStatus.DEFAULT && !isInvestFlowActive
@@ -18,20 +20,39 @@ export default function ClaimSummary({ hasClaims, unclaimedAmount }: ClaimSummar
   if (!hasClaimSummary) return null
 
   return (
+    <ClaimSummaryView
+      showClaimText={!activeClaimAccount && !hasClaims}
+      totalAvailableAmount={(activeClaimAccount && unclaimedAmount) || undefined}
+      totalAvailableText={'Total available to claim'}
+    />
+  )
+}
+
+type ClaimSummaryViewProps = {
+  showClaimText?: boolean
+  totalAvailableAmount?: CurrencyAmount<Currency>
+  totalAvailableText?: string
+}
+
+export function ClaimSummaryView({ showClaimText, totalAvailableText, totalAvailableAmount }: ClaimSummaryViewProps) {
+  return (
     <ClaimSummaryWrapper>
       <CowProtocolLogo size={100} />
-      {!activeClaimAccount && !hasClaims && (
+      {showClaimText && (
         <ClaimSummaryTitle>
           <Trans>
             Claim <b>vCOW</b> token
           </Trans>
         </ClaimSummaryTitle>
       )}
-      {activeClaimAccount && (
+      {totalAvailableAmount && (
         <div>
           <ClaimTotal>
-            <b>Total available to claim</b>
-            <p>{formatSmart(unclaimedAmount) ?? 0} vCOW</p>
+            {totalAvailableText && <b>{totalAvailableText}</b>}
+            <p>
+              {formatSmart(totalAvailableAmount, AMOUNT_PRECISION, { thousandSeparator: true, isLocaleAware: true })}{' '}
+              vCOW
+            </p>
           </ClaimTotal>
         </div>
       )}

--- a/src/custom/pages/Claim/InvestmentFlow/index.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/index.tsx
@@ -12,6 +12,7 @@ import {
   AccountClaimSummary,
 } from 'pages/Claim/styled'
 import { InvestSummaryRow } from 'pages/Claim/InvestmentFlow/InvestSummaryRow'
+import { ClaimSummaryView } from 'pages/Claim/ClaimSummary'
 
 import { ClaimType, useClaimState, useUserEnhancedClaimData, useClaimDispatchers } from 'state/claim/hooks'
 import { ClaimStatus } from 'state/claim/actions'
@@ -173,6 +174,7 @@ export default function InvestmentFlow({ hasClaims, isAirdropOnly, ...tokenAppro
       {/* Invest flow: Step 2 > Review summary */}
       {investFlowStep === 2 ? (
         <InvestContent>
+          <ClaimSummaryView totalAvailableAmount={totalVCow} />
           <ClaimTable>
             <InvestSummaryTable>
               <thead>

--- a/src/custom/pages/Claim/InvestmentFlow/index.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo } from 'react'
+import { CurrencyAmount } from '@uniswap/sdk-core'
 
 import {
   InvestFlow,
@@ -79,6 +80,21 @@ function _enhancedUserClaimToClaimWithInvestment(
   return { ...claim, ...calculateInvestmentAmounts(claim, investmentAmount) }
 }
 
+function _calculateTotalVCow(allClaims: ClaimWithInvestmentData[]) {
+  // Re-use the vCow instance, if there's any claim at all
+  const zeroVCow = allClaims[0] && CurrencyAmount.fromRawAmount(allClaims[0].claimAmount.currency, '0')
+
+  if (!zeroVCow) {
+    return
+  }
+
+  // Sum up all the vCowAmount being claimed
+  return allClaims.reduce<typeof zeroVCow>(
+    (total, { vCowAmount }) => total.add(vCowAmount?.wrapped || zeroVCow),
+    zeroVCow
+  )
+}
+
 export default function InvestmentFlow({ hasClaims, isAirdropOnly, ...tokenApproveData }: InvestmentFlowProps) {
   const { account } = useActiveWeb3React()
   const { selected, activeClaimAccount, claimStatus, isInvestFlowActive, investFlowStep, investFlowData } =
@@ -100,6 +116,7 @@ export default function InvestmentFlow({ hasClaims, isAirdropOnly, ...tokenAppro
       freeClaims.concat(selectedClaims).map((claim) => _enhancedUserClaimToClaimWithInvestment(claim, investFlowData)),
     [freeClaims, investFlowData, selectedClaims]
   )
+  const totalVCow = useMemo(() => _calculateTotalVCow(allClaims), [allClaims])
 
   useEffect(() => {
     initInvestFlowData()

--- a/src/custom/pages/Claim/InvestmentFlow/index.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/index.tsx
@@ -174,7 +174,7 @@ export default function InvestmentFlow({ hasClaims, isAirdropOnly, ...tokenAppro
       {/* Invest flow: Step 2 > Review summary */}
       {investFlowStep === 2 ? (
         <InvestContent>
-          <ClaimSummaryView totalAvailableAmount={totalVCow} />
+          <ClaimSummaryView totalAvailableAmount={totalVCow} totalAvailableText={'Total amount to claim'} />
           <ClaimTable>
             <InvestSummaryTable>
               <thead>

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -11,7 +11,7 @@ import Confetti from 'components/Confetti'
 import useENS from 'hooks/useENS'
 
 import ClaimNav from './ClaimNav'
-import ClaimSummary from './ClaimSummary'
+import { ClaimSummary } from './ClaimSummary'
 import ClaimAddress from './ClaimAddress'
 import CanUserClaimMessage from './CanUserClaimMessage'
 import ClaimingStatus from './ClaimingStatus'


### PR DESCRIPTION
# Summary

Show total vCOW amount on investment summary page

![Screen Shot 2022-01-20 at 11 24 19](https://user-images.githubusercontent.com/43217/150410865-304b9a51-cbd9-4598-b8bc-1bec5622ece4.png)

  # To Test

1. On claim page, pick a wallet that has at least 1 investment
2. Proceed to the last step
* Total amount on top should match the sum of all the investments + free claims displayed on the page