### PR TITLE
Fix claim table price

### DIFF
--- a/src/custom/pages/Claim/ClaimsTable.tsx
+++ b/src/custom/pages/Claim/ClaimsTable.tsx
@@ -82,7 +82,7 @@ const ClaimsTableRow = ({
         {formatSmartLocaleAware(claimAmount, AMOUNT_PRECISION) || 0} vCOW
       </td>
       <td data-title="Details">
-        {!isFree && price && (
+        {price && (
           <span>
             Price:{' '}
             <b title={formatMax(price)}>{`${formatSmartLocaleAware(price) || 0} vCOW per ${

--- a/src/custom/pages/Claim/ClaimsTable.tsx
+++ b/src/custom/pages/Claim/ClaimsTable.tsx
@@ -82,15 +82,14 @@ const ClaimsTableRow = ({
         {formatSmartLocaleAware(claimAmount, AMOUNT_PRECISION) || 0} vCOW
       </td>
       <td data-title="Details">
-        {!isFree ||
-          (price && (
-            <span>
-              Price:{' '}
-              <b title={formatMax(price)}>{`${formatSmartLocaleAware(price) || 0} vCOW per ${
-                currencyAmount?.currency?.symbol
-              }`}</b>
-            </span>
-          ))}
+        {!isFree && price && (
+          <span>
+            Price:{' '}
+            <b title={formatMax(price)}>{`${formatSmartLocaleAware(price) || 0} vCOW per ${
+              currencyAmount?.currency?.symbol
+            }`}</b>
+          </span>
+        )}
         <span>
           Cost:{' '}
           <b title={cost && `${formatMax(cost, cost.currency.decimals)} ${cost.currency.symbol}`}>


### PR DESCRIPTION
# Summary

Price was hidden due to bad conditional. Now it's visible again!

Before:
![Screen Shot 2022-01-25 at 10 56 42](https://user-images.githubusercontent.com/43217/151041045-7ea277c5-8416-45f0-b7fa-2c639682e3ac.png)

Now:
![Screen Shot 2022-01-25 at 10 56 03](https://user-images.githubusercontent.com/43217/151041055-b42ab22f-5bc7-4f10-9af0-0137a82d3800.png)


  # To Test

1. Load an account with paid claims
* Price should be visible again