### PR TITLE
Check claims disconnected

### DIFF
--- a/src/custom/pages/Claim/FooterNavButtons.tsx
+++ b/src/custom/pages/Claim/FooterNavButtons.tsx
@@ -50,7 +50,7 @@ export default function FooterNavButtons({
   const isInputAddressValid = isAddress(resolvedAddress || '')
 
   // User is connected and has some unclaimed claims
-  const isConnectedAndHasClaims = !!activeClaimAccount && !!hasClaims && claimStatus === ClaimStatus.DEFAULT
+  const isConnectedAndHasClaims = account && activeClaimAccount && hasClaims && claimStatus === ClaimStatus.DEFAULT
   const noPaidClaimsSelected = !selected.length
 
   let buttonContent: ReactNode = null

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -168,10 +168,7 @@ export default function Claim() {
 
   // on account/activeAccount/non-connected account (if claiming for someone else) change
   useEffect(() => {
-    // disconnected wallet?
-    if (!account) {
-      setActiveClaimAccount('')
-    } else if (!isSearchUsed) {
+    if (!isSearchUsed && account) {
       setActiveClaimAccount(account)
     }
 


### PR DESCRIPTION
# Summary

Allow checking for claims while disconnected

![Screen Shot 2022-01-24 at 16 21 18](https://user-images.githubusercontent.com/43217/150887282-3a97e573-09d0-49d4-8c5a-37186641d9ac.png)

  # To Test

1. Open the claim page and DO NOT connect your wallet
2. Check for accounts which should have claims in mainnet
* The claims should be visible
* The button should say `Connect wallet`
* Everything else should work as usual

  # Background

*Optional: Give background information for changes you've made, that might be difficult to explain via comments*

