### PR TITLE
No longer showing claiming status on vCOW button

### DIFF
--- a/src/custom/components/CowClaimButton/index.tsx
+++ b/src/custom/components/CowClaimButton/index.tsx
@@ -1,8 +1,6 @@
 import { Trans } from '@lingui/macro'
-import { Dots } from 'components/swap/styleds'
 import styled, { css } from 'styled-components/macro'
 import CowProtocolLogo from 'components/CowProtocolLogo'
-import { useUserHasSubmittedClaim } from 'state/transactions/hooks'
 
 export const Wrapper = styled.div<{ isClaimPage?: boolean | null }>`
   ${({ theme }) => theme.card.boxShadow};
@@ -78,23 +76,13 @@ interface CowClaimButtonProps {
   handleOnClickClaim?: () => void
 }
 
-export default function CowClaimButton({ isClaimPage, account, handleOnClickClaim }: CowClaimButtonProps) {
-  const { claimTxn } = useUserHasSubmittedClaim(account ?? undefined)
-
+export default function CowClaimButton({ isClaimPage, handleOnClickClaim }: CowClaimButtonProps) {
   return (
     <Wrapper isClaimPage={isClaimPage} onClick={handleOnClickClaim}>
-      {claimTxn && !claimTxn?.receipt ? (
-        <Dots>
-          <Trans>Claiming vCOW...</Trans>
-        </Dots>
-      ) : (
-        <>
-          <CowProtocolLogo />
-          <b>
-            <Trans>vCOW</Trans>
-          </b>
-        </>
-      )}
+      <CowProtocolLogo />
+      <b>
+        <Trans>vCOW</Trans>
+      </b>
     </Wrapper>
   )
 }


### PR DESCRIPTION
# Summary

Disable `Claiming vCow...` text as it's redundant with pending txs

![Screen Shot 2022-01-26 at 10 30 05](https://user-images.githubusercontent.com/43217/151224587-15a07ffd-17f6-4fde-97bd-66f04d985f35.png)

  # To Test

1. Perform a claim
* The `vCOW` button on top should not change

![Screen Shot 2022-01-26 at 10 31 58](https://user-images.githubusercontent.com/43217/151224887-01017a96-b9b0-4fee-894a-2f1f212b1a85.png)
