### PR TITLE
Deployment in all networks

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -54,11 +54,9 @@ export const GP_VAULT_RELAYER: Partial<Record<number, string>> = {
 }
 
 export const V_COW_CONTRACT_ADDRESS: Partial<Record<number, string>> = {
-  // TODO: load addresses from contract package when available
-  // [ChainId.MAINNET]: GPv2Settlement[ChainId.MAINNET].address,
-  // [ChainId.RINKEBY]: GPv2Settlement[ChainId.RINKEBY].address,
-  // [ChainId.XDAI]: GPv2Settlement[ChainId.XDAI].address,
-  [ChainId.RINKEBY]: '0xB26D8c5D3d0A67F419F7b314D462C8357Cd4b122',
+  [ChainId.MAINNET]: '0x6d04B3ad33594978D0D4B01CdB7c3bA4a90a7DFe',
+  [ChainId.XDAI]: '0x18598a23E830eFBA0061A4d27E511cB5AE6AC43E',
+  [ChainId.RINKEBY]: '0xD7Dd9397Fb942565959c77f8e112ec5aa7D8C92c',
 }
 
 // See https://github.com/gnosis/gp-v2-contracts/commit/821b5a8da213297b0f7f1d8b17c893c5627020af#diff-12bbbe13cd5cf42d639e34a39d8795021ba40d3ee1e1a8282df652eb161a11d6R13

--- a/src/custom/constants/tokens/index.ts
+++ b/src/custom/constants/tokens/index.ts
@@ -37,21 +37,21 @@ export const V_COW: Record<number, Token> = {
     V_COW_CONTRACT_ADDRESS[SupportedChainId.MAINNET] || '',
     18,
     'vCOW',
-    'Virtual CowSwap Token'
+    'CoW Protocol Virtual Token'
   ),
   [SupportedChainId.XDAI]: new Token(
     SupportedChainId.XDAI,
     V_COW_CONTRACT_ADDRESS[SupportedChainId.XDAI] || '',
     18,
     'vCOW',
-    'Virtual CowSwap Token'
+    'CoW Protocol Virtual Token'
   ),
   [SupportedChainId.RINKEBY]: new Token(
     SupportedChainId.RINKEBY,
     V_COW_CONTRACT_ADDRESS[SupportedChainId.RINKEBY] || '',
     18,
     'vCOW',
-    'Virtual CowSwap Token'
+    'CoW Protocol Virtual Token'
   ),
 }
 

--- a/src/custom/constants/tokens/index.ts
+++ b/src/custom/constants/tokens/index.ts
@@ -32,21 +32,20 @@ export const ADDRESS_IMAGE_OVERRIDE = {
 }
 
 export const V_COW: Record<number, Token> = {
-  // TODO: enable once contract addresses are added
-  // [SupportedChainId.MAINNET]: new Token(
-  //   SupportedChainId.MAINNET,
-  //   V_COW_CONTRACT_ADDRESS[SupportedChainId.MAINNET] || '',
-  //   18,
-  //   'vCOW',
-  //   'Virtual CowSwap Token'
-  // ),
-  // [SupportedChainId.XDAI]: new Token(
-  //   SupportedChainId.XDAI,
-  //   V_COW_CONTRACT_ADDRESS[SupportedChainId.XDAI] || '',
-  //   18,
-  //   'vCOW',
-  //   'Virtual CowSwap Token'
-  // ),
+  [SupportedChainId.MAINNET]: new Token(
+    SupportedChainId.MAINNET,
+    V_COW_CONTRACT_ADDRESS[SupportedChainId.MAINNET] || '',
+    18,
+    'vCOW',
+    'Virtual CowSwap Token'
+  ),
+  [SupportedChainId.XDAI]: new Token(
+    SupportedChainId.XDAI,
+    V_COW_CONTRACT_ADDRESS[SupportedChainId.XDAI] || '',
+    18,
+    'vCOW',
+    'Virtual CowSwap Token'
+  ),
   [SupportedChainId.RINKEBY]: new Token(
     SupportedChainId.RINKEBY,
     V_COW_CONTRACT_ADDRESS[SupportedChainId.RINKEBY] || '',

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -58,7 +58,7 @@ import {
 import { EnhancedUserClaimData } from 'pages/Claim/types'
 import { supportedChainId } from 'utils/supportedChainId'
 
-const CLAIMS_REPO_BRANCH = 'main'
+const CLAIMS_REPO_BRANCH = 'test-deployment-all-networks'
 export const CLAIMS_REPO = `https://raw.githubusercontent.com/gnosis/cow-merkle-drop/${CLAIMS_REPO_BRANCH}/`
 
 // Base amount = 1 VCOW


### PR DESCRIPTION
# Summary

This PR setups the addresses for the 3 available claimings: Rinkeby, Gnosis Chain and Mainnet.




# To Test

## What networks can be tested?
Rinkeby, Gnosis Chain and Mainnet

## What users can we use for testing?
- **Dummies**: just some 10K accounts generated with a single menmonic. 
- **Real data**: Real claimings (or close enough, since there might be small changes in the final deployment). There's a partition on the accounts depending on the airdrop amount (<10K cow goest to Gnosis Chain, otherwise Mainnet)

## Where can I find the dummy address to test
- **Rinkeby**:  (first tab) https://docs.google.com/spreadsheets/d/1pf97wtawkibZPNTrVbyo2FSZKXf6Xo_A0sddWXKxnE4/edit#gid=390159133
- **Gnosis Chain and Mainnnet**:  (second tab) https://docs.google.com/spreadsheets/d/1pf97wtawkibZPNTrVbyo2FSZKXf6Xo_A0sddWXKxnE4/edit#gid=390159133

The dummies allow you to test any of the different kinds of claimings.

## What about the PK?
- Ask @anxolin or @fedgiac , otherwise the mnemonic is shared in 1password with all the team


On each network:
1. [ ]Use the dummies accounts, or your REAL account to test
    * [ ] Real in GC
    * [ ] Dummies in GC (all roles)
2. [ ] Make sure we test also Gnosis Safe account
    * [ ] Gnosis Safe in Mainnnet
    * [ ] Gnosis Safe in GC?