### PR TITLE
Claim for another account

### DIFF
--- a/src/custom/pages/Claim/ClaimingStatus.tsx
+++ b/src/custom/pages/Claim/ClaimingStatus.tsx
@@ -29,11 +29,14 @@ import { AMOUNT_PRECISION } from 'constants/index'
 import { shortenAddress } from 'utils'
 import CopyHelper from 'components/Copy'
 import { ButtonSecondary } from 'components/Button'
+import { ClaimCommonTypes } from './types'
 
 const COW_TWEET_TEMPLATE =
   'I just joined the 🐮 CoWmunity @MEVprotection and claimed my first vCOW tokens! Join me at https://cowswap.exchange/'
 
-export default function ClaimingStatus() {
+type ClaimNavProps = Pick<ClaimCommonTypes, 'handleChangeAccount'>
+
+export default function ClaimingStatus({ handleChangeAccount }: ClaimNavProps) {
   const { chainId, account } = useActiveWeb3React()
   const { activeClaimAccount, claimStatus, claimedAmount } = useClaimState()
 
@@ -159,9 +162,14 @@ export default function ClaimingStatus() {
           </AttemptFooter>
         </>
       )}
-      {(isConfirmed || isFailure) && (
+      {isFailure && (
         <ButtonSecondary onClick={() => setClaimStatus(ClaimStatus.DEFAULT)}>
           <Trans>Go back</Trans>
+        </ButtonSecondary>
+      )}
+      {isConfirmed && (
+        <ButtonSecondary onClick={handleChangeAccount}>
+          <Trans>Claim for another account</Trans>
         </ButtonSecondary>
       )}
     </ConfirmOrLoadingWrapper>

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -237,7 +237,7 @@ export default function Claim() {
             />
 
             {/* Try claiming or inform successful claim */}
-            <ClaimingStatus />
+            <ClaimingStatus handleChangeAccount={handleChangeAccount} />
             {/* IS Airdrop + investing (advanced) */}
             <ClaimsTable isAirdropOnly={isAirdropOnly} claims={userClaimData} hasClaims={hasClaims} />
             {/* Investing vCOW flow (advanced) */}


### PR DESCRIPTION
# Summary

This PR reiterates on https://github.com/gnosis/cowswap/pull/2355/files to replace the "Go back" link for a "Claim for another account" one in case the tx succeds (based on this comment https://github.com/gnosis/cowswap/pull/2355/files#r795621057)

Result:
![image](https://user-images.githubusercontent.com/2352112/151801111-a5742fdc-9c67-47f6-89d5-0a4278d49f8a.png)


When clicked, you get to this screen:
![image](https://user-images.githubusercontent.com/2352112/151800836-4dde2c3f-46bc-4851-bb19-ecb4d2b00ec9.png)


# To Test

1. Test to do any kind of claiming (which succeeds)
2. Test the new link
3. Test the case where the transaction fails

