### PR TITLE
Disable claiming: BARN / PROD / ENS

### DIFF
--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -45,7 +45,7 @@ import Modal from 'components/Modal'
 // import ClaimModal from 'components/claim/ClaimModal'
 import UniBalanceContent from 'components/Header/UniBalanceContent'
 import CowClaimButton from 'components/CowClaimButton'
-import { IS_CLAIMING_ENABLED } from 'pages/Claim'
+import { IS_CLAIMING_ENABLED } from 'pages/Claim/const'
 
 export const NETWORK_LABELS: { [chainId in ChainId]?: string } = {
   [ChainId.RINKEBY]: 'Rinkeby',

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -45,6 +45,7 @@ import Modal from 'components/Modal'
 // import ClaimModal from 'components/claim/ClaimModal'
 import UniBalanceContent from 'components/Header/UniBalanceContent'
 import CowClaimButton from 'components/CowClaimButton'
+import { IS_CLAIMING_ENABLED } from 'pages/Claim'
 
 export const NETWORK_LABELS: { [chainId in ChainId]?: string } = {
   [ChainId.RINKEBY]: 'Rinkeby',
@@ -258,9 +259,11 @@ export default function Header() {
             <NetworkSelector />
           </HeaderElement>
           <HeaderElement>
-            <VCowWrapper>
-              <CowClaimButton isClaimPage={isClaimPage} account={account} handleOnClickClaim={handleOnClickClaim} />
-            </VCowWrapper>
+            {IS_CLAIMING_ENABLED && (
+              <VCowWrapper>
+                <CowClaimButton isClaimPage={isClaimPage} account={account} handleOnClickClaim={handleOnClickClaim} />
+              </VCowWrapper>
+            )}
 
             <AccountElement active={!!account} style={{ pointerEvents: 'auto' }}>
               {account && userEthBalance && (

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -20,6 +20,7 @@ import { version } from '@src/../package.json'
 import { environmentName } from 'utils/environments'
 import { useFilterEmptyQueryParams } from 'hooks/useFilterEmptyQueryParams'
 import RedirectAnySwapAffectedUsers from 'pages/error/AnySwapAffectedUsers/RedirectAnySwapAffectedUsers'
+import { IS_CLAIMING_ENABLED } from 'pages/Claim'
 
 const SENTRY_DSN = process.env.REACT_APP_SENTRY_DSN
 const SENTRY_TRACES_SAMPLE_RATE = process.env.REACT_APP_SENTRY_TRACES_SAMPLE_RATE
@@ -75,7 +76,7 @@ export default function App() {
           <Route exact strict path="/swap" component={Swap} />
           <Route exact strict path="/swap/:outputCurrency" component={RedirectToSwap} />
           <Route exact strict path="/send" component={RedirectPathToSwapOnly} />
-          <Route exact strict path="/claim" component={Claim} />
+          {IS_CLAIMING_ENABLED && <Route exact strict path="/claim" component={Claim} />}
           <Route exact strict path="/about" component={About} />
           <Route exact strict path="/profile" component={Profile} />
           <Route exact strict path="/faq" component={Faq} />

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -20,7 +20,7 @@ import { version } from '@src/../package.json'
 import { environmentName } from 'utils/environments'
 import { useFilterEmptyQueryParams } from 'hooks/useFilterEmptyQueryParams'
 import RedirectAnySwapAffectedUsers from 'pages/error/AnySwapAffectedUsers/RedirectAnySwapAffectedUsers'
-import { IS_CLAIMING_ENABLED } from 'pages/Claim'
+import { IS_CLAIMING_ENABLED } from 'pages/Claim/const'
 
 const SENTRY_DSN = process.env.REACT_APP_SENTRY_DSN
 const SENTRY_TRACES_SAMPLE_RATE = process.env.REACT_APP_SENTRY_TRACES_SAMPLE_RATE

--- a/src/custom/pages/Claim/const.ts
+++ b/src/custom/pages/Claim/const.ts
@@ -1,0 +1,3 @@
+import { isProd, isEns, isBarn } from 'utils/environments'
+
+export const IS_CLAIMING_ENABLED = !isProd && !isEns && !isBarn

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -26,11 +26,15 @@ import useTransactionConfirmationModal from 'hooks/useTransactionConfirmationMod
 import { useErrorModal } from 'hooks/useErrorMessageAndModal'
 import FooterNavButtons from './FooterNavButtons'
 
+import { isProd, isEns, isBarn } from 'utils/environments'
+
 /* TODO: Replace URLs with the actual final URL destinations */
 export const COW_LINKS = {
   vCowPost: 'https://cow.fi/',
   stepGuide: 'https://cow.fi/',
 }
+
+export const IS_CLAIMING_ENABLED = !isProd && !isEns && !isBarn
 
 export default function Claim() {
   const { account } = useActiveWeb3React()

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -34,6 +34,8 @@ import { useTokenBalance } from 'state/wallet/hooks'
 import { V_COW } from 'constants/tokens'
 import VCOWDropdown from './VCOWDropdown'
 
+import { IS_CLAIMING_ENABLED } from 'pages/Claim'
+
 export default function Profile() {
   const referralLink = useReferralLink()
   const { account, chainId } = useActiveWeb3React()
@@ -66,7 +68,7 @@ export default function Profile() {
           <CardHead>
             <Title>Profile</Title>
           </CardHead>
-          {vCowBalance && <VCOWDropdown balance={vCowBalance} />}
+          {IS_CLAIMING_ENABLED && vCowBalance && <VCOWDropdown balance={vCowBalance} />}
         </ProfileGridWrap>
       </ProfileWrapper>
       {chainId && chainId === ChainId.MAINNET && <AffiliateStatusCheck />}

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -34,7 +34,7 @@ import { useTokenBalance } from 'state/wallet/hooks'
 import { V_COW } from 'constants/tokens'
 import VCOWDropdown from './VCOWDropdown'
 
-import { IS_CLAIMING_ENABLED } from 'pages/Claim'
+import { IS_CLAIMING_ENABLED } from 'pages/Claim/const'
 
 export default function Profile() {
   const referralLink = useReferralLink()


### PR DESCRIPTION
# Summary

This PR removes in production, barn and ENS the claiming so its hidden.

> For people trying to use it ahead of time, note it's not possible 😆
basically because the functionality is hooked to FAKE tokens. The REAL token would be deploy by the DAO if they decide to deploy it.


Removes the button from the header:
<img width="1034" alt="Screenshot at Jan 25 16-22-18" src="https://user-images.githubusercontent.com/2352112/151017840-962e6bca-b946-449e-8ab0-15a4b8150591.png">


Removes the balance from the Profile:
<img width="1020" alt="Screenshot at Jan 25 16-22-33" src="https://user-images.githubusercontent.com/2352112/151018261-67743f2e-de09-49e6-8573-386031ebc341.png">

It evens remove the page:
<img width="1238" alt="Screenshot at Jan 25 16-22-06" src="https://user-images.githubusercontent.com/2352112/151018313-b9c5072d-94fd-46c1-a0fe-9ed20ba40bb1.png">



# To Test

1. Test it locally, change the flag in the `src/custom/pages/Claim/const.ts` file
2. Verify the app behaves as it shoud