### PR TITLE
Improve claim behalf error

### DIFF
--- a/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
@@ -39,10 +39,10 @@ import { IS_TESTING_ENV } from '../const'
 const ErrorMessages = {
   NoBalance: (symbol = '') => `You don't have ${symbol} balance to invest`,
 
-  InsufficientBalance: (selfClaim: boolean, symbol = '') =>
-    selfClaim
-      ? `Insufficient ${symbol} balance to cover investment amount`
-      : `Your ${symbol} balance is not enough to cover 100% of the investment amount.`,
+  InsufficientBalanceSelf: (symbol = '') => `Insufficient ${symbol} balance to cover investment amount`,
+  InsufficientBalanceBehalf: (symbol = '') =>
+    `Your ${symbol} balance is not enough to cover 100% of the investment amount.`,
+
   OverMaxInvestment: `Your investment amount can't be above the maximum investment allowed`,
   InvestmentIsZero: `Your investment amount can't be zero`,
   NotApproved: (symbol = '') => `Please approve ${symbol} token`,
@@ -242,7 +242,7 @@ export default function InvestOption({ claim, optionIndex, openModal, closeModal
     if (noBalance) {
       error = ErrorMessages.NoBalance(token?.symbol)
     } else if (balance.lessThan(maxCost) && !isSelfClaiming) {
-      error = ErrorMessages.InsufficientBalance(isSelfClaiming, token?.symbol)
+      error = ErrorMessages.InsufficientBalanceBehalf(token?.symbol)
     } else if (isPendingOnchainApprove) {
       error = ErrorMessages.WaitForApproval(token?.symbol)
     } else if (!isNative && !isApproved) {
@@ -255,7 +255,7 @@ export default function InvestOption({ claim, optionIndex, openModal, closeModal
     } else if (parsedAmount.greaterThan(maxCost)) {
       error = ErrorMessages.OverMaxInvestment
     } else if (parsedAmount.greaterThan(balance)) {
-      error = ErrorMessages.InsufficientBalance(isSelfClaiming, token?.symbol)
+      error = ErrorMessages.InsufficientBalanceSelf(token?.symbol)
     }
 
     // Set percentage

--- a/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
@@ -37,7 +37,12 @@ import { ONE_HUNDRED_PERCENT } from 'constants/misc'
 import { IS_TESTING_ENV } from '../const'
 
 const ErrorMessages = {
-  InsufficientBalance: (symbol = '') => `Insufficient ${symbol} balance to cover investment amount`,
+  NoBalance: (symbol = '') => `You don't have ${symbol} balance to invest`,
+
+  InsufficientBalance: (selfClaim: boolean, symbol = '') =>
+    selfClaim
+      ? `Insufficient ${symbol} balance to cover investment amount`
+      : `Your ${symbol} balance is not enough to cover 100% of the investment amount.`,
   OverMaxInvestment: `Your investment amount can't be above the maximum investment allowed`,
   InvestmentIsZero: `Your investment amount can't be zero`,
   NotApproved: (symbol = '') => `Please approve ${symbol} token`,
@@ -218,7 +223,7 @@ export default function InvestOption({ claim, optionIndex, openModal, closeModal
       return
     }
 
-    if (!isSelfClaiming && !balance.lessThan(maxCost)) {
+    if (!isSelfClaiming) {
       setMaxAmount()
     }
   }, [balance, isSelfClaiming, maxCost, setMaxAmount])
@@ -234,14 +239,14 @@ export default function InvestOption({ claim, optionIndex, openModal, closeModal
     }
 
     // set different errors in order of importance
-    if (balance.lessThan(maxCost) && !isSelfClaiming) {
-      error = ErrorMessages.InsufficientBalance(token?.symbol)
+    if (noBalance) {
+      error = ErrorMessages.NoBalance(token?.symbol)
+    } else if (balance.lessThan(maxCost) && !isSelfClaiming) {
+      error = ErrorMessages.InsufficientBalance(isSelfClaiming, token?.symbol)
     } else if (isPendingOnchainApprove) {
       error = ErrorMessages.WaitForApproval(token?.symbol)
     } else if (!isNative && !isApproved) {
       error = ErrorMessages.NotApproved(token?.symbol)
-    } else if (noBalance) {
-      error = ErrorMessages.InsufficientBalance(token?.symbol)
     } else if (!parsedAmount && !isTouched) {
       // this is to remove initial zero balance error message until user touches the input
       error = ''
@@ -250,13 +255,17 @@ export default function InvestOption({ claim, optionIndex, openModal, closeModal
     } else if (parsedAmount.greaterThan(maxCost)) {
       error = ErrorMessages.OverMaxInvestment
     } else if (parsedAmount.greaterThan(balance)) {
-      error = ErrorMessages.InsufficientBalance(token?.symbol)
+      error = ErrorMessages.InsufficientBalance(isSelfClaiming, token?.symbol)
     }
 
     if (error !== null) {
       // if there is error set it in redux
       setInputError(error)
-      setPercentage('0')
+      if (noBalance) {
+        setPercentage('0')
+      } else {
+        setPercentage(_formatPercentage(calculatePercentage(balance, maxCost)))
+      }
     } else {
       if (!parsedAmount) {
         return

--- a/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
@@ -258,28 +258,28 @@ export default function InvestOption({ claim, optionIndex, openModal, closeModal
       error = ErrorMessages.InsufficientBalance(isSelfClaiming, token?.symbol)
     }
 
+    // Set percentage
+    let percentageValue
+    if (noBalance || !parsedAmount) {
+      percentageValue = '0'
+    } else {
+      percentageValue = _formatPercentage(calculatePercentage(parsedAmount, maxCost))
+    }
+    setPercentage(percentageValue)
+
+    // Set invested amount and error/warnings
     if (error !== null) {
-      // if there is error set it in redux
       setInputError(error)
-      if (noBalance) {
-        setPercentage('0')
-      } else {
-        setPercentage(_formatPercentage(calculatePercentage(balance, maxCost)))
-      }
     } else {
       if (!parsedAmount) {
         return
       }
-      // basically the magic happens in this block
 
       // update redux state to remove error for this field
       resetInputError()
 
       // update redux state with new investAmount value
       setInvestedAmount(parsedAmount.quotient.toString())
-
-      // update the local state with percentage value
-      setPercentage(_formatPercentage(calculatePercentage(parsedAmount, maxCost)))
     }
   }, [
     balance,


### PR DESCRIPTION
# Summary

This PR tries to improve this case:

![image](https://user-images.githubusercontent.com/2352112/151391492-f6a89969-972f-448e-83de-071544747244.png)


The problem here is that is not clear enough why there's an error. In principle, we should assume users are educated about the investment and they have read the blog post where we mention that investing for others requires investing 100% of the oportunity.

the problem above in my opinion, is that we are not hinting this is the case. 

The proposed solution, is to do these small actions:
![image](https://user-images.githubusercontent.com/2352112/151392391-67c5e3e0-0134-43e3-9691-7282a3c80a44.png)


Additionally, for the case of investing with zero balance, i thought the messages were too long, so i did a specific message for it:
![image](https://user-images.githubusercontent.com/2352112/151392565-a2e82aa1-d392-407f-ac86-2a1783d4c19f.png)




  # To Test

1.  Test to claim on behalf of someone having 0 balance
2.  Test to claim on behalf of someone having a fraction of the maximum amount
3. Test to claim on  behalf of someone having all the investment
4. Claim for yourself, make sure is not broken :) 
