### PR TITLE
Fix explorer link

### DIFF
--- a/src/custom/pages/Claim/ClaimingStatus.tsx
+++ b/src/custom/pages/Claim/ClaimingStatus.tsx
@@ -5,9 +5,10 @@ import { ClaimStatus } from 'state/claim/actions'
 import { useClaimState } from 'state/claim/hooks'
 import { useActiveWeb3React } from 'hooks/web3'
 import CowProtocolLogo from 'components/CowProtocolLogo'
-import { ExplorerDataType, getExplorerLink } from 'utils/getExplorerLink'
 import { useAllClaimingTransactions } from 'state/enhancedTransactions/hooks'
 import { useMemo } from 'react'
+import { ExplorerLink } from 'components/ExplorerLink'
+import { ExplorerDataType } from 'utils/getExplorerLink'
 // import { formatSmartLocationAware } from 'utils/format'
 
 export default function ClaimingStatus() {
@@ -70,12 +71,7 @@ export default function ClaimingStatus() {
         </AttemptFooter>
       )}
       {isSubmitted && chainId && lastClaimTx?.hash && (
-        <ExternalLink
-          href={getExplorerLink(chainId, lastClaimTx.hash, ExplorerDataType.TRANSACTION)}
-          style={{ zIndex: 99, marginTop: '20px' }}
-        >
-          <Trans>View transaction on Explorer</Trans>
-        </ExternalLink>
+        <ExplorerLink id={lastClaimTx.hash} type={ExplorerDataType.TRANSACTION} />
       )}
     </ConfirmOrLoadingWrapper>
   )

--- a/src/custom/pages/Claim/ClaimingStatus.tsx
+++ b/src/custom/pages/Claim/ClaimingStatus.tsx
@@ -1,6 +1,5 @@
 import { Trans } from '@lingui/macro'
 import { ConfirmOrLoadingWrapper, ConfirmedIcon, AttemptFooter, CowSpinner } from 'pages/Claim/styled'
-import { ExternalLink } from 'theme'
 import { ClaimStatus } from 'state/claim/actions'
 import { useClaimState } from 'state/claim/hooks'
 import { useActiveWeb3React } from 'hooks/web3'


### PR DESCRIPTION
# Summary

Fix the Explorer link URL. It was wrong for Gnosis Chain. Also addresses the suggestion from @elena-zh to make it more 

**Before:**
![image](https://user-images.githubusercontent.com/2352112/150676621-6ef727dc-2a92-4028-baaf-cad108eb3912.png)

And will always take you


**After:**
![image](https://user-images.githubusercontent.com/2352112/150676597-47fe4665-0351-4104-bbde-a6d9464111fa.png)

And:
* Takes you to the right explorer depending on the network
* The label would be more precise, i.e. "Verify on Blockscout" if network is Gnosis Chain

# To Test

1. Do a claiming in the 3 networks. You can use the first two tabs of this file to find dummy examples: https://docs.google.com/spreadsheets/d/1pf97wtawkibZPNTrVbyo2FSZKXf6Xo_A0sddWXKxnE4/edit#gid=1980526507 
2. Verify the link, should say "Verify on Etherscan" or "Verify on Blockscout" and take u to the right place

  