### PR TITLE
Responsive claim summary table

### DIFF
--- a/src/custom/components/CowProtocolLogo/index.tsx
+++ b/src/custom/components/CowProtocolLogo/index.tsx
@@ -2,14 +2,22 @@ import styled from 'styled-components/macro'
 import CowProtocolIcon from 'assets/cow-swap/cowprotocol.svg'
 
 export const Icon = styled.span<Props>`
+  --defaultSize: 24px;
+  --smallSize: ${({ size }) => (size ? `calc(${size}px / 2)` : 'calc(var(--defaultSize) / 2)')};
   ${({ theme }) => theme.cowToken.background};
   ${({ theme }) => theme.cowToken.boxShadow};
-  height: ${({ size }) => (size ? `${size}px` : '24px')};
-  width: ${({ size }) => (size ? `${size}px` : '24px')};
+  height: ${({ size }) => (size ? `${size}px` : 'var(--defaultSize)')};
+  width: ${({ size }) => (size ? `${size}px` : 'var(--defaultSize)')};
   display: inline-block;
   margin: 0;
-  border-radius: ${({ size }) => (size ? `${size}px` : '24px')};
+  border-radius: ${({ size }) => (size ? `${size}px` : 'var(--defaultSize)')};
   position: relative;
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    width: var(--smallSize);
+    height: var(--smallSize);
+    border-radius: var(--smallSize);
+  `};
 
   &::after {
     content: '';

--- a/src/custom/components/CowProtocolLogo/index.tsx
+++ b/src/custom/components/CowProtocolLogo/index.tsx
@@ -3,7 +3,7 @@ import CowProtocolIcon from 'assets/cow-swap/cowprotocol.svg'
 
 export const Icon = styled.span<Props>`
   --defaultSize: 24px;
-  --smallSize: ${({ size }) => (size ? `calc(${size}px / 2)` : 'calc(var(--defaultSize) / 2)')};
+  --smallSize: ${({ size }) => (size ? `calc(${size}px / 1.5)` : 'calc(var(--defaultSize) / 1.5)')};
   ${({ theme }) => theme.cowToken.background};
   ${({ theme }) => theme.cowToken.boxShadow};
   height: ${({ size }) => (size ? `${size}px` : 'var(--defaultSize)')};

--- a/src/custom/components/Stepper/index.tsx
+++ b/src/custom/components/Stepper/index.tsx
@@ -22,6 +22,9 @@ export const Step = styled.div<{
   position: relative;
   flex: 1 1 ${({ totalSteps }) => `calc(100% / ${totalSteps})`};
 
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    --circleSize: 26px;
+  `}
   &::before,
   &::after {
     content: '';
@@ -82,6 +85,7 @@ export const Step = styled.div<{
     color: ${({ isActiveStep, completedStep, theme }) =>
       completedStep ? theme.text1 : isActiveStep ? theme.text1 : transparentize(0.4, theme.text1)};
     font-weight: ${({ isActiveStep, completedStep }) => (completedStep ? '300' : isActiveStep ? 'bold' : '300')};
+    text-align: center;
   }
 
   > i {

--- a/src/custom/pages/Claim/ClaimsTable.tsx
+++ b/src/custom/pages/Claim/ClaimsTable.tsx
@@ -78,10 +78,10 @@ const ClaimsTableRow = ({
           {!isFree && <i>with {currencyAmount?.currency?.symbol}</i>}
         </span>
       </td>
-      <td title={`${formatMax(claimAmount, claimAmount.currency.decimals)} vCOW`}>
+      <td data-title="Amount" title={`${formatMax(claimAmount, claimAmount.currency.decimals)} vCOW`}>
         {formatSmartLocaleAware(claimAmount, AMOUNT_PRECISION) || 0} vCOW
       </td>
-      <td>
+      <td data-title="Details">
         {!isFree ||
           (price && (
             <span>

--- a/src/custom/pages/Claim/ClaimsTable.tsx
+++ b/src/custom/pages/Claim/ClaimsTable.tsx
@@ -34,13 +34,6 @@ const ClaimTr = styled.tr<{ isPending?: boolean }>`
   > td {
     background-color: ${({ isPending }) => (isPending ? '#221954' : 'rgb(255 255 255 / 6%)')};
     cursor: ${({ isPending }) => (isPending ? 'pointer' : 'initial')};
-
-    &:first-child {
-      border-radius: 8px 0 0 8px;
-    }
-    &:last-child {
-      border-radius: 0 8px 8px 0;
-    }
   }
 `
 
@@ -60,7 +53,7 @@ const ClaimsTableRow = ({
 }: ClaimsTableRowProps) => {
   return (
     <ClaimTr key={index} isPending={isPendingClaim}>
-      <td>
+      <td data-title="Select">
         {' '}
         <label className="checkAll">
           {isPendingClaim ? (
@@ -76,7 +69,7 @@ const ClaimsTableRow = ({
           )}
         </label>
       </td>
-      <td>
+      <td data-title="Type of Claim">
         {' '}
         {!isFree && <TokenLogo symbol={`${currencyAmount?.currency?.symbol}`} size={34} />}
         <CowProtocolLogo size={34} />
@@ -85,8 +78,8 @@ const ClaimsTableRow = ({
           {!isFree && <i>with {currencyAmount?.currency?.symbol}</i>}
         </span>
       </td>
-      <td>{formatSmartLocaleAware(claimAmount, AMOUNT_PRECISION) || 0} vCOW</td>
-      <td>
+      <td data-title="Amount">{formatSmartLocaleAware(claimAmount, AMOUNT_PRECISION) || 0} vCOW</td>
+      <td data-title="Details">
         {!isFree ||
           (price && (
             <span>

--- a/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
@@ -202,16 +202,16 @@ export default function InvestOption({ approveData, claim, optionIndex }: Invest
                   `${currencyAmount?.currency?.symbol} not approved`
                 ) : (
                   <Row>
-                    <span>{currencyAmount?.currency?.symbol} approved</span>
                     <img src={CheckCircle} alt="Approved" />
+                    <span>{currencyAmount?.currency?.symbol} approved</span>
                   </Row>
                 )}
               </i>
             ) : (
               <i>
                 <Row>
-                  <span>Approval not required!</span>
                   <img src={CheckCircle} alt="Approved" />
+                  <span>Approval not required!</span>
                 </Row>
               </i>
             )}

--- a/src/custom/pages/Claim/InvestmentFlow/InvestSummaryRow.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestSummaryRow.tsx
@@ -25,7 +25,7 @@ export function InvestSummaryRow(props: Props): JSX.Element | null {
 
   return (
     <tr>
-      <td>
+      <td data-title="Type of Claim">
         {isFree ? (
           <>
             <CowProtocolLogo size={42} />
@@ -45,7 +45,7 @@ export function InvestSummaryRow(props: Props): JSX.Element | null {
         )}
       </td>
 
-      <td>
+      <td data-title="Amount">
         <i title={`${formatMax(vCowAmount, vCowAmount?.currency.decimals)} vCOW`}>
           {formatSmartLocaleAware(vCowAmount, AMOUNT_PRECISION) || '0'} vCOW
         </i>
@@ -66,7 +66,7 @@ export function InvestSummaryRow(props: Props): JSX.Element | null {
         )}
       </td>
 
-      <td>
+      <td data-title="Details">
         {!isFree && (
           <span>
             <b>Price:</b>{' '}

--- a/src/custom/pages/Claim/styled.ts
+++ b/src/custom/pages/Claim/styled.ts
@@ -323,6 +323,25 @@ export const ClaimTable = styled.div`
     ${({ theme }) => theme.mediaWidth.upToSmall`
       display: block;
     `};
+
+    input[type='checkbox'] {
+      ${({ theme }) => theme.mediaWidth.upToSmall`
+      width: 42px;
+      height: 42px;
+      
+      &::after {
+        width: 15px;
+        height: 24px;
+        border: 4px solid var(--active-inner);
+        border-top: 0;
+        border-left: 0;
+        left: 0;
+        right: 0;
+        top: -6px;
+        bottom: 0;
+        margin: auto;
+      `};
+    }
   }
 
   thead,
@@ -419,6 +438,7 @@ export const ClaimTable = styled.div`
 
       ${({ theme }) => theme.mediaWidth.upToSmall`
         margin: 0 4px 0 0;
+        font-size: 20px;
         flex-flow: row wrap;
       `};
     }
@@ -428,7 +448,7 @@ export const ClaimTable = styled.div`
       font-size: 15px;
 
       ${({ theme }) => theme.mediaWidth.upToSmall`
-        font-size: 16px;
+        font-size: 20px;
         margin: 0 0 0 3px;
       `};
     }
@@ -441,7 +461,7 @@ export const ClaimTable = styled.div`
     font-weight: 500;
 
     ${({ theme }) => theme.mediaWidth.upToSmall`
-      font-size: 16px;
+      font-size: 20px;
       font-weight: bold;
     `};
   }
@@ -454,7 +474,7 @@ export const ClaimTable = styled.div`
     gap: 4px;
 
     ${({ theme }) => theme.mediaWidth.upToSmall`
-      font-size: 15px;
+      font-size: 16px;
     `};
 
     > span {
@@ -1162,10 +1182,10 @@ export const InvestInput = styled.span`
       color: ${({ theme }) => theme.text1};
     }
 
-  > div > label > span > ${UnderlineButton} {
-    margin-left: 4px;
+    > div > label > span > ${UnderlineButton} {
+      margin-left: 4px;
 
-  }
+    }
 `
 
 export const InvestAvailableBar = styled.div<{ percentage?: number }>`

--- a/src/custom/pages/Claim/styled.ts
+++ b/src/custom/pages/Claim/styled.ts
@@ -23,6 +23,7 @@ export const PageWrapper = styled.div`
   background: ${({ theme }) => theme.bg1};
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
+    padding: 16px;
     border-radius: var(--border-radius-small);
   `};
 
@@ -162,8 +163,8 @@ ${ButtonPrimary} {
   padding: 24px 16px;
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
-      margin: 0 auto 24px;
-    `};
+    margin: 0 auto 24px;
+  `};
 
   &[disabled] {
     cursor: not-allowed;
@@ -458,6 +459,10 @@ export const ClaimTotal = styled.div`
     margin: 0;
     font-size: 30px;
     font-weight: bold;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      font-size: 16px;
+    `};
   }
 `
 
@@ -527,10 +532,18 @@ export const EligibleBanner = styled.div`
   margin: 0 auto 16px;
   font-weight: 600;
 
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    text-align: left;
+    padding: 18px;
+  `}
   > img {
     margin: 0 6px 0 0;
     width: 21px;
     height: 21px;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      margin: 0 12px 0 6px;
+   `}
   }
 `
 
@@ -643,24 +656,26 @@ export const CheckAddress = styled.div`
 
   ${Icon} {
     margin: 0 auto;
-  }
 
-  > h1 {
-    font-size: 32px;
-    font-weight: 300;
-    text-align: center;
-  }
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      margin: 0 0 0 6px;
+   `}
+    > h1 {
+      font-size: 32px;
+      font-weight: 300;
+      text-align: center;
+    }
 
-  > h1 > b {
-    font-weight: bold;
-  }
+    > h1 > b {
+      font-weight: bold;
+    }
 
-  > p {
-    text-align: center;
-    font-size: 18px;
-    line-height: 1.2;
-    margin: 0 0 24px;
-  }
+    > p {
+      text-align: center;
+      font-size: 18px;
+      line-height: 1.2;
+      margin: 0 0 24px;
+    }
 `
 
 export const ClaimBreakdown = styled.div`

--- a/src/custom/pages/Claim/styled.ts
+++ b/src/custom/pages/Claim/styled.ts
@@ -874,12 +874,20 @@ export const InvestContent = styled.div`
       font-size: 14px;
       grid-template-columns: repeat(3, auto);
 
+      ${({ theme }) => theme.mediaWidth.upToSmall`
+        grid-template-columns: 1fr;
+      `}
       tr > td {
         flex-flow: column wrap;
         align-content: center;
         gap: 18px;
         font-weight: 300;
         font-size: 14px;
+
+        ${({ theme }) => theme.mediaWidth.upToSmall`
+          gap: 4px 0;
+          margin: 0;
+        `};
       }
 
       tr > td > span {
@@ -893,6 +901,10 @@ export const InvestContent = styled.div`
 
         &:last-child {
           width: 100%;
+
+          ${({ theme }) => theme.mediaWidth.upToSmall`
+            width: auto;
+          `};
         }
       }
 
@@ -900,6 +912,10 @@ export const InvestContent = styled.div`
         flex-flow: row wrap;
         align-content: center;
         gap: 6px;
+
+        ${({ theme }) => theme.mediaWidth.upToSmall`
+          align-items: center;
+        `};
 
         > span > b,
         > b {
@@ -920,12 +936,21 @@ export const InvestContent = styled.div`
 
         > span {
           margin: 0;
+
+          ${({ theme }) => theme.mediaWidth.upToSmall`
+            margin: 24px 0 0;
+          `};
         }
 
         > i {
           font-style: normal;
           font-size: 18px;
           font-weight: 500;
+
+          ${({ theme }) => theme.mediaWidth.upToSmall`
+            font-size: 16px;
+            font-weight: bold;
+          `};
         }
       }
 
@@ -936,6 +961,11 @@ export const InvestContent = styled.div`
 
         > span {
           width: 100%;
+
+          ${({ theme }) => theme.mediaWidth.upToSmall`
+            flex-flow: row wrap;
+            gap: 0 3px;
+          `};
         }
       }
     }

--- a/src/custom/pages/Claim/styled.ts
+++ b/src/custom/pages/Claim/styled.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components/macro'
 import { CheckCircle, Frown } from 'react-feather'
 import { Icon } from 'components/CowProtocolLogo'
 import { ButtonPrimary, ButtonSecondary } from 'components/Button'
+import { Step } from 'components/Stepper'
 import { transparentize, darken } from 'polished'
 import LogoETH from 'assets/cow-swap/network-mainnet-logo.svg'
 import LogoGNO from 'assets/cow-swap/gno.png'
@@ -186,14 +187,36 @@ ${ButtonSecondary} {
     text-decoration: underline;
   }
 }
+
+${Step} {
+  > b {
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      font-size: 13px;
+    `};
+  }
+
+  > i {
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      display: none;
+    `};
+  }
+
+}
 `
 
 export const TokenLogo = styled.div<{ symbol: string; size: number }>`
+  --smallSize: ${({ size }) => (size ? `calc(${size}px / 1.5)` : 'calc(var(--defaultSize) / 1.5)')};
   display: flex;
-  width: ${({ size }) => `${size}px`};
-  height: ${({ size }) => `${size}px`};
-  border-radius: ${({ size }) => `${size}px`};
+  height: ${({ size }) => (size ? `${size}px` : 'var(--defaultSize)')};
+  width: ${({ size }) => (size ? `${size}px` : 'var(--defaultSize)')};
+  border-radius: ${({ size }) => (size ? `${size}px` : 'var(--defaultSize)')};
   background: ${({ symbol, theme }) => `url(${_getLogo(symbol) || theme.blueShade3}) no-repeat center/contain`};
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    width: var(--smallSize);
+    height: var(--smallSize);
+    border-radius: var(--smallSize);
+  `};
 `
 
 function _getLogo(symbol: string) {
@@ -282,6 +305,10 @@ export const ClaimTable = styled.div`
 
   ${TokenLogo} {
     margin: 0 -16px 0 0;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      margin: 0 -6px 0 0;
+    `};
   }
 
   table {
@@ -290,6 +317,10 @@ export const ClaimTable = styled.div`
     min-width: 100%;
     font-size: 16px;
     grid-template-columns: min-content auto auto 240px;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      display: block;
+    `};
   }
 
   thead,
@@ -298,8 +329,49 @@ export const ClaimTable = styled.div`
     display: contents;
   }
 
-  tr > td {
-    background: ${({ theme }) => theme.blueShade3};
+  thead {
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      display: none;
+    `};
+  }
+
+  tr {
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      display: block;
+      background: ${({ theme }) => theme.blueShade3};
+      border-radius: 12px;
+      margin: 0 0 12px;
+    `};
+
+    > td {
+      background: ${({ theme }) => theme.blueShade3};
+      margin: 0 0 12px;
+
+      ${({ theme }) => theme.mediaWidth.upToSmall`
+        background: none;
+        flex-flow: row wrap;
+        align-items: flex-start;
+        gap: 4px 0;
+        margin: 0;
+        
+        &::before {
+          font-size: 16px;
+          font-weight: normal;
+          content: attr(data-title);
+          display: block;
+          flex: 1 1 100%;
+          margin: 0 0 4px;
+        }
+      `};
+
+      &:first-child {
+        border-radius: 8px 0 0 8px;
+      }
+
+      &:last-child {
+        border-radius: 0 8px 8px 0;
+      }
+    }
   }
 
   th,
@@ -337,20 +409,26 @@ export const ClaimTable = styled.div`
     font-weight: 300;
   }
 
-  tr > td {
-    margin: 0 0 12px;
-  }
-
   tr > td:nth-of-type(2) {
     > span {
       margin: 0 12px 0 0;
       display: flex;
       flex-flow: column wrap;
+
+      ${({ theme }) => theme.mediaWidth.upToSmall`
+        margin: 0 4px 0 0;
+        flex-flow: row wrap;
+      `};
     }
 
     > span > i {
       font-style: normal;
       font-size: 15px;
+
+      ${({ theme }) => theme.mediaWidth.upToSmall`
+        font-size: 16px;
+        margin: 0 0 0 3px;
+      `};
     }
   }
 
@@ -359,6 +437,11 @@ export const ClaimTable = styled.div`
   tr > td:nth-of-type(3) {
     font-size: 18px;
     font-weight: 500;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      font-size: 16px;
+      font-weight: bold;
+    `};
   }
 
   tr > td:nth-of-type(4) {
@@ -367,6 +450,10 @@ export const ClaimTable = styled.div`
     flex-flow: column wrap;
     align-items: flex-start;
     gap: 4px;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      font-size: 15px;
+    `};
 
     > span {
       color: ${({ theme }) => transparentize(0.1, theme.text1)};
@@ -453,6 +540,10 @@ export const ClaimTotal = styled.div`
     font-weight: normal;
     margin: 0 0 2px;
     opacity: 0.7;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      margin: 0 0 3px;
+    `};
   }
 
   > p {
@@ -462,6 +553,7 @@ export const ClaimTotal = styled.div`
 
     ${({ theme }) => theme.mediaWidth.upToSmall`
       font-size: 16px;
+      line-height: 1;
     `};
   }
 `
@@ -841,6 +933,11 @@ export const InvestTokenGroup = styled.div`
   border-radius: 12px;
   background: ${({ theme }) => theme.blueShade3};
 
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    flex-flow: row wrap;
+    padding: 16px;
+   `};
+
   ${TokenLogo},
   ${Icon} {
     border: 4px solid ${({ theme }) => theme.blueShade3};
@@ -851,6 +948,10 @@ export const InvestTokenGroup = styled.div`
     flex-flow: column wrap;
     flex: 0 1 auto;
     padding: 0 32px 0 0;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      padding: 0;
+    `};
   }
 
   > div > span {
@@ -859,16 +960,29 @@ export const InvestTokenGroup = styled.div`
     justify-content: flex-start;
     align-items: flex-start;
     margin: 0 25px 0 0;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      order: 1;
+    `};
   }
 
   > div > h3 {
     font-size: 21px;
     font-weight: 600;
     margin: 0 0 18px;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      order: 2;
+      margin: 8px 0 24px;
+    `};
   }
 
   ${TokenLogo} {
     margin: 0 -36px 0 0;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      margin: 0 -17px 0 0;
+    `};
   }
 
   > span {
@@ -927,6 +1041,11 @@ export const InvestInput = styled.span`
     border-radius: 12px;
     padding: 0 12px;
     height: 32px;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      top: initial;
+      bottom: 12px;
+    `};
   }
 
   > div > label > input {
@@ -939,6 +1058,10 @@ export const InvestInput = styled.span`
     width: 100%;
     line-height: 1;
     text-align: left;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      font-size: 21px;
+    `};
 
     &::placeholder {
       opacity: 0.5;
@@ -960,15 +1083,30 @@ export const InvestInput = styled.span`
     display: flex;
     width: 100%;
     font-size: 14px;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      flex-flow: row wrap;
+      justify-content: flex-start;
+      align-items: flex-start;
+  `};
   }
 
   > div > label > span > b {
     margin: 0 3px 0 0;
     font-weight: normal;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      bottom: 12px;
+      top: initial;
+    `};
   }
 
   > div > Label > span > i {
     font-style: normal;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      margin: 0 5px 0 0;
+    `};
   }
 
   > div > label > span > button {
@@ -977,6 +1115,11 @@ export const InvestInput = styled.span`
     cursor: pointer;
     color: ${({ theme }) => theme.primary4};
     text-decoration: underline;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      margin: 0;
+      padding: 0;
+    `};
 
     &:hover {
       color: ${({ theme }) => theme.text1};
@@ -1035,6 +1178,10 @@ export const InvestSummary = styled.div`
   font-size: 15px;
   gap: 16px 36px;
 
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    gap: 16px 8px;
+  `};
+
   > span {
     display: flex;
     flex-flow: column wrap;
@@ -1054,7 +1201,7 @@ export const InvestSummary = styled.div`
   }
 
   > span > i > div > img {
-    margin: 0 0 0 4px;
+    margin: 0 4px 0 0;
     height: 21px;
     width: 21px;
   }


### PR DESCRIPTION
# Summary

- Makes the claim summary table responsive

https://user-images.githubusercontent.com/31534717/150978545-6e4ff670-07dd-419f-8dbc-e6663e83fe1a.mov

## Todo in upcoming PR's
- Highlight each 'card' differently when selected/not selected.
- Make the investment summary table also responsive, using the same approach.
