### PR TITLE
Improve eligible banner styles.

### DIFF
--- a/src/custom/pages/Claim/styled.ts
+++ b/src/custom/pages/Claim/styled.ts
@@ -703,8 +703,8 @@ export const EligibleBanner = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  background: ${({ theme }) => transparentize(0.9, theme.attention)};
-  color: ${({ theme }) => darken(0.1, theme.attention)};
+  background: ${({ theme }) => transparentize(0.9, theme.success)};
+  color: ${({ theme }) => darken(0.1, theme.success)};
   margin: 0 auto 16px;
   font-weight: 600;
 
@@ -719,7 +719,7 @@ export const EligibleBanner = styled.div`
     height: 21px;
 
     > path {
-      fill: ${({ theme }) => darken(0.1, theme.attention)};
+      fill: ${({ theme }) => darken(0.1, theme.success)};
     }
 
     ${({ theme }) => theme.mediaWidth.upToSmall`

--- a/src/custom/pages/Claim/styled.ts
+++ b/src/custom/pages/Claim/styled.ts
@@ -704,7 +704,7 @@ export const EligibleBanner = styled.div`
   justify-content: center;
   align-items: center;
   background: ${({ theme }) => transparentize(0.9, theme.success)};
-  color: ${({ theme }) => darken(0.1, theme.success)};
+  color: ${({ theme }) => theme.success};
   margin: 0 auto 16px;
   font-weight: 600;
 
@@ -719,7 +719,7 @@ export const EligibleBanner = styled.div`
     height: 21px;
 
     > path {
-      fill: ${({ theme }) => darken(0.1, theme.success)};
+      fill: ${({ theme }) => theme.success};
     }
 
     ${({ theme }) => theme.mediaWidth.upToSmall`


### PR DESCRIPTION
# Summary

- Changes the color for the eligible banner, to use a green 'success' color instead of the orange 'attention'.
<img width="910" alt="Screen Shot 2022-01-28 at 12 47 43" src="https://user-images.githubusercontent.com/31534717/151542002-a8e5fa0f-4eea-4a7b-9ff8-90d0a9338fce.png">
<img width="851" alt="Screen Shot 2022-01-28 at 12 47 36" src="https://user-images.githubusercontent.com/31534717/151542009-d5273e32-ee2f-45fc-a735-4674583d202e.png">

