### PR TITLE
New Gnosis Chain contract address

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -55,7 +55,7 @@ export const GP_VAULT_RELAYER: Partial<Record<number, string>> = {
 
 export const V_COW_CONTRACT_ADDRESS: Partial<Record<number, string>> = {
   [ChainId.MAINNET]: '0x6d04B3ad33594978D0D4B01CdB7c3bA4a90a7DFe',
-  [ChainId.XDAI]: '0x18598a23E830eFBA0061A4d27E511cB5AE6AC43E',
+  [ChainId.XDAI]: '0xA3A674a40709A837A5E742C2866eda7d3b35a7c0',
   [ChainId.RINKEBY]: '0xD7Dd9397Fb942565959c77f8e112ec5aa7D8C92c',
 }
 


### PR DESCRIPTION
# Summary

Waterfalls onto https://github.com/gnosis/cowswap/pull/2260

Updating Gnosis Chain contract address to latest

  # To Test

1. Check Gnosis Chain claims for example `0x8d99F8b2710e6A3B94d9bf465A98E5273069aCBd`
* You should see for the example above 3 claims
![Screen Shot 2022-01-22 at 14 48 41](https://user-images.githubusercontent.com/43217/150657848-d9a05acd-a6c4-4e45-b549-4129d1b8b0d2.png)
