### PR TITLE
Add support for token transfer links

### DIFF
--- a/src/custom/components/EnhancedTransactionLink/index.tsx
+++ b/src/custom/components/EnhancedTransactionLink/index.tsx
@@ -1,5 +1,3 @@
-import { ExplorerDataType } from 'utils/getExplorerLink'
-
 import { ExplorerLink } from 'components/ExplorerLink'
 import { GnosisSafeLink } from 'components/AccountDetails/Transaction/StatusDetails'
 
@@ -27,6 +25,6 @@ export function EnhancedTransactionLink(props: Props) {
 
     return <GnosisSafeLink chainId={chainId} safeTransaction={safeTx} gnosisSafeThreshold={gnosisSafeInfo.threshold} />
   } else {
-    return <ExplorerLink id={tx.hash} type={ExplorerDataType.TRANSACTION} />
+    return <ExplorerLink id={tx.hash} type="transaction" />
   }
 }

--- a/src/custom/pages/Claim/ClaimingStatus.tsx
+++ b/src/custom/pages/Claim/ClaimingStatus.tsx
@@ -13,11 +13,10 @@ import { useClaimState } from 'state/claim/hooks'
 import { useActiveWeb3React } from 'hooks/web3'
 import CowProtocolLogo from 'components/CowProtocolLogo'
 import { useAllClaimingTransactions } from 'state/enhancedTransactions/hooks'
-import React, { useMemo } from 'react'
+import { useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { ExplorerLink } from 'components/ExplorerLink'
 import { EnhancedTransactionLink } from 'components/EnhancedTransactionLink'
-import { ExplorerDataType } from 'utils/getExplorerLink'
 import { V_COW } from 'constants/tokens'
 import AddToMetamask from 'components/AddToMetamask'
 import SVG from 'react-inlinesvg'
@@ -88,7 +87,7 @@ export default function ClaimingStatus() {
                     You have just claimed on behalf of{' '}
                     <b>
                       {activeClaimAccount} (
-                      <ExplorerLink id={activeClaimAccount} type={ExplorerDataType.ADDRESS} />)
+                      <ExplorerLink id={activeClaimAccount} type="token-transfer" />)
                     </b>
                   </p>
                 </div>

--- a/src/custom/pages/Claim/InvestmentFlow/index.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/index.tsx
@@ -33,7 +33,6 @@ import { ClaimCommonTypes, ClaimWithInvestmentData, EnhancedUserClaimData } from
 import { COW_LINKS } from 'pages/Claim'
 import { ExternalLink } from 'theme'
 import { ExplorerLink } from 'components/ExplorerLink'
-import { ExplorerDataType } from 'utils/getExplorerLink'
 
 import { BadgeVariant } from 'components/Badge'
 import { DollarSign, Icon, Send } from 'react-feather'
@@ -115,7 +114,7 @@ function AccountDetails({ label, account, connectedAccount, Icon }: AccountDetai
         <Icon width={14} height={14} /> {label}:
       </b>
       <i>
-        <ExplorerLink id={account} label={account} type={ExplorerDataType.ADDRESS} />{' '}
+        <ExplorerLink id={account} label={account} type="address" />{' '}
         {account === connectedAccount ? (
           <Badge variant={BadgeVariant.POSITIVE}>&nbsp; Connected account</Badge>
         ) : (

--- a/src/custom/utils/index.ts
+++ b/src/custom/utils/index.ts
@@ -26,7 +26,7 @@ const ETHERSCAN_PREFIXES: { [chainId in ChainId]: string } = {
   100: 'xdai.',
 }
 
-export type BlockExplorerLinkType = 'transaction' | 'token' | 'address' | 'block'
+export type BlockExplorerLinkType = 'transaction' | 'token' | 'address' | 'block' | 'token-transfer'
 
 function getEtherscanUrl(chainId: ChainId, data: string, type: BlockExplorerLinkType): string {
   const prefix = `https://${ETHERSCAN_PREFIXES[chainId] || ETHERSCAN_PREFIXES[1]}etherscan.io`
@@ -40,6 +40,9 @@ function getEtherscanUrl(chainId: ChainId, data: string, type: BlockExplorerLink
     }
     case 'block': {
       return `${prefix}/block/${data}`
+    }
+    case 'token-transfer': {
+      return `${prefix}/address/${data}#tokentxns`
     }
     case 'address':
     default: {
@@ -66,6 +69,8 @@ function getBlockscoutUrlSuffix(type: BlockExplorerLinkType, data: string): stri
       return `blocks/${data}/transactions`
     case 'address':
       return `address/${data}/transactions`
+    case 'token-transfer':
+      return `address/${data}/token-transfers`
     case 'token':
       return `tokens/${data}/token-transfers`
   }


### PR DESCRIPTION
# Summary

Send the user to the token transfer page within the explorer. Before it was possible to see an empty address. Now you can see your incoming vCOW token

Etherscan:
![image](https://user-images.githubusercontent.com/2352112/151163122-1ce3871d-c230-4eb7-b507-7fc7fdf7c9b8.png)


Blockscout:
![image](https://user-images.githubusercontent.com/2352112/151163414-ce770bbc-4ad3-479d-9a62-b1530f6cad55.png)


# To Test

1. Claim for someone else
2. Check the link
