### PR TITLE
Simplify links

### DIFF
--- a/src/custom/pages/Claim/ClaimNav.tsx
+++ b/src/custom/pages/Claim/ClaimNav.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { ButtonSecondary } from 'components/Button'
 import { shortenAddress } from 'utils'
 import { TopNav, ClaimAccount, ClaimAccountButtons } from './styled'

--- a/src/custom/pages/Claim/ClaimNav.tsx
+++ b/src/custom/pages/Claim/ClaimNav.tsx
@@ -13,8 +13,10 @@ export default function ClaimNav({ account, handleChangeAccount }: ClaimNavProps
   const { activeClaimAccount, activeClaimAccountENS, claimStatus, investFlowStep } = useClaimState()
   const { setActiveClaimAccount } = useClaimDispatchers()
 
-  const isAttempting = useMemo(() => claimStatus === ClaimStatus.ATTEMPTING, [claimStatus])
+  const isDefaultStatus = claimStatus === ClaimStatus.DEFAULT
+  const isConfirmed = claimStatus === ClaimStatus.CONFIRMED
   const hasActiveAccount = activeClaimAccount !== ''
+  const allowToChangeAccount = investFlowStep < 2 && (isDefaultStatus || isConfirmed)
 
   return (
     <TopNav>
@@ -28,20 +30,15 @@ export default function ClaimNav({ account, handleChangeAccount }: ClaimNavProps
           )}
         </div>
         <ClaimAccountButtons>
-          {!!account && (account !== activeClaimAccount || activeClaimAccount === '') && (
-            <ButtonSecondary disabled={isAttempting} onClick={() => setActiveClaimAccount(account)}>
-              Switch to connected account
-            </ButtonSecondary>
-          )}
-
-          {/* Hide account changing action on:
-           * last investment step
-           * attempted claim in progress
-           */}
-          {hasActiveAccount && (investFlowStep < 2 || !isAttempting) && (
-            <ButtonSecondary disabled={isAttempting} onClick={handleChangeAccount}>
-              Change account
-            </ButtonSecondary>
+          {allowToChangeAccount && hasActiveAccount ? (
+            <ButtonSecondary onClick={handleChangeAccount}>Change account</ButtonSecondary>
+          ) : (
+            !!account &&
+            allowToChangeAccount && (
+              <ButtonSecondary onClick={() => setActiveClaimAccount(account)}>
+                Switch to connected account
+              </ButtonSecondary>
+            )
           )}
         </ClaimAccountButtons>
       </ClaimAccount>


### PR DESCRIPTION
# Summary

This PR simplifies the logic of the buttons in the top part:

![image](https://user-images.githubusercontent.com/2352112/150694419-a0c69cf5-e53e-4c09-a58a-f0ad951c3674.png)

Hopefully, now the logic should be easier to read, and also how they work should be simpler too. The rules are:
- **We allow to change the account** :  Only in the default status and confirmed status. Meaning, when we are not claiming or we just sent the tx to the wallet. Additionally, within the investment flow, we don't show the buttons in the last step.
- **We never show the two links**: Before we were showing sometimes `Change account` and sometimes `Switch to connected account`. Now, only one of those will be visible. If you want to go back and use your connected wallet, normally you will need to first click on "change account", then in "Switch to connected account"



## Before
We used to show most of the times the two buttons
![image](https://user-images.githubusercontent.com/2352112/150694576-00ff52bd-6943-410d-b676-9b3cef7a8933.png)


## After
![image](https://user-images.githubusercontent.com/2352112/150694694-7142cf17-042a-490d-95bb-b075632ebb61.png)

![image](https://user-images.githubusercontent.com/2352112/150694700-76a36c73-c168-4d14-8732-8650be6a3579.png)



# To Test

1. Do some full workflows of investing and make sure links are good all the time