### PR TITLE
Disable claim review on errors

### DIFF
--- a/src/custom/pages/Claim/FooterNavButtons.tsx
+++ b/src/custom/pages/Claim/FooterNavButtons.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { Trans } from '@lingui/macro'
 import { isAddress } from '@ethersproject/address'
 import { useClaimDispatchers, useClaimState } from 'state/claim/hooks'
@@ -33,6 +34,7 @@ export default function FooterNavButtons({
     // claiming
     claimStatus,
     // investment
+    investFlowData,
     investFlowStep,
     isInvestFlowActive,
     // table select change
@@ -44,6 +46,10 @@ export default function FooterNavButtons({
     setInvestFlowStep,
     setIsInvestFlowActive,
   } = useClaimDispatchers()
+
+  const hasError = useMemo(() => {
+    return investFlowData.some(({ error }) => Boolean(error))
+  }, [investFlowData])
 
   const isInputAddressValid = isAddress(resolvedAddress || '')
 
@@ -86,7 +92,7 @@ export default function FooterNavButtons({
               <Trans>Approve tokens</Trans>
             </ButtonPrimary>
           ) : investFlowStep === 1 ? (
-            <ButtonPrimary onClick={() => setInvestFlowStep(2)}>
+            <ButtonPrimary onClick={() => setInvestFlowStep(2)} disabled={hasError}>
               <Trans>Review</Trans>
             </ButtonPrimary>
           ) : (

--- a/src/custom/state/claim/actions.ts
+++ b/src/custom/state/claim/actions.ts
@@ -25,6 +25,7 @@ export type ClaimActions = {
   setInvestFlowStep: (payload: number) => void
   initInvestFlowData: () => void
   updateInvestAmount: (payload: { index: number; amount: string }) => void
+  updateInvestError: (payload: { index: number; error: string | undefined }) => void
 
   // claim row selection
   setSelected: (payload: number[]) => void
@@ -51,7 +52,10 @@ export const updateInvestAmount = createAction<{
   index: number
   amount: string
 }>('claim/updateInvestAmount')
-
+export const updateInvestError = createAction<{
+  index: number
+  error: string | undefined
+}>('claim/updateInvestError')
 // claim row selection
 export const setSelected = createAction<number[]>('claim/setSelected')
 export const setSelectedAll = createAction<boolean>('claim/setSelectedAll')

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -53,6 +53,7 @@ import {
   setSelectedAll,
   ClaimStatus,
   resetClaimUi,
+  updateInvestError,
 } from '../actions'
 import { EnhancedUserClaimData } from 'pages/Claim/types'
 import { supportedChainId } from 'utils/supportedChainId'
@@ -767,6 +768,8 @@ export function useClaimDispatchers() {
       setInvestFlowStep: (payload: number) => dispatch(setInvestFlowStep(payload)),
       initInvestFlowData: () => dispatch(initInvestFlowData()),
       updateInvestAmount: (payload: { index: number; amount: string }) => dispatch(updateInvestAmount(payload)),
+      updateInvestError: (payload: { index: number; error: string | undefined }) =>
+        dispatch(updateInvestError(payload)),
       // claim row selection
       setSelected: (payload: number[]) => dispatch(setSelected(payload)),
       setSelectedAll: (payload: boolean) => dispatch(setSelectedAll(payload)),

--- a/src/custom/state/claim/reducer.ts
+++ b/src/custom/state/claim/reducer.ts
@@ -14,6 +14,7 @@ import {
   setSelectedAll,
   resetClaimUi,
   ClaimStatus,
+  updateInvestError,
 } from './actions'
 
 export const initialState: ClaimState = {
@@ -39,6 +40,7 @@ export const initialState: ClaimState = {
 export type InvestClaim = {
   index: number
   investedAmount: string
+  error?: string
 }
 
 export type ClaimState = {
@@ -100,6 +102,9 @@ export default createReducer(initialState, (builder) =>
     })
     .addCase(updateInvestAmount, (state, { payload: { index, amount } }) => {
       state.investFlowData[index].investedAmount = amount
+    })
+    .addCase(updateInvestError, (state, { payload: { index, error } }) => {
+      state.investFlowData[index].error = error
     })
     .addCase(setSelected, (state, { payload }) => {
       state.selected = payload


### PR DESCRIPTION
# Summary

Disable claim review button on errors

![Screen Shot 2022-01-20 at 16 40 47](https://user-images.githubusercontent.com/43217/150444795-a350711b-1415-4f31-858a-0288c8ca98ae.png)

  # To Test

1. Load a claim on behalf of another account for which you have no funds to cover 100%
2. Go to approval step
* You should not be able to move forward

  # Background

Error due to lack of approval is still not captured, it'll be handled in another PR

