### PR TITLE
Remove cow claim button on desktop fly-out menu

### DIFF
--- a/src/custom/components/Menu/index.tsx
+++ b/src/custom/components/Menu/index.tsx
@@ -49,6 +49,7 @@ const MenuItemResponsive = styled(MenuItemResponsiveBase)`
   flex: 0 1 auto;
   padding: 16px;
   font-size: 18px;
+
   svg {
     width: 18px;
     height: 18px;
@@ -99,8 +100,10 @@ export const StyledMenu = styled(MenuMod)<{ isClaimPage: boolean }>`
 
   ${ClaimButtonWrapper} {
     margin: 0 0 12px;
+    display: none;
 
     ${({ theme }) => theme.mediaWidth.upToSmall`
+      display: flex;
       margin: 0 12px 12px;
       width: 100%;
       height: 56px;
@@ -199,6 +202,7 @@ const MenuFlyout = styled(MenuFlyoutUni)`
       align-items: center;
     }
   }
+
   > a:hover {
     background: ${({ theme }) => theme.disabled};
     border-radius: 6px;


### PR DESCRIPTION
# Summary

- Removes the Cow Claim button in the fly out menu. Only shown for mobile.
<img width="691" alt="Screen Shot 2022-01-25 at 13 53 46" src="https://user-images.githubusercontent.com/31534717/150980817-3d76dfc3-bd2e-492a-b122-acfb129b88d1.png">

