### PR TITLE
Set initial claim invest input amount to an empty string

### DIFF
--- a/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
@@ -44,7 +44,7 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
   const { isSmartContractWallet } = useWalletInfo()
 
   const [percentage, setPercentage] = useState<string>('0')
-  const [typedValue, setTypedValue] = useState<string>('0')
+  const [typedValue, setTypedValue] = useState<string>('')
   const [inputWarning, setInputWarning] = useState<string>('')
 
   const investedAmount = investFlowData[optionIndex].investedAmount


### PR DESCRIPTION
# Summary

Suuuper big issue

Changing from:
![Screen Shot 2022-01-24 at 15 41 54](https://user-images.githubusercontent.com/43217/150883649-4da76f17-9760-4de7-ac9f-5662a4071a28.png)

To: 
![Screen Shot 2022-01-24 at 15 42 08](https://user-images.githubusercontent.com/43217/150883658-34ba1e9d-f1ba-4619-bb52-38e888e400b3.png)

  # To Test

1. Go to a paid claim
* Input amount should be empty (placeholder is a `0`)