### PR TITLE
Pr2256/follow up

### DIFF
--- a/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState, useEffect } from 'react'
-import { Percent } from '@uniswap/sdk-core'
+import { CurrencyAmount, Percent } from '@uniswap/sdk-core'
+import { BigNumber } from '@ethersproject/bignumber'
 
 import CowProtocolLogo from 'components/CowProtocolLogo'
 import { InvestTokenGroup, TokenLogo, InvestSummary, InvestInput, InvestAvailableBar } from '../styled'
@@ -21,7 +22,7 @@ import { tryParseAmount } from 'state/swap/hooks'
 import { calculateInvestmentAmounts, calculatePercentage } from 'state/claim/hooks/utils'
 import { AMOUNT_PRECISION, PERCENTAGE_PRECISION } from 'constants/index'
 import { useGasPrices } from 'state/gas/hooks'
-import { _estimateTxCost } from 'components/swap/EthWethWrap/helpers'
+import { AVG_APPROVE_COST_GWEI } from 'components/swap/EthWethWrap/helpers'
 import { useWalletInfo } from 'hooks/useWalletInfo'
 
 const ErrorMsgs = {
@@ -29,14 +30,14 @@ const ErrorMsgs = {
   OverMaxInvestment: `Your investment amount can't be above the maximum investment allowed`,
   InvestmentIsZero: `Your investment amount can't be zero`,
   NotApproved: (symbol = '') => `Please approve ${symbol} token`,
-  InsufficientNativeBalance: (symbol = '') =>
-    `You might not have enough ${symbol} to pay the for network transaction fee`,
+  InsufficientNativeBalance: (symbol = '', amount = '') =>
+    `You might not have enough ${symbol} to pay for the network transaction fee (estimated ${amount} ${symbol})`,
 }
 
 export default function InvestOption({ approveData, claim, optionIndex }: InvestOptionProps) {
   const { currencyAmount, price, cost: maxCost } = claim
   const { updateInvestAmount, updateInvestError } = useClaimDispatchers()
-  const { investFlowData, activeClaimAccount } = useClaimState()
+  const { investFlowData, activeClaimAccount, estimatedGas } = useClaimState()
 
   const { handleSetError, handleCloseError, ErrorModal } = useErrorModal()
 
@@ -65,19 +66,28 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
   )
 
   const token = currencyAmount?.currency
+  const isNative = token?.isNative
   const balance = useCurrencyBalance(account || undefined, token)
 
-  const gasPrice = useGasPrices(chainId)
-  const { singleTxCost } = useMemo(
-    () => _estimateTxCost(gasPrice, token?.isNative ? token : undefined),
-    [gasPrice, token]
-  )
+  const gasPrice = useGasPrices(isNative ? chainId : undefined)
 
   const isSelfClaiming = account === activeClaimAccount
   const noBalance = !balance || balance.equalTo('0')
 
   const isApproved = approveData?.approveState === ApprovalState.APPROVED
-  const isNative = token?.isNative
+
+  const gasCost = useMemo(() => {
+    if (!estimatedGas || !isNative) {
+      return
+    }
+
+    // Based on how much gas will be used (estimatedGas) and current gas prices (if available)
+    // calculate how much that would cost in native currency.
+    // We pick `fast` to be conservative. Also, it's non-blocking, so the user is aware but can proceed
+    const amount = BigNumber.from(estimatedGas).mul(gasPrice?.fast || AVG_APPROVE_COST_GWEI)
+
+    return CurrencyAmount.fromRawAmount(token, amount.toString())
+  }, [estimatedGas, gasPrice?.fast, isNative, token])
 
   // on invest max amount click handler
   const setMaxAmount = useCallback(() => {
@@ -164,8 +174,8 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
       error = ErrorMsgs.OverMaxInvestment
     } else if (parsedAmount.greaterThan(balance)) {
       error = ErrorMsgs.InsufficientBalance(token?.symbol)
-    } else if (isNative && parsedAmount && singleTxCost?.add(parsedAmount).greaterThan(balance)) {
-      warning = ErrorMsgs.InsufficientNativeBalance(token?.symbol)
+    } else if (isNative && gasCost && parsedAmount.add(gasCost).greaterThan(balance)) {
+      warning = ErrorMsgs.InsufficientNativeBalance(token?.symbol, formatSmartLocaleAware(gasCost))
     }
     setInputWarning(warning || '')
 
@@ -200,7 +210,7 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
     resetInputError,
     setInvestedAmount,
     isSmartContractWallet,
-    singleTxCost,
+    gasCost,
   ])
 
   return (

--- a/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
@@ -29,7 +29,8 @@ const ErrorMsgs = {
   OverMaxInvestment: `Your investment amount can't be above the maximum investment allowed`,
   InvestmentIsZero: `Your investment amount can't be zero`,
   NotApproved: (symbol = '') => `Please approve ${symbol} token`,
-  InsufficientNativeBalance: (symbol = '') => `You might not have enough ${symbol} to pay the network transaction fee`,
+  InsufficientNativeBalance: (symbol = '') =>
+    `You might not have enough ${symbol} to pay the for network transaction fee`,
 }
 
 export default function InvestOption({ approveData, claim, optionIndex }: InvestOptionProps) {

--- a/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
@@ -29,8 +29,7 @@ const ErrorMsgs = {
   OverMaxInvestment: `Your investment amount can't be above the maximum investment allowed`,
   InvestmentIsZero: `Your investment amount can't be zero`,
   NotApproved: (symbol = '') => `Please approve ${symbol} token`,
-  InsufficientNativeBalance: (symbol = '', action = "won't") =>
-    `You ${action} have enough ${symbol} to pay the network transaction fee`,
+  InsufficientNativeBalance: (symbol = '') => `You might not have enough ${symbol} to pay the network transaction fee`,
 }
 
 export default function InvestOption({ approveData, claim, optionIndex }: InvestOptionProps) {
@@ -165,11 +164,7 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
     } else if (parsedAmount.greaterThan(balance)) {
       error = ErrorMsgs.InsufficientBalance(token?.symbol)
     } else if (isNative && parsedAmount && singleTxCost?.add(parsedAmount).greaterThan(balance)) {
-      if (isSmartContractWallet) {
-        warning = ErrorMsgs.InsufficientNativeBalance(token?.symbol, 'might not')
-      } else {
-        error = ErrorMsgs.InsufficientNativeBalance(token?.symbol)
-      }
+      warning = ErrorMsgs.InsufficientNativeBalance(token?.symbol)
     }
     setInputWarning(warning || '')
 

--- a/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
@@ -23,7 +23,6 @@ import { calculateInvestmentAmounts, calculatePercentage } from 'state/claim/hoo
 import { AMOUNT_PRECISION, PERCENTAGE_PRECISION } from 'constants/index'
 import { useGasPrices } from 'state/gas/hooks'
 import { AVG_APPROVE_COST_GWEI } from 'components/swap/EthWethWrap/helpers'
-import { useWalletInfo } from 'hooks/useWalletInfo'
 
 const ErrorMsgs = {
   InsufficientBalance: (symbol = '') => `Insufficient ${symbol} balance to cover investment amount`,
@@ -42,7 +41,6 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
   const { handleSetError, handleCloseError, ErrorModal } = useErrorModal()
 
   const { account, chainId } = useActiveWeb3React()
-  const { isSmartContractWallet } = useWalletInfo()
 
   const [percentage, setPercentage] = useState<string>('0')
   const [typedValue, setTypedValue] = useState<string>('0')
@@ -209,7 +207,6 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
     setInputError,
     resetInputError,
     setInvestedAmount,
-    isSmartContractWallet,
     gasCost,
   ])
 

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -113,6 +113,15 @@ export default function Claim() {
     setInputAddress('')
   }
 
+  // aggregate the input for claim callback
+  const claimInputData = useMemo(() => {
+    const freeClaims = getFreeClaims(userClaimData)
+    const paidClaims = prepareInvestClaims(investFlowData, userClaimData)
+
+    const inputData = freeClaims.map(({ index }) => ({ index }))
+    return inputData.concat(paidClaims)
+  }, [investFlowData, userClaimData])
+
   // handle submit claim
   const handleSubmitClaim = useCallback(() => {
     // Reset error handling
@@ -120,8 +129,6 @@ export default function Claim() {
 
     // just to be sure
     if (!activeClaimAccount) return
-
-    const freeClaims = getFreeClaims(userClaimData)
 
     const sendTransaction = (inputData: ClaimInput[]) => {
       setClaimStatus(ClaimStatus.ATTEMPTING)
@@ -137,32 +144,26 @@ export default function Claim() {
         })
     }
 
-    const inputData = freeClaims.map(({ index }) => ({ index }))
-
     // check if there are any selected (paid) claims
     if (!selected.length) {
-      console.log('Starting claiming with', inputData)
-      sendTransaction(inputData)
+      console.log('Starting claiming with', claimInputData)
+      sendTransaction(claimInputData)
     } else if (investFlowStep == 2) {
-      // Free claims + selected investment opportunities
-      const investClaims = prepareInvestClaims(investFlowData, userClaimData)
-      inputData.push(...investClaims)
-      console.log('Starting claiming with', inputData)
-      sendTransaction(inputData)
+      console.log('Starting claiming with', claimInputData)
+      sendTransaction(claimInputData)
     } else {
       setIsInvestFlowActive(true)
     }
   }, [
     handleCloseError,
     activeClaimAccount,
-    userClaimData,
     selected.length,
     investFlowStep,
     setClaimStatus,
     claimCallback,
     setClaimedAmount,
     handleSetError,
-    investFlowData,
+    claimInputData,
     setIsInvestFlowActive,
   ])
 

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -69,6 +69,7 @@ export default function Claim() {
     // claiming
     setClaimStatus,
     setClaimedAmount,
+    setEstimatedGas,
     // investing
     setIsInvestFlowActive,
     // claim row selection
@@ -96,7 +97,7 @@ export default function Claim() {
   const isPaidClaimsOnly = useMemo(() => hasPaidClaim(userClaimData) && !hasFreeClaim(userClaimData), [userClaimData])
 
   // claim callback
-  const { claimCallback } = useClaimCallback(activeClaimAccount)
+  const { claimCallback, estimateGasCallback } = useClaimCallback(activeClaimAccount)
 
   // handle change account
   const handleChangeAccount = () => {
@@ -121,6 +122,11 @@ export default function Claim() {
     const inputData = freeClaims.map(({ index }) => ({ index }))
     return inputData.concat(paidClaims)
   }, [investFlowData, userClaimData])
+
+  // track gas price estimation for given input data
+  useEffect(() => {
+    estimateGasCallback(claimInputData).then((gas) => setEstimatedGas(gas?.toString() || ''))
+  }, [claimInputData, estimateGasCallback, setEstimatedGas])
 
   // handle submit claim
   const handleSubmitClaim = useCallback(() => {

--- a/src/custom/state/claim/actions.ts
+++ b/src/custom/state/claim/actions.ts
@@ -19,6 +19,7 @@ export type ClaimActions = {
   // claiming
   setClaimStatus: (payload: ClaimStatus) => void
   setClaimedAmount: (payload: string) => void
+  setEstimatedGas: (payload: string) => void
 
   // investing
   setIsInvestFlowActive: (payload: boolean) => void
@@ -43,6 +44,7 @@ export const setIsSearchUsed = createAction<boolean>('claim/setIsSearchUsed')
 // claiming
 export const setClaimedAmount = createAction<string>('claim/setClaimedAmount')
 export const setClaimStatus = createAction<ClaimStatus>('claim/setClaimStatus')
+export const setEstimatedGas = createAction<string>('claim/setEstimatedGas')
 
 // investing
 export const setIsInvestFlowActive = createAction<boolean>('claim/setIsInvestFlowActive')

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -54,6 +54,7 @@ import {
   ClaimStatus,
   resetClaimUi,
   updateInvestError,
+  setEstimatedGas,
 } from '../actions'
 import { EnhancedUserClaimData } from 'pages/Claim/types'
 import { supportedChainId } from 'utils/supportedChainId'
@@ -415,6 +416,7 @@ function _validateClaimable(
  */
 export function useClaimCallback(account: string | null | undefined): {
   claimCallback: (claimInputs: ClaimInput[]) => Promise<string>
+  estimateGasCallback: (claimInputs: ClaimInput[]) => Promise<BigNumber | undefined>
 } {
   // get claim data for given account
   const { chainId, account: connectedAccount } = useActiveWeb3React()
@@ -442,6 +444,76 @@ export function useClaimCallback(account: string | null | undefined): {
     },
   })
 
+  const getClaimArgs = useCallback(
+    async function (claimInput: ClaimInput[]): Promise<GetClaimManyArgsResult> {
+      if (claims.length === 0) {
+        throw new Error('User has no claims')
+      }
+      if (claimInput.length === 0) {
+        throw new Error('No claims selected')
+      }
+      if (!account) {
+        throw new Error('Claim account not set')
+      }
+      if (!connectedAccount) {
+        throw new Error('Not connected')
+      }
+      if (!nativeTokenPrice) {
+        throw new Error("There's no native token price")
+      }
+
+      _validateClaimable(claims, claimInput, isInvestmentWindowOpen, isAirdropWindowOpen)
+
+      return _getClaimManyArgs({
+        claimInput,
+        claims,
+        account,
+        connectedAccount,
+        nativeTokenPrice,
+      })
+    },
+    [account, claims, connectedAccount, isAirdropWindowOpen, isInvestmentWindowOpen, nativeTokenPrice]
+  )
+
+  const estimateGasCallback = useCallback(
+    async function (
+      claimInput: ClaimInput[],
+      claimArgs?: GetClaimManyArgsResult['args']
+    ): Promise<BigNumber | undefined> {
+      if (!vCowContract || !chainId) {
+        return
+      }
+
+      try {
+        let args = claimArgs
+        if (!claimArgs) {
+          const { args: _args } = await getClaimArgs(claimInput)
+          args = _args
+        }
+
+        if (!args) {
+          console.debug('Failed to estimate gas for claiming: There were no valid claims selected')
+          return
+        }
+
+        const estimatedGas = await vCowContract.estimateGas.claimMany(...args)
+
+        const a = calculateGasMargin(chainId, estimatedGas)
+
+        console.table([
+          [`estimated`, estimatedGas.toString()],
+          ['withMargin', a.toString()],
+        ])
+
+        return a
+      } catch (e) {
+        console.debug('Failed to estimate gas for claiming:', e.message)
+        return
+      }
+    },
+    [chainId, getClaimArgs, vCowContract]
+  )
+
   const claimCallback = useCallback(
     /**
      * Claim callback that sends tx to wallet to claim whatever user selected
@@ -449,68 +521,51 @@ export function useClaimCallback(account: string | null | undefined): {
      * Returns a string with the formatted vCow amount being claimed
      */
     async function (claimInput: ClaimInput[]): Promise<string> {
-      if (
-        claims.length === 0 ||
-        claimInput.length === 0 ||
-        !account ||
-        !connectedAccount ||
-        !chainId ||
-        !vCowContract ||
-        !vCowToken ||
-        !nativeTokenPrice
-      ) {
-        throw new Error("Not initialized, can't claim")
+      if (claimInput.length === 0) {
+        throw new Error('No claims selected')
+      }
+      if (!account) {
+        throw new Error('Claim account not set')
+      }
+      if (!connectedAccount) {
+        throw new Error('Not connected')
+      }
+      if (!vCowContract) {
+        throw new Error('vCOW contract not present')
+      }
+      if (!vCowToken) {
+        throw new Error('vCOW token not present')
       }
 
-      _validateClaimable(claims, claimInput, isInvestmentWindowOpen, isAirdropWindowOpen)
-
-      const { args, totalClaimedAmount } = _getClaimManyArgs({
-        claimInput,
-        claims,
-        account,
-        connectedAccount,
-        nativeTokenPrice,
-      })
+      const { args, totalClaimedAmount } = await getClaimArgs(claimInput)
 
       if (!args) {
-        throw new Error('There were no valid claims selected')
+        throw new Error('No valid claims selected')
       }
+
+      const gasLimit = await estimateGasCallback(claimInput, args)
 
       const vCowAmount = CurrencyAmount.fromRawAmount(vCowToken, totalClaimedAmount)
       const formattedVCowAmount = formatSmartLocaleAware(vCowAmount, AMOUNT_PRECISION) || '0'
 
-      return vCowContract.estimateGas.claimMany(...args).then((estimatedGas) => {
-        // Last item in the array contains the call overrides
-        const extendedArgs = _extendFinalArg(args, {
-          from: connectedAccount, // add the `from` as the connected account
-          gasLimit: calculateGasMargin(chainId, estimatedGas), // add the estimated gas limit
-        })
+      const extendedArgs = _extendFinalArg(args, {
+        from: connectedAccount, // add the `from` as the connected account
+        gasLimit,
+      })
 
-        return vCowContract.claimMany(...extendedArgs).then((response: TransactionResponse) => {
-          addTransaction({
-            hash: response.hash,
-            summary: `Claim ${formattedVCowAmount} vCOW`,
-            claim: { recipient: account, indices: args[0] as number[] },
-          })
-          return formattedVCowAmount
+      return vCowContract.claimMany(...extendedArgs).then((response: TransactionResponse) => {
+        addTransaction({
+          hash: response.hash,
+          summary: `Claim ${formattedVCowAmount} vCOW`,
+          claim: { recipient: account, indices: args[0] as number[] },
         })
+        return formattedVCowAmount
       })
     },
-    [
-      account,
-      addTransaction,
-      chainId,
-      claims,
-      connectedAccount,
-      isAirdropWindowOpen,
-      isInvestmentWindowOpen,
-      nativeTokenPrice,
-      vCowContract,
-      vCowToken,
-    ]
+    [account, addTransaction, connectedAccount, estimateGasCallback, getClaimArgs, vCowContract, vCowToken]
   )
 
-  return { claimCallback }
+  return { claimCallback, estimateGasCallback }
 }
 
 type GetClaimManyArgsParams = {

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -774,6 +774,7 @@ export function useClaimDispatchers() {
       // claiming
       setClaimStatus: (payload: ClaimStatus) => dispatch(setClaimStatus(payload)),
       setClaimedAmount: (payload: string) => dispatch(setClaimedAmount(payload)),
+      setEstimatedGas: (payload: string) => dispatch(setEstimatedGas(payload)),
       // investing
       setIsInvestFlowActive: (payload: boolean) => dispatch(setIsInvestFlowActive(payload)),
       setInvestFlowStep: (payload: number) => dispatch(setInvestFlowStep(payload)),

--- a/src/custom/state/claim/reducer.ts
+++ b/src/custom/state/claim/reducer.ts
@@ -15,6 +15,7 @@ import {
   resetClaimUi,
   ClaimStatus,
   updateInvestError,
+  setEstimatedGas,
 } from './actions'
 
 export const initialState: ClaimState = {
@@ -28,6 +29,7 @@ export const initialState: ClaimState = {
   // claiming
   claimStatus: ClaimStatus.DEFAULT,
   claimedAmount: '',
+  estimatedGas: '',
   // investment
   isInvestFlowActive: false,
   investFlowStep: 0,
@@ -54,6 +56,7 @@ export type ClaimState = {
   // claiming
   claimStatus: ClaimStatus
   claimedAmount: string
+  estimatedGas: string
   // investment
   isInvestFlowActive: boolean
   investFlowStep: number
@@ -82,6 +85,9 @@ export default createReducer(initialState, (builder) =>
     })
     .addCase(setClaimedAmount, (state, { payload }) => {
       state.claimedAmount = payload
+    })
+    .addCase(setEstimatedGas, (state, { payload }) => {
+      state.estimatedGas = payload
     })
     .addCase(setIsInvestFlowActive, (state, { payload }) => {
       state.isInvestFlowActive = payload
@@ -118,5 +124,6 @@ export default createReducer(initialState, (builder) =>
       state.investFlowStep = initialState.investFlowStep
       state.isInvestFlowActive = initialState.isInvestFlowActive
       state.claimedAmount = initialState.claimedAmount
+      state.estimatedGas = initialState.estimatedGas
     })
 )


### PR DESCRIPTION
# Summary

Follow up to #2256 

* No longer blocking EOAs in case native amount is being fully used. Showing same warning as SC wallets instead.
* Refactoring how gas is cost is calculated:
  * Using real gas cost based on selected input from the contract call data
  * Storing calculated gas on redux
  * Using `fast` gas prices for safety
* Show how much we think the tx will cost in the warning message

Example warning message
![Screen Shot 2022-01-24 at 14 16 25](https://user-images.githubusercontent.com/43217/150878794-fc2b3609-6b3f-46a5-9b92-e7fcd8c9e5ef.png)

What you'll see if you ignore the message
![Screen Shot 2022-01-24 at 14 19 01](https://user-images.githubusercontent.com/43217/150878816-96fb1169-ac52-4e02-9bcc-bdaf3f498a44.png)
 
  # To Test

Same steps as PR #2256 