### PR TITLE
Check pending claims for disconnected accounts

### DIFF
--- a/src/custom/pages/Claim/ClaimsOnOtherChainsBanner.tsx
+++ b/src/custom/pages/Claim/ClaimsOnOtherChainsBanner.tsx
@@ -72,7 +72,7 @@ function ClaimsOnOtherChainsBanner({ className }: { className?: string }) {
     <NotificationBanner className={className} isVisible id={account ?? undefined} level="info">
       <Wrapper>
         <AlertTriangle />
-        <div>You have other available claims on</div>
+        <div>This account has available claims on</div>
         <div>
           {chainsWithClaims.map((chainId, index, array) => {
             const changeNetworksCallback = () => callback(chainId)

--- a/src/custom/state/claim/updater.tsx
+++ b/src/custom/state/claim/updater.tsx
@@ -1,15 +1,13 @@
 import { useEffect } from 'react'
 import { SupportedChainId } from 'constants/chains'
-import { useActiveWeb3React } from 'hooks/web3'
 import { useClaimDispatchers, useClaimState, useUserAvailableClaims } from './hooks'
 
 export default function Updater() {
-  const { account } = useActiveWeb3React()
   const { activeClaimAccount } = useClaimState()
   const { setHasClaimsOnOtherChains } = useClaimDispatchers()
 
-  const mainnetAvailable = useUserAvailableClaims(activeClaimAccount || account, SupportedChainId.MAINNET)
-  const gnosisAvailable = useUserAvailableClaims(activeClaimAccount || account, SupportedChainId.XDAI)
+  const mainnetAvailable = useUserAvailableClaims(activeClaimAccount, SupportedChainId.MAINNET)
+  const gnosisAvailable = useUserAvailableClaims(activeClaimAccount, SupportedChainId.XDAI)
 
   useEffect(() => {
     setHasClaimsOnOtherChains({ chain: SupportedChainId.MAINNET, hasClaims: mainnetAvailable.length > 0 })

--- a/src/custom/state/claim/updater.tsx
+++ b/src/custom/state/claim/updater.tsx
@@ -1,14 +1,15 @@
 import { useEffect } from 'react'
 import { SupportedChainId } from 'constants/chains'
 import { useActiveWeb3React } from 'hooks/web3'
-import { useClaimDispatchers, useUserAvailableClaims } from './hooks'
+import { useClaimDispatchers, useClaimState, useUserAvailableClaims } from './hooks'
 
 export default function Updater() {
   const { account } = useActiveWeb3React()
+  const { activeClaimAccount } = useClaimState()
   const { setHasClaimsOnOtherChains } = useClaimDispatchers()
 
-  const mainnetAvailable = useUserAvailableClaims(account, SupportedChainId.MAINNET)
-  const gnosisAvailable = useUserAvailableClaims(account, SupportedChainId.XDAI)
+  const mainnetAvailable = useUserAvailableClaims(activeClaimAccount || account, SupportedChainId.MAINNET)
+  const gnosisAvailable = useUserAvailableClaims(activeClaimAccount || account, SupportedChainId.XDAI)
 
   useEffect(() => {
     setHasClaimsOnOtherChains({ chain: SupportedChainId.MAINNET, hasClaims: mainnetAvailable.length > 0 })


### PR DESCRIPTION
# Summary

Checks claims on all not only for the connected wallet.
Also as a side effect allows to check claims when no wallet is connected

EDIT 2022-01-28

* No longer checking the connected account by default. Only if that's selected in the claim UI
* Updated banner text to make clear it's for the checked account
![Screen Shot 2022-01-28 at 08 24 17](https://user-images.githubusercontent.com/43217/151584069-77644d51-6082-4332-a299-2f5ce1f7954b.png)

  # To Test

1. While connected to rinkeby, check claims for one account that has mainnet and/or gchain claims
* The claims banner should be displayed
2. While disconnected, check the same account
* The same banner should be displayed