### PR TITLE
[Fixes] Fixes for #2313 

### DIFF
--- a/src/custom/components/Header/NetworkSelector/NetworkSelectorMod.tsx
+++ b/src/custom/components/Header/NetworkSelector/NetworkSelectorMod.tsx
@@ -174,9 +174,9 @@ export default function NetworkSelector() {
     chainInfo: info,
     mainnetInfo,
     isUnsupportedChain,
-    isModalOpen: open,
     showSelector,
     nodeRef: node,
+    isModalOpen: open,
   } = useChangeNetworks({ account, chainId, library })
 
   if (!chainId || !info || !library || isUnsupportedChain) {

--- a/src/custom/components/Header/NetworkSelector/NetworkSelectorMod.tsx
+++ b/src/custom/components/Header/NetworkSelector/NetworkSelectorMod.tsx
@@ -6,19 +6,12 @@ import // ARBITRUM_HELP_CENTER_LINK,
 // SupportedL2ChainId,
 // SupportedChainId
 '@src/constants/chains'
-import { supportedChainId } from 'utils/supportedChainId'
-import { SupportedChainId, CHAIN_INFO, ALL_SUPPORTED_CHAIN_IDS } from 'constants/chains'
-import { useOnClickOutside } from 'hooks/useOnClickOutside'
-import { useActiveWeb3React } from 'hooks/web3'
-import { useCallback, useRef, useEffect, useState, useMemo } from 'react'
+import { CHAIN_INFO, ALL_SUPPORTED_CHAIN_IDS } from 'constants/chains'
 import { /* ArrowDownCircle, */ ChevronDown } from 'react-feather'
-import { useModalOpen, useToggleModal, useWalletModalToggle } from 'state/application/hooks'
-import { ApplicationModal } from 'state/application/reducer'
-import { useAppSelector } from 'state/hooks'
 import styled from 'styled-components/macro'
 import { /* ExternalLink, */ MEDIA_WIDTHS } from 'theme'
-import { switchToNetwork } from 'utils/switchToNetwork'
-import { UnsupportedChainIdError, useWeb3React } from '@web3-react/core'
+import useChangeNetworks from 'hooks/useChangeNetworks'
+import { useActiveWeb3React } from 'hooks/web3'
 
 // const ActiveRowLinkList = styled.div`
 //   display: flex;
@@ -174,63 +167,17 @@ const StyledChevronDown = styled(ChevronDown)`
 // }
 
 export default function NetworkSelector() {
-  const { chainId: preChainId, library, account } = useActiveWeb3React()
-  const { error } = useWeb3React() // MOD: check unsupported network
-  const node = useRef<HTMLDivElement>()
-  const open = useModalOpen(ApplicationModal.NETWORK_SELECTOR)
-  const toggle = useToggleModal(ApplicationModal.NETWORK_SELECTOR)
-  const toggleWalletModal = useWalletModalToggle() // MOD
-  useOnClickOutside(node, open ? toggle : undefined)
-  const implements3085 = useAppSelector((state) => state.application.implements3085)
-
-  // MOD: checks if a requested network switch was sent
-  // used for when user disconnected and selects a network internally
-  // if 3085 supported, will connect wallet and change network
-  const [queuedNetworkSwitch, setQueuedNetworkSwitch] = useState<null | number>(null)
-
-  // MOD: get supported chain and check unsupported
-  const [chainId, isUnsupportedChain] = useMemo(() => {
-    const chainId = supportedChainId(preChainId)
-
-    return [chainId, error instanceof UnsupportedChainIdError] // Mod - return if chainId is unsupported
-  }, [preChainId, error])
-
-  const info = chainId ? CHAIN_INFO[chainId] : undefined
-
-  // const isOnL2 = chainId ? L2_CHAIN_IDS.includes(chainId) : false
-  // const showSelector = Boolean(!account || implements3085 || isOnL2)
-  const showSelector = Boolean(!account || implements3085)
-  const mainnetInfo = CHAIN_INFO[SupportedChainId.MAINNET]
-
-  const conditionalToggle = useCallback(() => {
-    if (showSelector) {
-      toggle()
-    }
-  }, [showSelector, toggle])
-
-  const networkCallback = useCallback(
-    (supportedChainId) => {
-      if (!account) {
-        toggleWalletModal()
-        return setQueuedNetworkSwitch(supportedChainId)
-      } else if (implements3085 && library && supportedChainId) {
-        switchToNetwork({ library, chainId: supportedChainId })
-        return open && toggle()
-      }
-
-      return
-    },
-    [account, implements3085, library, open, toggle, toggleWalletModal]
-  )
-
-  // MOD: used with mod hook - used to connect disconnected wallet to selected network
-  // if wallet supports 3085
-  useEffect(() => {
-    if (queuedNetworkSwitch && account && chainId && implements3085) {
-      networkCallback(queuedNetworkSwitch)
-      setQueuedNetworkSwitch(null)
-    }
-  }, [networkCallback, queuedNetworkSwitch, chainId, account, implements3085])
+  const { account, chainId, library } = useActiveWeb3React()
+  const {
+    callback: networkCallback,
+    conditionalToggle,
+    chainInfo: info,
+    mainnetInfo,
+    isUnsupportedChain,
+    isModalOpen: open,
+    showSelector,
+    nodeRef: node,
+  } = useChangeNetworks({ account, chainId, library })
 
   if (!chainId || !info || !library || isUnsupportedChain) {
     return null

--- a/src/custom/hooks/useChangeNetworks.ts
+++ b/src/custom/hooks/useChangeNetworks.ts
@@ -53,7 +53,6 @@ export default function useChangeNetworks({ account, chainId: preChainId, librar
   // if 3085 supported, will connect wallet and change network
   const [queuedNetworkSwitch, setQueuedNetworkSwitch] = useState<null | number>(null)
 
-  // uwc-debug
   const networkCallback = useCallback(
     (supportedChainId) => {
       if (!account) {

--- a/src/custom/hooks/useChangeNetworks.ts
+++ b/src/custom/hooks/useChangeNetworks.ts
@@ -2,21 +2,31 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { UnsupportedChainIdError, useWeb3React } from '@web3-react/core'
 import { useOnClickOutside } from 'hooks/useOnClickOutside'
 import { useActiveWeb3React } from 'hooks/web3'
-import { useModalOpen, useToggleModal, useWalletModalToggle } from 'state/application/hooks'
+import {
+  useCloseModals,
+  useModalOpen,
+  useOpenModal,
+  // useToggleModal,
+  useWalletModalToggle,
+} from 'state/application/hooks'
 import { ApplicationModal } from 'state/application/reducer'
 import { useAppSelector } from 'state/hooks'
 import { CHAIN_INFO, SupportedChainId } from 'constants/chains'
 import { switchToNetwork } from 'utils/switchToNetwork'
 import { supportedChainId } from 'utils/supportedChainId'
 
-export default function useChangeNetworks() {
-  const { chainId: preChainId, library, account } = useActiveWeb3React()
+type ChangeNetworksParams = Pick<ReturnType<typeof useActiveWeb3React>, 'account' | 'chainId' | 'library'>
+
+export default function useChangeNetworks({ account, chainId: preChainId, library }: ChangeNetworksParams) {
   const { error } = useWeb3React() // MOD: check unsupported network
-  const node = useRef<HTMLDivElement>()
-  const open = useModalOpen(ApplicationModal.NETWORK_SELECTOR)
-  const toggle = useToggleModal(ApplicationModal.NETWORK_SELECTOR)
+  const nodeRef = useRef<HTMLDivElement>()
+  const isModalOpen = useModalOpen(ApplicationModal.NETWORK_SELECTOR)
+  const closeModal = useCloseModals()
+  const openModal = useOpenModal(ApplicationModal.NETWORK_SELECTOR)
   const toggleWalletModal = useWalletModalToggle() // MOD
-  useOnClickOutside(node, open ? toggle : undefined)
+
+  useOnClickOutside(nodeRef, isModalOpen ? closeModal : undefined)
+
   const implements3085 = useAppSelector((state) => state.application.implements3085)
 
   // MOD: get supported chain and check unsupported
@@ -33,28 +43,37 @@ export default function useChangeNetworks() {
 
   const conditionalToggle = useCallback(() => {
     if (showSelector) {
-      toggle()
+      if (isModalOpen) {
+        alert('called')
+        closeModal()
+      } else {
+        alert('called close')
+        openModal()
+      }
     }
-  }, [showSelector, toggle])
+  }, [closeModal, isModalOpen, openModal, showSelector])
 
   // MOD: checks if a requested network switch was sent
   // used for when user disconnected and selects a network internally
   // if 3085 supported, will connect wallet and change network
   const [queuedNetworkSwitch, setQueuedNetworkSwitch] = useState<null | number>(null)
 
+  // uwc-debug
   const networkCallback = useCallback(
     (supportedChainId) => {
+      console.debug('adasdasdasdasdasd')
       if (!account) {
         toggleWalletModal()
         return setQueuedNetworkSwitch(supportedChainId)
       } else if (implements3085 && library && supportedChainId) {
         switchToNetwork({ library, chainId: supportedChainId })
-        return open && toggle()
+
+        return isModalOpen && closeModal()
       }
 
       return
     },
-    [account, implements3085, library, open, toggle, toggleWalletModal]
+    [account, implements3085, library, toggleWalletModal, isModalOpen, closeModal]
   )
 
   // if wallet supports 3085
@@ -68,8 +87,13 @@ export default function useChangeNetworks() {
   return {
     callback: networkCallback,
     conditionalToggle,
+    openModal,
+    closeModal,
+    isModalOpen,
     isUnsupportedChain,
     chainInfo: info,
     mainnetInfo,
+    showSelector,
+    nodeRef,
   }
 }

--- a/src/custom/pages/Claim/ClaimsOnOtherChainsBanner.tsx
+++ b/src/custom/pages/Claim/ClaimsOnOtherChainsBanner.tsx
@@ -42,8 +42,8 @@ const Wrapper = styled.div`
 `
 
 function ClaimsOnOtherChainsBanner({ className }: { className?: string }) {
-  const { chainId } = useActiveWeb3React()
-  const { callback } = useChangeNetworks()
+  const { account, library, chainId } = useActiveWeb3React()
+  const { callback } = useChangeNetworks({ account, library, chainId })
 
   const { hasClaimsOnOtherChains } = useClaimState()
   const chainsWithClaims: SupportedChainId[] = useMemo(


### PR DESCRIPTION
Fixes issues in #2313 

- [x] Couldn't change networks from NetworksSwitcher (in header) while claim page was open and banner showing claims available in another chain present. Fixed
- [x] adds hook to initial place it was used, NetworkSwitcher component
- [x] used local state to use modals and fixes unsynced state

## TESTING
1. in #2313 should NOT be able to have vCow claim page open and switch networks from NetworksSwitcher while banner showing u can claim elsewhere
2. in this you SHOULD be able to do that