### PR TITLE
Style invest summary page.

### DIFF
--- a/src/custom/pages/Claim/InvestmentFlow/InvestSummaryRow.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestSummaryRow.tsx
@@ -22,7 +22,7 @@ export function InvestSummaryRow(props: Props): JSX.Element | null {
 
   return (
     <tr>
-      <td>
+      <td data-title="Type of Claim">
         {isFree ? (
           <>
             <CowProtocolLogo size={42} />
@@ -42,7 +42,7 @@ export function InvestSummaryRow(props: Props): JSX.Element | null {
         )}
       </td>
 
-      <td>
+      <td data-title="Amount">
         <i>{formatSmartLocaleAware(vCowAmount, AMOUNT_PRECISION) || '0'} vCOW</i>
 
         {!isFree && (
@@ -61,7 +61,7 @@ export function InvestSummaryRow(props: Props): JSX.Element | null {
         )}
       </td>
 
-      <td>
+      <td data-title="Details">
         {!isFree && (
           <span>
             <b>Price:</b>{' '}

--- a/src/custom/pages/Claim/styled.ts
+++ b/src/custom/pages/Claim/styled.ts
@@ -854,12 +854,20 @@ export const InvestContent = styled.div`
       font-size: 14px;
       grid-template-columns: repeat(3, auto);
 
+      ${({ theme }) => theme.mediaWidth.upToSmall`
+        grid-template-columns: 1fr;
+      `}
       tr > td {
         flex-flow: column wrap;
         align-content: center;
         gap: 18px;
         font-weight: 300;
         font-size: 14px;
+
+        ${({ theme }) => theme.mediaWidth.upToSmall`
+          gap: 4px 0;
+          margin: 0;
+        `};
       }
 
       tr > td > span {
@@ -873,6 +881,10 @@ export const InvestContent = styled.div`
 
         &:last-child {
           width: 100%;
+
+          ${({ theme }) => theme.mediaWidth.upToSmall`
+            width: auto;
+          `};
         }
       }
 
@@ -880,6 +892,10 @@ export const InvestContent = styled.div`
         flex-flow: row wrap;
         align-content: center;
         gap: 6px;
+
+        ${({ theme }) => theme.mediaWidth.upToSmall`
+          align-items: center;
+        `};
 
         > span > b,
         > b {
@@ -900,12 +916,21 @@ export const InvestContent = styled.div`
 
         > span {
           margin: 0;
+
+          ${({ theme }) => theme.mediaWidth.upToSmall`
+            margin: 24px 0 0;
+          `};
         }
 
         > i {
           font-style: normal;
           font-size: 18px;
           font-weight: 500;
+
+          ${({ theme }) => theme.mediaWidth.upToSmall`
+            font-size: 16px;
+            font-weight: bold;
+          `};
         }
       }
 
@@ -916,6 +941,11 @@ export const InvestContent = styled.div`
 
         > span {
           width: 100%;
+
+          ${({ theme }) => theme.mediaWidth.upToSmall`
+            flex-flow: row wrap;
+            gap: 0 3px;
+          `};
         }
       }
     }


### PR DESCRIPTION
# Summary

- Makes the invest summary page responsive
<img width="394" alt="Screen Shot 2022-01-25 at 15 48 35" src="https://user-images.githubusercontent.com/31534717/150999327-9b78cf19-00d7-4156-824c-974400d2b1e5.png">
<img width="404" alt="Screen Shot 2022-01-25 at 15 48 06" src="https://user-images.githubusercontent.com/31534717/150999346-efeb1afd-2bbf-4e4b-a317-2bda90d7e416.png">

