### PR TITLE
Reset ens on redux state when changing accounts

### DIFF
--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -96,6 +96,7 @@ export default function Claim() {
   // handle change account
   const handleChangeAccount = () => {
     setActiveClaimAccount('')
+    setActiveClaimAccountENS('')
     setSelected([])
     setClaimStatus(ClaimStatus.DEFAULT)
     setIsSearchUsed(true)


### PR DESCRIPTION
# Summary

ENS names now properly reset when account is changed

  # To Test

1. On this PR, on either mainnet or rinkeby, look for claims for `vitalik.eth`
2. Then, change account and look for claims for another account
* The account name (top left of claims page) should have been updated

The same does not happen right now on staging, the account name displayed will remain the ens name.