### PR TITLE
Add vesting banner.

### DIFF
--- a/src/custom/pages/Claim/InvestmentFlow/index.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/index.tsx
@@ -10,6 +10,7 @@ import {
   AccountClaimSummary,
   StepExplainer,
   Badge,
+  BannerExplainer,
 } from 'pages/Claim/styled'
 import { InvestSummaryRow } from 'pages/Claim/InvestmentFlow/InvestSummaryRow'
 import { ClaimSummaryView } from 'pages/Claim/ClaimSummary'
@@ -39,6 +40,7 @@ import { ExplorerDataType } from 'utils/getExplorerLink'
 import { BadgeVariant } from 'components/Badge'
 import { OperationType } from 'components/TransactionConfirmationModal'
 import RoundArrow from 'assets/cow-swap/round-arrow.svg'
+import CowProtocolImage from 'assets/cow-swap/cowprotocol.svg'
 import SVG from 'react-inlinesvg'
 
 const STEPS_DATA = [
@@ -191,8 +193,9 @@ export default function InvestmentFlow({ hasClaims, isAirdropOnly, modalCbs }: I
         <>
           <p>
             You have chosen to exercise one or more investment opportunities alongside claiming your airdrop. Exercising
-            your investment options will give you the chance to acquire vCOW tokens at a fixed price. This process
-            consists of two steps.
+            your investment options will give you the chance to acquire vCOW tokens at a fixed price. Read{' '}
+            <ExternalLink href={COW_LINKS.stepGuide}> the step by step guide</ExternalLink> for more details on the
+            claiming process.
           </p>
           <StepExplainer>
             <span data-step="Step 1">
@@ -208,11 +211,18 @@ export default function InvestmentFlow({ hasClaims, isAirdropOnly, modalCbs }: I
               </p>
             </span>
           </StepExplainer>
-          <p>
-            For more details around the token, please read{' '}
-            <ExternalLink href={COW_LINKS.vCowPost}>the blog post</ExternalLink>. For more details about the claiming
-            process, please read <ExternalLink href={COW_LINKS.stepGuide}>step by step guide</ExternalLink>.
-          </p>
+          <ExternalLink href={COW_LINKS.vCowPost}>
+            <BannerExplainer>
+              <SVG src={CowProtocolImage} description="Read more" />
+              <span>
+                <b>What is linear vesting?</b>
+                <small>
+                  When you buy vCOW tokens you will receive them gradually over a period of 4 years.{' '}
+                  <strong>Learn More ↗</strong>
+                </small>
+              </span>
+            </BannerExplainer>
+          </ExternalLink>
         </>
       )}
 

--- a/src/custom/pages/Claim/styled.ts
+++ b/src/custom/pages/Claim/styled.ts
@@ -896,6 +896,12 @@ export const InvestFlow = styled.div`
     font-weight: 500;
     text-align: center;
   }
+
+  > a,
+  > a:hover,
+  > a:visited {
+    text-decoration: none;
+  }
 `
 
 export const InvestContent = styled.div`
@@ -1668,9 +1674,9 @@ export const BannerExplainer = styled.div`
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  height: 120px;
+  height: 130px;
   border-radius: 12px;
-  padding: 0 24px;
+  padding: 0 24px 0 20%;
   background: ${({ theme }) => theme.bg8};
   position: relative;
   overflow: hidden;
@@ -1678,7 +1684,7 @@ export const BannerExplainer = styled.div`
   transition: border 0.2s ease-in-out;
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
-    padding: 12px;
+    padding: 24px;
     height: auto;
   `}
 
@@ -1725,9 +1731,13 @@ export const BannerExplainer = styled.div`
   > span > small {
     color: ${({ theme }) => theme.white};
     font-size: 16px;
+    font-weight: 400;
+    text-align: right;
+    padding: 0 0 0 20%;
 
     ${({ theme }) => theme.mediaWidth.upToSmall`
       text-align: center;
+      padding: 0;
     `}
   }
 

--- a/src/custom/pages/Claim/styled.ts
+++ b/src/custom/pages/Claim/styled.ts
@@ -899,7 +899,8 @@ export const InvestFlow = styled.div`
 
   > a,
   > a:hover,
-  > a:visited {
+  > a:visited,
+  > a:focus {
     text-decoration: none;
   }
 `

--- a/src/custom/theme/baseTheme.tsx
+++ b/src/custom/theme/baseTheme.tsx
@@ -43,7 +43,7 @@ export function colors(darkMode: boolean): Colors {
     bg5: darkMode ? '#1d4373' : '#D5E9F0',
     bg6: darkMode ? '#163861' : '#b0dfee',
     bg7: darkMode ? '#1F4471' : '#CEE7EF',
-    bg8: darkMode ? '#021E34' : '#000000',
+    bg8: darkMode ? '#021E34' : '#152943',
 
     // ****** specialty colors ******
     advancedBG: darkMode ? '#163861' : '#d5e8f0',


### PR DESCRIPTION
# Summary

- Decided to replace the black color of the banner (in light mode) with a more dark blue color.
- Added a vesting explainer banner
<img width="832" alt="Screen Shot 2022-01-27 at 12 37 43" src="https://user-images.githubusercontent.com/31534717/151352002-1e771158-ce55-4b16-a83d-7f608c4dd16e.png">
<img width="858" alt="Screen Shot 2022-01-27 at 12 37 52" src="https://user-images.githubusercontent.com/31534717/151352014-e4924aec-ab13-4bcf-be7b-c9833c3d036f.png">
<img width="414" alt="Screen Shot 2022-01-27 at 12 39 02" src="https://user-images.githubusercontent.com/31534717/151352033-13b0d01e-97f7-47b2-ba2c-94218ad25ca4.png">


vCow banner in previous step (from `vcow-banner`)

<img width="913" alt="Screen Shot 2022-01-27 at 12 39 16" src="https://user-images.githubusercontent.com/31534717/151352082-24653f15-5995-4430-95e0-e583c40c3cf0.png">


## Note
- Feel free to suggest another text. The idea is to keep the text in the banner short and descriptive. 
