### PR TITLE
Responsive balance indicator.

### DIFF
--- a/src/custom/components/CowProtocolLogo/index.tsx
+++ b/src/custom/components/CowProtocolLogo/index.tsx
@@ -2,14 +2,22 @@ import styled from 'styled-components/macro'
 import CowProtocolIcon from 'assets/cow-swap/cowprotocol.svg'
 
 export const Icon = styled.span<Props>`
+  --defaultSize: 24px;
+  --smallSize: ${({ size }) => (size ? `calc(${size}px / 2)` : 'calc(var(--defaultSize) / 2)')};
   ${({ theme }) => theme.cowToken.background};
   ${({ theme }) => theme.cowToken.boxShadow};
-  height: ${({ size }) => (size ? `${size}px` : '24px')};
-  width: ${({ size }) => (size ? `${size}px` : '24px')};
+  height: ${({ size }) => (size ? `${size}px` : 'var(--defaultSize)')};
+  width: ${({ size }) => (size ? `${size}px` : 'var(--defaultSize)')};
   display: inline-block;
   margin: 0;
-  border-radius: ${({ size }) => (size ? `${size}px` : '24px')};
+  border-radius: ${({ size }) => (size ? `${size}px` : 'var(--defaultSize)')};
   position: relative;
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    width: var(--smallSize);
+    height: var(--smallSize);
+    border-radius: var(--smallSize);
+  `};
 
   &::after {
     content: '';

--- a/src/custom/pages/Claim/styled.ts
+++ b/src/custom/pages/Claim/styled.ts
@@ -23,6 +23,7 @@ export const PageWrapper = styled.div`
   background: ${({ theme }) => theme.bg1};
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
+    padding: 16px;
     border-radius: var(--border-radius-small);
   `};
 
@@ -162,8 +163,8 @@ ${ButtonPrimary} {
   padding: 24px 16px;
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
-      margin: 0 auto 24px;
-    `};
+    margin: 0 auto 24px;
+  `};
 
   &[disabled] {
     cursor: not-allowed;
@@ -458,6 +459,10 @@ export const ClaimTotal = styled.div`
     margin: 0;
     font-size: 30px;
     font-weight: bold;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      font-size: 16px;
+    `};
   }
 `
 
@@ -527,10 +532,18 @@ export const EligibleBanner = styled.div`
   margin: 0 auto 16px;
   font-weight: 600;
 
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    text-align: left;
+    padding: 18px;
+  `}
   > img {
     margin: 0 6px 0 0;
     width: 21px;
     height: 21px;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      margin: 0 12px 0 6px;
+   `}
   }
 `
 
@@ -643,24 +656,26 @@ export const CheckAddress = styled.div`
 
   ${Icon} {
     margin: 0 auto;
-  }
 
-  > h1 {
-    font-size: 32px;
-    font-weight: 300;
-    text-align: center;
-  }
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      margin: 0 0 0 6px;
+   `}
+    > h1 {
+      font-size: 32px;
+      font-weight: 300;
+      text-align: center;
+    }
 
-  > h1 > b {
-    font-weight: bold;
-  }
+    > h1 > b {
+      font-weight: bold;
+    }
 
-  > p {
-    text-align: center;
-    font-size: 18px;
-    line-height: 1.2;
-    margin: 0 0 24px;
-  }
+    > p {
+      text-align: center;
+      font-size: 18px;
+      line-height: 1.2;
+      margin: 0 0 24px;
+    }
 `
 
 export const ClaimBreakdown = styled.div`


### PR DESCRIPTION
# Summary

- For now only responsive styles for the balance and the eligible (orange) banner
<img width="411" alt="Screen Shot 2022-01-24 at 12 42 39" src="https://user-images.githubusercontent.com/31534717/150777118-13201513-5cd8-4597-83cf-457fe2a08a31.png">

