### PR TITLE
Fix Gnosis Safe claiming Workflow

### DIFF
--- a/src/custom/components/EnhancedTransactionLink/index.tsx
+++ b/src/custom/components/EnhancedTransactionLink/index.tsx
@@ -1,0 +1,32 @@
+import { ExplorerDataType } from 'utils/getExplorerLink'
+
+import { ExplorerLink } from 'components/ExplorerLink'
+import { GnosisSafeLink } from 'components/AccountDetails/Transaction/StatusDetails'
+
+import { EnhancedTransactionDetails, HashType } from 'state/enhancedTransactions/reducer'
+import { useWalletInfo } from 'hooks/useWalletInfo'
+
+interface Props {
+  tx: EnhancedTransactionDetails
+}
+
+/**
+ * Creates a link to the relevant explorer: Etherscan, GP Explorer or Blockscout, or Gnosis Safe web if its a Gnosis Safe Transaction
+ * @param props
+ */
+export function EnhancedTransactionLink(props: Props) {
+  const { tx } = props
+  const { chainId, gnosisSafeInfo } = useWalletInfo()
+
+  if (tx.hashType === HashType.GNOSIS_SAFE_TX) {
+    const safeTx = tx.safeTransaction
+
+    if (!chainId || !safeTx || !gnosisSafeInfo) {
+      return null
+    }
+
+    return <GnosisSafeLink chainId={chainId} safeTransaction={safeTx} gnosisSafeThreshold={gnosisSafeInfo.threshold} />
+  } else {
+    return <ExplorerLink id={tx.hash} type={ExplorerDataType.TRANSACTION} />
+  }
+}

--- a/src/custom/pages/Claim/ClaimingStatus.tsx
+++ b/src/custom/pages/Claim/ClaimingStatus.tsx
@@ -6,8 +6,7 @@ import { useActiveWeb3React } from 'hooks/web3'
 import CowProtocolLogo from 'components/CowProtocolLogo'
 import { useAllClaimingTransactions } from 'state/enhancedTransactions/hooks'
 import { useMemo } from 'react'
-import { ExplorerLink } from 'components/ExplorerLink'
-import { ExplorerDataType } from 'utils/getExplorerLink'
+import { EnhancedTransactionLink } from 'components/EnhancedTransactionLink'
 
 export default function ClaimingStatus() {
   const { chainId } = useActiveWeb3React()
@@ -66,9 +65,7 @@ export default function ClaimingStatus() {
           </p>
         </AttemptFooter>
       )}
-      {isSubmitted && chainId && lastClaimTx?.hash && (
-        <ExplorerLink id={lastClaimTx.hash} type={ExplorerDataType.TRANSACTION} />
-      )}
+      {isSubmitted && chainId && lastClaimTx?.hash && <EnhancedTransactionLink tx={lastClaimTx} />}
     </ConfirmOrLoadingWrapper>
   )
 }

--- a/src/custom/pages/Claim/ClaimingStatus.tsx
+++ b/src/custom/pages/Claim/ClaimingStatus.tsx
@@ -1,13 +1,13 @@
 import { Trans } from '@lingui/macro'
 import { ConfirmOrLoadingWrapper, ConfirmedIcon, AttemptFooter, CowSpinner } from 'pages/Claim/styled'
-import { ExternalLink } from 'theme'
 import { ClaimStatus } from 'state/claim/actions'
 import { useClaimState } from 'state/claim/hooks'
 import { useActiveWeb3React } from 'hooks/web3'
 import CowProtocolLogo from 'components/CowProtocolLogo'
-import { ExplorerDataType, getExplorerLink } from 'utils/getExplorerLink'
 import { useAllClaimingTransactions } from 'state/enhancedTransactions/hooks'
 import { useMemo } from 'react'
+import { ExplorerLink } from 'components/ExplorerLink'
+import { ExplorerDataType } from 'utils/getExplorerLink'
 
 export default function ClaimingStatus() {
   const { chainId } = useActiveWeb3React()
@@ -67,12 +67,7 @@ export default function ClaimingStatus() {
         </AttemptFooter>
       )}
       {isSubmitted && chainId && lastClaimTx?.hash && (
-        <ExternalLink
-          href={getExplorerLink(chainId, lastClaimTx.hash, ExplorerDataType.TRANSACTION)}
-          style={{ zIndex: 99, marginTop: '20px' }}
-        >
-          <Trans>View transaction on Explorer</Trans>
-        </ExternalLink>
+        <ExplorerLink id={lastClaimTx.hash} type={ExplorerDataType.TRANSACTION} />
       )}
     </ConfirmOrLoadingWrapper>
   )


### PR DESCRIPTION
# Summary

This PR address the issue with the broken link for Gnosis Safe transactions. Close #2270

Now it shows the right link that takes you to Gnosis Safe, so you can sign the tx there:
<img width="1105" alt="Screenshot at Jan 24 15-10-12" src="https://user-images.githubusercontent.com/2352112/150810016-8b5508ad-20b4-4625-b99a-8844a50c541f.png">

The link will take you to the queue:
<img width="1152" alt="Screenshot at Jan 24 15-11-03" src="https://user-images.githubusercontent.com/2352112/150810236-d9c41b26-9361-4eba-965d-5ff0ca2a241a.png">


The transaction is also visible in the recent activity window:
<img width="1224" alt="Screenshot at Jan 24 15-12-51" src="https://user-images.githubusercontent.com/2352112/150810202-077fe44e-9bf1-4321-a426-991f5b52298b.png">




# To Test

1. Claim something using Gnosis Safe
2. Make sure link works 
3. Do the same with an EOA, make sure it still works
