### PR TITLE
Claimed amount on success screen

### DIFF
--- a/src/custom/pages/Claim/ClaimingStatus.tsx
+++ b/src/custom/pages/Claim/ClaimingStatus.tsx
@@ -8,11 +8,10 @@ import CowProtocolLogo from 'components/CowProtocolLogo'
 import { ExplorerDataType, getExplorerLink } from 'utils/getExplorerLink'
 import { useAllClaimingTransactions } from 'state/enhancedTransactions/hooks'
 import { useMemo } from 'react'
-// import { formatSmartLocationAware } from 'utils/format'
 
 export default function ClaimingStatus() {
   const { chainId } = useActiveWeb3React()
-  const { activeClaimAccount, claimStatus /* , claimedAmount */ } = useClaimState()
+  const { activeClaimAccount, claimStatus, claimedAmount } = useClaimState()
 
   const allClaimTxs = useAllClaimingTransactions()
   const lastClaimTx = useMemo(() => {
@@ -39,8 +38,7 @@ export default function ClaimingStatus() {
         )}
       </ConfirmedIcon>
       <h3>{isConfirmed ? 'Claimed!' : 'Claiming'}</h3>
-      {/* TODO: fix this in new pr */}
-      {!isConfirmed && <Trans>{/* formatSmartLocationAware(claimedAmount) || '0' */} vCOW</Trans>}
+      {!isConfirmed && <Trans>{claimedAmount} vCOW</Trans>}
 
       {isConfirmed && (
         <>
@@ -48,8 +46,7 @@ export default function ClaimingStatus() {
             <h3>You have successfully claimed</h3>
           </Trans>
           <Trans>
-            {/* TODO: fix this in new pr */}
-            <p>{/* formatSmartLocationAware(claimedAmount) || '0' */} vCOW</p>
+            <p>{claimedAmount} vCOW</p>
           </Trans>
           <Trans>
             <span role="img" aria-label="party-hat">

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -122,7 +122,7 @@ export default function Claim() {
       claimCallback(inputData)
         .then((vCowAmount) => {
           setClaimStatus(ClaimStatus.SUBMITTED)
-          setClaimedAmount(vCowAmount || '')
+          setClaimedAmount(vCowAmount)
         })
         .catch((error) => {
           setClaimStatus(ClaimStatus.DEFAULT)

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -62,7 +62,7 @@ export default function Claim() {
     setIsSearchUsed,
     // claiming
     setClaimStatus,
-    // setClaimedAmount, // TODO: uncomment when used
+    setClaimedAmount,
     // investing
     setIsInvestFlowActive,
     // claim row selection
@@ -120,8 +120,9 @@ export default function Claim() {
     const sendTransaction = (inputData: ClaimInput[]) => {
       setClaimStatus(ClaimStatus.ATTEMPTING)
       claimCallback(inputData)
-        .then((/* res */) => {
+        .then((vCowAmount) => {
           setClaimStatus(ClaimStatus.SUBMITTED)
+          setClaimedAmount(vCowAmount || '')
         })
         .catch((error) => {
           setClaimStatus(ClaimStatus.DEFAULT)
@@ -153,6 +154,7 @@ export default function Claim() {
     investFlowStep,
     setClaimStatus,
     claimCallback,
+    setClaimedAmount,
     handleSetError,
     investFlowData,
     setIsInvestFlowActive,

--- a/src/custom/state/claim/actions.ts
+++ b/src/custom/state/claim/actions.ts
@@ -18,7 +18,7 @@ export type ClaimActions = {
 
   // claiming
   setClaimStatus: (payload: ClaimStatus) => void
-  setClaimedAmount: (payload: number) => void
+  setClaimedAmount: (payload: string) => void
 
   // investing
   setIsInvestFlowActive: (payload: boolean) => void
@@ -41,7 +41,7 @@ export const setActiveClaimAccountENS = createAction<string>('claim/setActiveCla
 export const setIsSearchUsed = createAction<boolean>('claim/setIsSearchUsed')
 
 // claiming
-export const setClaimedAmount = createAction<number>('claim/setClaimedAmount')
+export const setClaimedAmount = createAction<string>('claim/setClaimedAmount')
 export const setClaimStatus = createAction<ClaimStatus>('claim/setClaimStatus')
 
 // investing

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -762,7 +762,7 @@ export function useClaimDispatchers() {
       setIsSearchUsed: (payload: boolean) => dispatch(setIsSearchUsed(payload)),
       // claiming
       setClaimStatus: (payload: ClaimStatus) => dispatch(setClaimStatus(payload)),
-      setClaimedAmount: (payload: number) => dispatch(setClaimedAmount(payload)),
+      setClaimedAmount: (payload: string) => dispatch(setClaimedAmount(payload)),
       // investing
       setIsInvestFlowActive: (payload: boolean) => dispatch(setIsInvestFlowActive(payload)),
       setInvestFlowStep: (payload: number) => dispatch(setInvestFlowStep(payload)),

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -15,7 +15,7 @@ import { useTransactionAdder } from 'state/enhancedTransactions/hooks'
 
 import { GpEther, V_COW } from 'constants/tokens'
 
-import { formatSmart } from 'utils/format'
+import { formatSmartLocaleAware } from 'utils/format'
 import { calculateGasMargin } from 'utils/calculateGasMargin'
 import { isAddress } from 'utils'
 
@@ -57,6 +57,7 @@ import {
 } from '../actions'
 import { EnhancedUserClaimData } from 'pages/Claim/types'
 import { supportedChainId } from 'utils/supportedChainId'
+import { AMOUNT_PRECISION } from 'constants/index'
 
 const CLAIMS_REPO_BRANCH = 'main'
 export const CLAIMS_REPO = `https://raw.githubusercontent.com/gnosis/cow-merkle-drop/${CLAIMS_REPO_BRANCH}/`
@@ -476,6 +477,7 @@ export function useClaimCallback(account: string | null | undefined): {
       }
 
       const vCowAmount = CurrencyAmount.fromRawAmount(vCowToken, totalClaimedAmount)
+      const formattedVCowAmount = formatSmartLocaleAware(vCowAmount, AMOUNT_PRECISION) || '0'
 
       return vCowContract.estimateGas.claimMany(...args).then((estimatedGas) => {
         // Last item in the array contains the call overrides
@@ -487,10 +489,10 @@ export function useClaimCallback(account: string | null | undefined): {
         return vCowContract.claimMany(...extendedArgs).then((response: TransactionResponse) => {
           addTransaction({
             hash: response.hash,
-            summary: `Claim ${formatSmart(vCowAmount)} vCOW`,
+            summary: `Claim ${formattedVCowAmount} vCOW`,
             claim: { recipient: account, indices: args[0] as number[] },
           })
-          return response.hash
+          return formattedVCowAmount
         })
       })
     },

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -414,7 +414,7 @@ function _validateClaimable(
  * @param account
  */
 export function useClaimCallback(account: string | null | undefined): {
-  claimCallback: (claimInputs: ClaimInput[]) => Promise<string | undefined>
+  claimCallback: (claimInputs: ClaimInput[]) => Promise<string>
 } {
   // get claim data for given account
   const { chainId, account: connectedAccount } = useActiveWeb3React()

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -441,21 +441,13 @@ export function useClaimCallback(account: string | null | undefined): {
     },
   })
 
-  /**
-   * Extend the Payable optional param
-   */
-  function _extendFinalArg(args: ClaimManyFnArgs, extendedArg: Record<any, any>) {
-    const lastArg = args.pop()
-    args.push({
-      ...lastArg, // add back whatever is already there
-      ...extendedArg,
-    })
-
-    return args
-  }
-
   const claimCallback = useCallback(
-    async function (claimInput: ClaimInput[]) {
+    /**
+     * Claim callback that sends tx to wallet to claim whatever user selected
+     *
+     * Returns a string with the formatted vCow amount being claimed
+     */
+    async function (claimInput: ClaimInput[]): Promise<string> {
       if (
         claims.length === 0 ||
         claimInput.length === 0 ||
@@ -668,6 +660,19 @@ function _getClaimValue(claim: UserClaimData, vCowAmount: string, nativeTokenPri
   const claimValueInAtomsSquared = JSBI.multiply(JSBI.BigInt(vCowAmount), JSBI.BigInt(nativeTokenPrice))
   // Then it's divided by 10**18 to return the value in the native currency atoms
   return JSBI.divide(claimValueInAtomsSquared, DENOMINATOR).toString()
+}
+
+/**
+ * Extend the Payable optional param
+ */
+function _extendFinalArg(args: ClaimManyFnArgs, extendedArg: Record<any, any>) {
+  const lastArg = args.pop()
+  args.push({
+    ...lastArg, // add back whatever is already there
+    ...extendedArg,
+  })
+
+  return args
 }
 
 type LastAddress = string

--- a/src/custom/state/claim/reducer.ts
+++ b/src/custom/state/claim/reducer.ts
@@ -27,7 +27,7 @@ export const initialState: ClaimState = {
   isSearchUsed: false,
   // claiming
   claimStatus: ClaimStatus.DEFAULT,
-  claimedAmount: 0,
+  claimedAmount: '',
   // investment
   isInvestFlowActive: false,
   investFlowStep: 0,
@@ -53,7 +53,7 @@ export type ClaimState = {
   isSearchUsed: boolean
   // claiming
   claimStatus: ClaimStatus
-  claimedAmount: number
+  claimedAmount: string
   // investment
   isInvestFlowActive: boolean
   investFlowStep: number
@@ -117,5 +117,6 @@ export default createReducer(initialState, (builder) =>
       state.selectedAll = initialState.selectedAll
       state.investFlowStep = initialState.investFlowStep
       state.isInvestFlowActive = initialState.isInvestFlowActive
+      state.claimedAmount = initialState.claimedAmount
     })
 )


### PR DESCRIPTION
# Summary

Show claimed amount on success screen:

![Screen Shot 2022-01-21 at 13 44 46](https://user-images.githubusercontent.com/43217/150606596-092d4dbb-cf25-4c45-a75d-11b0ac664c42.png)
![Screen Shot 2022-01-21 at 13 45 08](https://user-images.githubusercontent.com/43217/150606597-02e4cf68-fa5d-4229-8b61-7f776df1dd49.png)

* Claimed amount is stored on redux as a locale aware formatted amount string
* It's saved after the claim callback returns (after user sends tx)

  # To Test

1. Make a claim
* Observe claimed amount of vCow is displayed while claiming and on success screen