### PR TITLE
Change account fixes

### DIFF
--- a/src/custom/pages/Claim/CanUserClaimMessage.tsx
+++ b/src/custom/pages/Claim/CanUserClaimMessage.tsx
@@ -6,7 +6,7 @@ import { ClaimCommonTypes } from './types'
 import { useClaimState, useClaimTimeInfo } from 'state/claim/hooks'
 import { ClaimStatus } from 'state/claim/actions'
 
-type ClaimIntroductionProps = Pick<ClaimCommonTypes, 'hasClaims', 'handleChangeAccount'> & {
+type ClaimIntroductionProps = Pick<ClaimCommonTypes, 'hasClaims' | 'handleChangeAccount'> & {
   isAirdropOnly: boolean
 }
 

--- a/src/custom/pages/Claim/CanUserClaimMessage.tsx
+++ b/src/custom/pages/Claim/CanUserClaimMessage.tsx
@@ -3,16 +3,15 @@ import { ButtonSecondary } from 'components/Button'
 import { ExternalLink } from 'theme'
 import { IntroDescription } from './styled'
 import { ClaimCommonTypes } from './types'
-import { useClaimDispatchers, useClaimState, useClaimTimeInfo } from 'state/claim/hooks'
+import { useClaimState, useClaimTimeInfo } from 'state/claim/hooks'
 import { ClaimStatus } from 'state/claim/actions'
 
-type ClaimIntroductionProps = Pick<ClaimCommonTypes, 'hasClaims'> & {
+type ClaimIntroductionProps = Pick<ClaimCommonTypes, 'hasClaims', 'handleChangeAccount'> & {
   isAirdropOnly: boolean
 }
 
-export default function CanUserClaimMessage({ hasClaims, isAirdropOnly }: ClaimIntroductionProps) {
+export default function CanUserClaimMessage({ hasClaims, isAirdropOnly, handleChangeAccount }: ClaimIntroductionProps) {
   const { activeClaimAccount, claimStatus } = useClaimState()
-  const { setActiveClaimAccount } = useClaimDispatchers()
 
   const { airdropDeadline } = useClaimTimeInfo()
 
@@ -39,7 +38,7 @@ export default function CanUserClaimMessage({ hasClaims, isAirdropOnly }: ClaimI
       <IntroDescription center>
         <Trans>
           Unfortunately this account is not eligible for any vCOW claims. <br />
-          <ButtonSecondary onClick={() => setActiveClaimAccount('')} padding="0">
+          <ButtonSecondary onClick={handleChangeAccount} padding="0">
             Try another account
           </ButtonSecondary>{' '}
           or <ExternalLink href="https://cow.fi/">read more about vCOW</ExternalLink>

--- a/src/custom/pages/Claim/ClaimNav.tsx
+++ b/src/custom/pages/Claim/ClaimNav.tsx
@@ -14,19 +14,21 @@ export default function ClaimNav({ account, handleChangeAccount }: ClaimNavProps
   const { setActiveClaimAccount } = useClaimDispatchers()
 
   const isAttempting = useMemo(() => claimStatus === ClaimStatus.ATTEMPTING, [claimStatus])
-
-  if (!activeClaimAccount) return null
+  const hasActiveAccount = activeClaimAccount !== ''
 
   return (
     <TopNav>
       <ClaimAccount>
         <div>
-          <Identicon account={activeClaimAccount} size={46} />
-          <p>{activeClaimAccountENS ? activeClaimAccountENS : shortenAddress(activeClaimAccount)}</p>
+          {hasActiveAccount && (
+            <>
+              <Identicon account={activeClaimAccount} size={46} />
+              <p>{activeClaimAccountENS ? activeClaimAccountENS : shortenAddress(activeClaimAccount)}</p>
+            </>
+          )}
         </div>
-
         <ClaimAccountButtons>
-          {!!account && account !== activeClaimAccount && (
+          {!!account && (account !== activeClaimAccount || activeClaimAccount === '') && (
             <ButtonSecondary disabled={isAttempting} onClick={() => setActiveClaimAccount(account)}>
               Switch to connected account
             </ButtonSecondary>
@@ -36,7 +38,7 @@ export default function ClaimNav({ account, handleChangeAccount }: ClaimNavProps
            * last investment step
            * attempted claim in progress
            */}
-          {(investFlowStep < 2 || !isAttempting) && (
+          {hasActiveAccount && (investFlowStep < 2 || !isAttempting) && (
             <ButtonSecondary disabled={isAttempting} onClick={handleChangeAccount}>
               Change account
             </ButtonSecondary>

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -216,7 +216,11 @@ export default function Claim() {
       {/* Get address/ENS (user not connected yet or opted for checking 'another' account) */}
       <ClaimAddress account={account} toggleWalletModal={toggleWalletModal} />
       {/* Is Airdrop only (simple) - does user have claims? Show messages dependent on claim state */}
-      <CanUserClaimMessage hasClaims={hasClaims} isAirdropOnly={isAirdropOnly} />
+      <CanUserClaimMessage
+        hasClaims={hasClaims}
+        isAirdropOnly={isAirdropOnly}
+        handleChangeAccount={handleChangeAccount}
+      />
 
       {/* Try claiming or inform succesfull claim */}
       <ClaimingStatus />


### PR DESCRIPTION
# Summary

This PR fixes a few issues with changing account

- Make the "Try another account" link work again. Somehow it was lost https://github.com/gnosis/cowswap/pull/2212/files
- Adds in the navigation a link to "Change account"

![Jan-20-2022 20-01-25](https://user-images.githubusercontent.com/2352112/150413778-a7b6f5dd-f5f3-4042-8916-c87d9d3236cb.gif)


@michelbio, there's a small effect when i remove the identicon. should we give enough fixed space?

# To Test

1. "Try another account" and "Change accont"
