### PR TITLE
Resetting state on network change

### DIFF
--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -33,7 +33,7 @@ export const COW_LINKS = {
 }
 
 export default function Claim() {
-  const { account } = useActiveWeb3React()
+  const { account, chainId } = useActiveWeb3React()
 
   const {
     // address/ENS address
@@ -174,7 +174,8 @@ export default function Claim() {
 
     // properly reset the user to the claims table and initial investment flow
     resetClaimUi()
-  }, [account, activeClaimAccount, resolvedAddress, isSearchUsed, setActiveClaimAccount, resetClaimUi])
+    // Depending on chainId even though it's not used because we want to reset the state on network change
+  }, [account, activeClaimAccount, chainId, resolvedAddress, isSearchUsed, setActiveClaimAccount, resetClaimUi])
 
   // Transaction confirmation modal
   const { TransactionConfirmationModal, openModal, closeModal } = useTransactionConfirmationModal(


### PR DESCRIPTION
# Summary

Fixes #2296 

Resetting state on network change

  # To Test

1. Connect with a wallet that has paid claims
2. Select and move to approvals step or the next one
3. Switch the network using either the switcher or the wallet
* Claims should be refreshed and reset to initial claim page
