### PR TITLE
Lowercasing searched address to find it on chunk file

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -55,7 +55,7 @@ export const GP_VAULT_RELAYER: Partial<Record<number, string>> = {
 
 export const V_COW_CONTRACT_ADDRESS: Partial<Record<number, string>> = {
   [ChainId.MAINNET]: '0x6d04B3ad33594978D0D4B01CdB7c3bA4a90a7DFe',
-  [ChainId.XDAI]: '0x18598a23E830eFBA0061A4d27E511cB5AE6AC43E',
+  [ChainId.XDAI]: '0xA3A674a40709A837A5E742C2866eda7d3b35a7c0',
   [ChainId.RINKEBY]: '0xD7Dd9397Fb942565959c77f8e112ec5aa7D8C92c',
 }
 

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -58,7 +58,7 @@ import {
 import { EnhancedUserClaimData } from 'pages/Claim/types'
 import { supportedChainId } from 'utils/supportedChainId'
 
-const CLAIMS_REPO_BRANCH = 'test-deployment-all-networks'
+const CLAIMS_REPO_BRANCH = '2022-01-22-test-deployment-all-networks'
 export const CLAIMS_REPO = `https://raw.githubusercontent.com/gnosis/cow-merkle-drop/${CLAIMS_REPO_BRANCH}/`
 
 // Base amount = 1 VCOW

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -727,12 +727,12 @@ function fetchClaims(account: string, chainId: number): Promise<UserClaims> {
     FETCH_CLAIM_PROMISES[claimKey] ??
     (FETCH_CLAIM_PROMISES[claimKey] = fetchClaimsMapping(chainId)
       .then((mapping) => {
-        const sorted = Object.keys(mapping).sort((a, b) => (a.toLowerCase() < b.toLowerCase() ? -1 : 1))
+        const sorted = Object.keys(mapping).sort((a, b) => (a < b ? -1 : 1))
 
         for (const startingAddress of sorted) {
           const lastAddress = mapping[startingAddress]
-          if (startingAddress.toLowerCase() <= lowerCasedAddress) {
-            if (lowerCasedAddress <= lastAddress.toLowerCase()) {
+          if (startingAddress <= lowerCasedAddress) {
+            if (lowerCasedAddress <= lastAddress) {
               return startingAddress
             }
           } else {


### PR DESCRIPTION
# Summary

Fixing issue that causes addresses with claim not be shown in the UI

  # To Test

1. On mainnet, search for the address `0x20026f06342e16415b070ae3bdb3983af7c51c95`
* It should show you 2 claims
2. On dev (https://cowswap.dev.gnosisdev.com/), search for the same address
* Without the fix you won't see any claim for it