### PR TITLE
Add link to the profile

### DIFF
--- a/src/custom/pages/Claim/ClaimingStatus.tsx
+++ b/src/custom/pages/Claim/ClaimingStatus.tsx
@@ -8,10 +8,11 @@ import CowProtocolLogo from 'components/CowProtocolLogo'
 import { ExplorerDataType, getExplorerLink } from 'utils/getExplorerLink'
 import { useAllClaimingTransactions } from 'state/enhancedTransactions/hooks'
 import { useMemo } from 'react'
+import { Link } from 'react-router-dom'
 // import { formatSmartLocationAware } from 'utils/format'
 
 export default function ClaimingStatus() {
-  const { chainId } = useActiveWeb3React()
+  const { chainId, account } = useActiveWeb3React()
   const { activeClaimAccount, claimStatus /* , claimedAmount */ } = useClaimState()
 
   const allClaimTxs = useAllClaimingTransactions()
@@ -24,8 +25,9 @@ export default function ClaimingStatus() {
   const isConfirmed = claimStatus === ClaimStatus.CONFIRMED
   const isAttempting = claimStatus === ClaimStatus.ATTEMPTING
   const isSubmitted = claimStatus === ClaimStatus.SUBMITTED
+  const isSelfClaiming = account === activeClaimAccount
 
-  if (!activeClaimAccount || claimStatus === ClaimStatus.DEFAULT) return null
+  if (!account || !activeClaimAccount || claimStatus === ClaimStatus.DEFAULT) return null
 
   return (
     <ConfirmOrLoadingWrapper activeBG={true}>
@@ -60,6 +62,11 @@ export default function ClaimingStatus() {
               🐄🎉
             </span>
           </Trans>
+          {isSelfClaiming && (
+            <Trans>
+              You can see your balance in the <Link to="/profile">Profile</Link>
+            </Trans>
+          )}
         </>
       )}
       {isAttempting && (

--- a/src/custom/pages/Claim/ClaimingStatus.tsx
+++ b/src/custom/pages/Claim/ClaimingStatus.tsx
@@ -9,6 +9,7 @@ import { ExplorerDataType, getExplorerLink } from 'utils/getExplorerLink'
 import { useAllClaimingTransactions } from 'state/enhancedTransactions/hooks'
 import { useMemo } from 'react'
 import { Link } from 'react-router-dom'
+import { ExplorerLink } from 'components/ExplorerLink'
 // import { formatSmartLocationAware } from 'utils/format'
 
 export default function ClaimingStatus() {
@@ -62,9 +63,14 @@ export default function ClaimingStatus() {
               🐄🎉
             </span>
           </Trans>
-          {isSelfClaiming && (
+          {isSelfClaiming ? (
             <Trans>
-              You can see your balance in the <Link to="/profile">Profile</Link>
+              You can see your vCOW balance in the <Link to="/profile">Profile</Link>
+            </Trans>
+          ) : (
+            <Trans>
+              You have just claimed on behalf of{' '}
+              <ExplorerLink id={activeClaimAccount} type={ExplorerDataType.ADDRESS} />
             </Trans>
           )}
         </>

--- a/src/custom/pages/Claim/InvestmentFlow/index.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/index.tsx
@@ -57,8 +57,8 @@ export type InvestOptionProps = {
   claim: EnhancedUserClaimData
   optionIndex: number
   approveData:
-  | { approveState: ApprovalState; approveCallback: (optionalParams?: OptionalApproveCallbackParams) => void }
-  | undefined
+    | { approveState: ApprovalState; approveCallback: (optionalParams?: OptionalApproveCallbackParams) => void }
+    | undefined
 }
 
 type InvestmentFlowProps = Pick<ClaimCommonTypes, 'hasClaims'> & {
@@ -198,8 +198,8 @@ export default function InvestmentFlow({ hasClaims, isAirdropOnly, ...tokenAppro
         {investFlowStep === 0
           ? 'Claim and invest'
           : investFlowStep === 1
-            ? 'Set allowance to Buy vCOW'
-            : 'Confirm transaction to claim all vCOW'}
+          ? 'Set allowance to Buy vCOW'
+          : 'Confirm transaction to claim all vCOW'}
       </h1>
 
       {investFlowStep === 0 && (


### PR DESCRIPTION
# Summary

Adds link to the profile. 
* ⚠️ This link won't be visible when you claim on behalf of someone else. This is because, this someone else is the one that received the tokens, not the connected account. The profile shows the balance only for the connected wallet.

![image](https://user-images.githubusercontent.com/2352112/150698687-21143e0b-c607-4ae0-816c-7b6a5b802756.png)

## Not included
I didn't include any style. I assume @biocom will revisit this screen completely. Michel, let us know if you want help mocking the app to get to this screen without the need to claim tokens each time.

# To Test

1. Claim for your self. You might need to use some of the PK in https://docs.google.com/spreadsheets/d/1pf97wtawkibZPNTrVbyo2FSZKXf6Xo_A0sddWXKxnE4/edit#gid=390159133
2. Verify the link is visible
