### PR TITLE
Do not show vCOW button on prod environments

### DIFF
--- a/src/custom/components/Menu/index.tsx
+++ b/src/custom/components/Menu/index.tsx
@@ -20,6 +20,7 @@ import { getExplorerAddressLink } from 'utils/explorer'
 import { useHasOrders } from 'api/gnosisProtocol/hooks'
 import { useHistory } from 'react-router-dom'
 import CowClaimButton, { Wrapper as ClaimButtonWrapper } from 'components/CowClaimButton'
+import { IS_CLAIMING_ENABLED } from 'pages/Claim/const'
 
 import twitterImage from 'assets/cow-swap/twitter.svg'
 import discordImage from 'assets/cow-swap/discord.svg'
@@ -291,12 +292,14 @@ export function Menu({ darkMode, toggleDarkMode, isClaimPage }: MenuProps) {
   return (
     <StyledMenu isClaimPage={isClaimPage}>
       <MenuFlyout>
-        <CowClaimButton
-          isClaimPage={isClaimPage}
-          handleOnClickClaim={handleOnClickClaim}
-          account={account}
-          chainId={chainId}
-        />
+        {IS_CLAIMING_ENABLED && (
+          <CowClaimButton
+            isClaimPage={isClaimPage}
+            handleOnClickClaim={handleOnClickClaim}
+            account={account}
+            chainId={chainId}
+          />
+        )}
 
         <ResponsiveInternalMenuItem to="/" onClick={close}>
           <Repeat size={14} /> Swap


### PR DESCRIPTION
# Summary

Do not show vCOW button on prod environments.
This was only visible in responsive mode.
It's not possible to see the changes in this PR as it requires a prod like environment (barn, prod, ens)