### PR TITLE
Improve responsiveness of header elements.

### DIFF
--- a/src/custom/components/CowClaimButton/index.tsx
+++ b/src/custom/components/CowClaimButton/index.tsx
@@ -26,6 +26,12 @@ export const Wrapper = styled.div<{ isClaimPage?: boolean | null }>`
     font-weight: inherit;
     white-space: nowrap;
 
+    ${({ theme }) => theme.mediaWidth.upToMedium`
+      overflow: hidden;
+      max-width: 100px;
+      text-overflow: ellipsis;
+    `};
+
   &::before,
   &::after {
     content: '';

--- a/src/custom/components/CowClaimButton/index.tsx
+++ b/src/custom/components/CowClaimButton/index.tsx
@@ -32,41 +32,46 @@ export const Wrapper = styled.div<{ isClaimPage?: boolean | null }>`
       text-overflow: ellipsis;
     `};
 
-  &::before,
-  &::after {
-    content: '';
-    position: absolute;
-    left: -1px;
-    top: -1px;
-    background: ${({ theme }) =>
-      `linear-gradient(45deg, ${theme.primary1}, ${theme.primary2}, ${theme.primary3}, ${theme.bg4}, ${theme.primary1}, ${theme.primary2})`};
-    background-size: 800%;
-    width: calc(100% + 2px);
-    height: calc(100% + 2px);
-    z-index: -1;
-    animation: glow 50s linear infinite;
-    transition: background-position 0.3s ease-in-out;
-    border-radius: 12px;
-  }
-
-  &::after {
-    filter: blur(8px);
-  }
-
-  &:hover::before,
-  &:hover::after {
-    animation: glow 12s linear infinite;
-  }
-
-  // Stop glowing effect on claim page
-  ${({ isClaimPage }) =>
-    isClaimPage &&
-    css`
-      &::before,
-      &::after {
-        content: none;
-      }
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      overflow: visible;
     `};
+
+    &::before,
+    &::after {
+      content: '';
+      position: absolute;
+      left: -1px;
+      top: -1px;
+      background: ${({ theme }) =>
+        `linear-gradient(45deg, ${theme.primary1}, ${theme.primary2}, ${theme.primary3}, ${theme.bg4}, ${theme.primary1}, ${theme.primary2})`};
+      background-size: 800%;
+      width: calc(100% + 2px);
+      height: calc(100% + 2px);
+      z-index: -1;
+      animation: glow 50s linear infinite;
+      transition: background-position 0.3s ease-in-out;
+      border-radius: 12px;
+    }
+
+    &::after {
+      filter: blur(8px);
+    }
+
+    &:hover::before,
+    &:hover::after {
+      animation: glow 12s linear infinite;
+    }
+
+    // Stop glowing effect on claim page
+    ${({ isClaimPage }) =>
+      isClaimPage &&
+      css`
+        &::before,
+        &::after {
+          content: none;
+        }
+      `};
+  }
 
   @keyframes glow {
     0% {

--- a/src/custom/components/CowClaimButton/index.tsx
+++ b/src/custom/components/CowClaimButton/index.tsx
@@ -34,6 +34,7 @@ export const Wrapper = styled.div<{ isClaimPage?: boolean | null }>`
 
     ${({ theme }) => theme.mediaWidth.upToSmall`
       overflow: visible;
+      max-width: initial;
     `};
 
     &::before,

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -4,8 +4,8 @@ import { SupportedChainId as ChainId } from 'constants/chains'
 import { useHistory, useLocation } from 'react-router-dom'
 
 import HeaderMod, {
-  Title,
-  HeaderLinks,
+  Title as TitleMod,
+  HeaderLinks as HeaderLinksMod,
   HeaderRow,
   HeaderControls as HeaderControlsUni,
   BalanceText as BalanceTextUni,
@@ -80,6 +80,12 @@ const StyledNavLink = styled(StyledNavLinkUni)`
 `
 
 const BalanceText = styled(BalanceTextUni)`
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    overflow: hidden;
+    max-width: 100px;
+    text-overflow: ellipsis;
+  `};
+
   ${({ theme }) => theme.mediaWidth.upToSmall`
     display: none;
   `};
@@ -133,16 +139,20 @@ export const Wrapper = styled.div`
   }
 `
 
-export const HeaderModWrapper = styled(HeaderMod)`
-  ${Title} {
-    margin: 0;
-    text-decoration: none;
-    color: ${({ theme }) => theme.text1};
-  }
+export const HeaderModWrapper = styled(HeaderMod)``
 
-  ${HeaderLinks} {
-    margin: 5px 0 0 0;
-  }
+const Title = styled(TitleMod)`
+  margin: 0;
+  text-decoration: none;
+  color: ${({ theme }) => theme.text1};
+`
+
+export const HeaderLinks = styled(HeaderLinksMod)`
+  margin: 5px 0 0 0;
+
+  ${({ theme }) => theme.mediaWidth.upToLarge`
+    display: none;
+  `};
 `
 
 export const TwitterLink = styled(StyledMenuButton)`

--- a/src/custom/components/Menu/index.tsx
+++ b/src/custom/components/Menu/index.tsx
@@ -31,7 +31,7 @@ export * from './MenuMod'
 const ResponsiveInternalMenuItem = styled(InternalMenuItem)`
   display: none;
 
-  ${({ theme }) => theme.mediaWidth.upToMedium`
+  ${({ theme }) => theme.mediaWidth.upToLarge`
       display: flex;
   `};
 `


### PR DESCRIPTION
# Summary

- This PR tries to solve for some items in https://github.com/gnosis/cowswap/issues/2148
- The way it does that, is to enforce a max balance size, for both the vCOW and the network token balance (ETH, xDAI, etc.). It will use text ellipsis when the element is > 100px width on tablet/medium resolutions. 
- This fix will not resolve it 100% but will do so in more scenarios. In the example below I used an extreme scenario (long network name, large vCOW balance, large xDAI balance). As you see, for a very short moment only it is still overlapping.

https://user-images.githubusercontent.com/31534717/152176120-294d2fdb-f246-4624-96c3-cddcf1a18985.mov


## Todo
- Ways to improve: On medium/small resolutions, we could show abbreviated / shorter network names. Specifically `Gnosis Chain` -> `GC`.


