### PR TITLE
2082/no success on failure

### DIFF
--- a/src/custom/pages/Claim/ClaimingStatus.tsx
+++ b/src/custom/pages/Claim/ClaimingStatus.tsx
@@ -46,6 +46,7 @@ export default function ClaimingStatus() {
   const isConfirmed = claimStatus === ClaimStatus.CONFIRMED
   const isAttempting = claimStatus === ClaimStatus.ATTEMPTING
   const isSubmitted = claimStatus === ClaimStatus.SUBMITTED
+  const isFailure = claimStatus === ClaimStatus.FAILED
   const isSelfClaiming = account === activeClaimAccount
 
   if (!account || !chainId || !activeClaimAccount || claimStatus === ClaimStatus.DEFAULT) return null
@@ -60,7 +61,7 @@ export default function ClaimingStatus() {
   return (
     <ConfirmOrLoadingWrapper activeBG={true}>
       <ConfirmedIcon isConfirmed={isConfirmed}>
-        {!isConfirmed ? (
+        {!isConfirmed && !isFailure ? (
           <CowSpinner>
             <CowProtocolLogo />
           </CowSpinner>
@@ -68,7 +69,7 @@ export default function ClaimingStatus() {
           <CowProtocolLogo size={100} />
         )}
       </ConfirmedIcon>
-      <h3>{isConfirmed ? 'Claim successful!' : 'Claiming'}</h3>
+      <h3>{isConfirmed ? 'Claim successful!' : isFailure ? 'Failed to claim' : 'Claiming'}</h3>
       {!isConfirmed && (
         <Trans>
           <span title={formattedMaxVCowAmount && `${formattedMaxVCowAmount} vCOW`}>{formattedVCowAmount} vCOW</span>
@@ -146,6 +147,15 @@ export default function ClaimingStatus() {
         </AttemptFooter>
       )}
       {isSubmitted && chainId && lastClaimTx?.hash && <EnhancedTransactionLink tx={lastClaimTx} />}
+
+      {isFailure && (
+        <>
+          {chainId && lastClaimTx?.hash && <EnhancedTransactionLink tx={lastClaimTx} />}
+          <AttemptFooter>
+            <p>The claim transaction failed. Please check the network parameters and try again.</p>
+          </AttemptFooter>
+        </>
+      )}
     </ConfirmOrLoadingWrapper>
   )
 }

--- a/src/custom/pages/Claim/ClaimingStatus.tsx
+++ b/src/custom/pages/Claim/ClaimingStatus.tsx
@@ -9,7 +9,7 @@ import {
   SuccessBanner,
 } from 'pages/Claim/styled'
 import { ClaimStatus } from 'state/claim/actions'
-import { useClaimState } from 'state/claim/hooks'
+import { useClaimDispatchers, useClaimState } from 'state/claim/hooks'
 import { useActiveWeb3React } from 'hooks/web3'
 import CowProtocolLogo from 'components/CowProtocolLogo'
 import { useAllClaimingTransactions } from 'state/enhancedTransactions/hooks'
@@ -28,6 +28,7 @@ import { formatMax, formatSmartLocaleAware } from 'utils/format'
 import { AMOUNT_PRECISION } from 'constants/index'
 import { shortenAddress } from 'utils'
 import CopyHelper from 'components/Copy'
+import { ButtonSecondary } from 'components/Button'
 
 const COW_TWEET_TEMPLATE =
   'I just joined the 🐮 CoWmunity @MEVprotection and claimed my first vCOW tokens! Join me at https://cowswap.exchange/'
@@ -35,6 +36,8 @@ const COW_TWEET_TEMPLATE =
 export default function ClaimingStatus() {
   const { chainId, account } = useActiveWeb3React()
   const { activeClaimAccount, claimStatus, claimedAmount } = useClaimState()
+
+  const { setClaimStatus } = useClaimDispatchers()
 
   const allClaimTxs = useAllClaimingTransactions()
   const lastClaimTx = useMemo(() => {
@@ -154,6 +157,9 @@ export default function ClaimingStatus() {
           <AttemptFooter>
             <p>The claim transaction failed. Please check the network parameters and try again.</p>
           </AttemptFooter>
+          <ButtonSecondary onClick={() => setClaimStatus(ClaimStatus.DEFAULT)}>
+            <Trans>Go back</Trans>
+          </ButtonSecondary>
         </>
       )}
     </ConfirmOrLoadingWrapper>

--- a/src/custom/pages/Claim/ClaimingStatus.tsx
+++ b/src/custom/pages/Claim/ClaimingStatus.tsx
@@ -157,10 +157,12 @@ export default function ClaimingStatus() {
           <AttemptFooter>
             <p>The claim transaction failed. Please check the network parameters and try again.</p>
           </AttemptFooter>
-          <ButtonSecondary onClick={() => setClaimStatus(ClaimStatus.DEFAULT)}>
-            <Trans>Go back</Trans>
-          </ButtonSecondary>
         </>
+      )}
+      {(isConfirmed || isFailure) && (
+        <ButtonSecondary onClick={() => setClaimStatus(ClaimStatus.DEFAULT)}>
+          <Trans>Go back</Trans>
+        </ButtonSecondary>
       )}
     </ConfirmOrLoadingWrapper>
   )

--- a/src/custom/state/claim/actions.ts
+++ b/src/custom/state/claim/actions.ts
@@ -6,6 +6,7 @@ export enum ClaimStatus {
   ATTEMPTING = 'ATTEMPTING',
   SUBMITTED = 'SUBMITTED',
   CONFIRMED = 'CONFIRMED',
+  FAILED = 'FAILED',
 }
 
 export type ClaimActions = {

--- a/src/custom/state/claim/middleware.ts
+++ b/src/custom/state/claim/middleware.ts
@@ -1,8 +1,8 @@
-import { Middleware, isAnyOf } from '@reduxjs/toolkit'
-import { getCowSoundSuccess, getCowSoundSend } from 'utils/sound'
+import { isAnyOf, Middleware } from '@reduxjs/toolkit'
+import { getCowSoundSend, getCowSoundSuccess } from 'utils/sound'
 import { AppState } from 'state'
-import { finalizeTransaction, addTransaction } from '../enhancedTransactions/actions'
-import { setClaimStatus, ClaimStatus } from './actions'
+import { addTransaction, finalizeTransaction } from '../enhancedTransactions/actions'
+import { ClaimStatus, setClaimStatus } from './actions'
 
 const isFinalizeTransaction = isAnyOf(finalizeTransaction)
 const isAddTransaction = isAnyOf(addTransaction)
@@ -25,9 +25,20 @@ export const claimMinedMiddleware: Middleware<Record<string, unknown>, AppState>
     const transaction = store.getState().transactions[chainId][hash]
 
     if (transaction.claim) {
-      console.debug('[stat:claim:middleware] Claim transaction finalized', transaction.hash, transaction.claim)
-      store.dispatch(setClaimStatus(ClaimStatus.CONFIRMED))
-      cowSound = getCowSoundSuccess()
+      const status = transaction.receipt?.status
+      console.debug(
+        `[stat:claim:middleware] Claim transaction finalized withs status ${status}`,
+        transaction.hash,
+        transaction.claim
+      )
+      if (status === 1) {
+        // success
+        store.dispatch(setClaimStatus(ClaimStatus.CONFIRMED))
+        cowSound = getCowSoundSuccess()
+      } else {
+        // not success...
+        store.dispatch(setClaimStatus(ClaimStatus.FAILED))
+      }
     }
   }
 

--- a/src/custom/state/enhancedTransactions/hooks/index.ts
+++ b/src/custom/state/enhancedTransactions/hooks/index.ts
@@ -131,8 +131,8 @@ export function useAllClaimingTransactions() {
 export function useAllClaimingTransactionIndices() {
   const claimingTransactions = useAllClaimingTransactions()
   return useMemo(() => {
-    const flattenedClaimingTransactions = claimingTransactions.reduce<number[]>((acc, { claim }) => {
-      if (claim && claim.indices) {
+    const flattenedClaimingTransactions = claimingTransactions.reduce<number[]>((acc, { claim, receipt }) => {
+      if (claim && claim.indices && !receipt) {
         acc.push(...claim.indices)
       }
       return acc


### PR DESCRIPTION
# Summary

Closes #2082 

No success on failure (😆)

![Screen Shot 2022-01-28 at 15 18 37](https://user-images.githubusercontent.com/43217/151634643-140aade2-34ee-45dc-8ffd-0ec53ddee583.png)


When the claim tx fail, show instead a failure screen

https://user-images.githubusercontent.com/43217/151634032-26ff5d71-f468-4b70-8cd8-47d757553bbe.mov

User the can `go back` to a step before and try to do it again.

As a bonus, successful claims also have a `go back` button because there was no other way back than to change the account and try it again.

  # To Test

1. Either free or paid claims, proceed until you get the tx request in your wallet
2. Make the tx fail but inserting half the gas limit provided (e.g.: if you get 160000 replace it with 80000)

https://user-images.githubusercontent.com/43217/151634316-181b3687-0d74-4682-8767-7532cdc6c71a.mov

3. Submit the tx
* The tx will fail and you will lose the gas, but not the investments if any
* The UI will show you a failure screen and give you the option to go back
3. Click on `go back` and try to execute again
4. This time do not edit the tx parameters
* Once the tx is executed, you'll see the success screen