### PR TITLE
Resetting claim status when resetting the state

### DIFF
--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -33,7 +33,7 @@ export const COW_LINKS = {
 }
 
 export default function Claim() {
-  const { account } = useActiveWeb3React()
+  const { account, chainId } = useActiveWeb3React()
 
   const {
     // address/ENS address
@@ -174,7 +174,8 @@ export default function Claim() {
 
     // properly reset the user to the claims table and initial investment flow
     resetClaimUi()
-  }, [account, activeClaimAccount, resolvedAddress, isSearchUsed, setActiveClaimAccount, resetClaimUi])
+    // Depending on chainId even though it's not used because we want to reset the state on network change
+  }, [account, activeClaimAccount, chainId, resolvedAddress, isSearchUsed, setActiveClaimAccount, resetClaimUi])
 
   // Transaction confirmation modal
   const { TransactionConfirmationModal, openModal, closeModal } = useTransactionConfirmationModal(

--- a/src/custom/state/claim/reducer.ts
+++ b/src/custom/state/claim/reducer.ts
@@ -127,6 +127,7 @@ export default createReducer(initialState, (builder) =>
       state.isInvestFlowActive = initialState.isInvestFlowActive
       state.claimedAmount = initialState.claimedAmount
       state.estimatedGas = initialState.estimatedGas
+      state.claimStatus = initialState.claimStatus
     })
     .addCase(setIsTouched, (state, { payload: { index, isTouched } }) => {
       state.investFlowData[index].isTouched = isTouched


### PR DESCRIPTION
# Summary

Depends on https://github.com/gnosis/cowswap/pull/2321

Fixes #2312 

ClaimStatus is reset to default every time there's a network or account change

  # To Test

1. Connect and claim for one account
2. On claim screen, disconnect/lock the account
* You should see the pending claim screen while disconnected