### PR TITLE
Fix for investment amount reset when you go back

### DIFF
--- a/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
@@ -144,6 +144,16 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
     }
   }, [balance, isSelfClaiming, maxCost, setMaxAmount])
 
+  // this will set input and percentage value if you go back from the review page
+  useEffect(() => {
+    const { investmentCost } = calculateInvestmentAmounts(claim, investedAmount)
+
+    if (investmentCost) {
+      onInputChange(investmentCost?.toExact())
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   return (
     <InvestTokenGroup>
       <div>


### PR DESCRIPTION
# Summary

Fixes #2242

- when you go back from review page the investment amounts and percentages will be set from the redux state.