### PR TITLE
Added copy button to claiming account

### DIFF
--- a/src/custom/pages/Claim/ClaimNav.tsx
+++ b/src/custom/pages/Claim/ClaimNav.tsx
@@ -5,6 +5,7 @@ import { ClaimCommonTypes } from './types'
 import { useClaimDispatchers, useClaimState } from 'state/claim/hooks'
 import { ClaimStatus } from 'state/claim/actions'
 import Identicon from 'components/Identicon'
+import CopyHelper from 'components/Copy'
 
 type ClaimNavProps = Pick<ClaimCommonTypes, 'account' | 'handleChangeAccount'>
 
@@ -24,7 +25,8 @@ export default function ClaimNav({ account, handleChangeAccount }: ClaimNavProps
           {hasActiveAccount && (
             <>
               <Identicon account={activeClaimAccount} size={46} />
-              <p>{activeClaimAccountENS ? activeClaimAccountENS : shortenAddress(activeClaimAccount)}</p>
+              <p>{activeClaimAccountENS ? activeClaimAccountENS : shortenAddress(activeClaimAccount)} </p>
+              <CopyHelper toCopy={activeClaimAccount} />
             </>
           )}
         </div>

--- a/src/custom/pages/Claim/styled.ts
+++ b/src/custom/pages/Claim/styled.ts
@@ -533,6 +533,10 @@ export const ClaimAccount = styled.div`
     flex-flow: row nowrap;
     justify-content: center;
     align-items: center;
+
+    button {
+      align-self: center;
+    }
   }
 
   > div > img {


### PR DESCRIPTION
# Summary

Copy button on claiming account
![Screen Shot 2022-01-26 at 11 19 30](https://user-images.githubusercontent.com/43217/151232939-570625be-0f26-441f-af57-e49f2f1b0230.png)


  # To Test

1. Go to claim, check for one account
* There should be a copy button next to the address in the top right