### PR TITLE
Move affiliate banner to the top in Profile page

### DIFF
--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -63,6 +63,7 @@ export default function Profile() {
 
   return (
     <Container>
+      {chainId && chainId === ChainId.MAINNET && <AffiliateStatusCheck />}
       <ProfileWrapper>
         <ProfileGridWrap horizontal>
           <CardHead>
@@ -71,7 +72,6 @@ export default function Profile() {
           {IS_CLAIMING_ENABLED && vCowBalance && <VCOWDropdown balance={vCowBalance} />}
         </ProfileGridWrap>
       </ProfileWrapper>
-      {chainId && chainId === ChainId.MAINNET && <AffiliateStatusCheck />}
       <Wrapper>
         <GridWrap>
           <CardHead>


### PR DESCRIPTION
# Summary

Close https://github.com/gnosis/cowswap/pull/2329

Fixes the Affiliate banner being displayed below the new Profile card

![image](https://user-images.githubusercontent.com/3328006/151357205-22db8bda-d5b7-492f-a44f-d9f343d07c27.png)

<img width="1007" alt="image" src="https://user-images.githubusercontent.com/3328006/151357287-b81b5274-429b-492c-b476-a050fc048a2f.png">

