### PR TITLE
Moved claim state updater to claim page

### DIFF
--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -10,6 +10,7 @@ import { useWalletModalToggle } from 'state/application/hooks'
 import { getFreeClaims, hasPaidClaim, hasFreeClaim, prepareInvestClaims } from 'state/claim/hooks/utils'
 import { useClaimDispatchers, useClaimState } from 'state/claim/hooks'
 import { ClaimStatus } from 'state/claim/actions'
+import ClaimsOnOtherChainsUpdater from 'state/claim/updater'
 
 import { OperationType } from 'components/TransactionConfirmationModal'
 import Confetti from 'components/Confetti'
@@ -231,6 +232,8 @@ export default function Claim() {
 
   return (
     <PageWrapper>
+      {/* State Updater */}
+      <ClaimsOnOtherChainsUpdater />
       {/* Cross chain claim banner */}
       <ClaimsOnOtherChainsBanner />
       {/* Claiming content */}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,7 +28,6 @@ import {
   PendingOrdersUpdater,
   UnfillableOrdersUpdater,
 } from 'state/orders/updaters'
-import ClaimsOnOtherChainsUpdater from 'state/claim/updater'
 // import { EventUpdater } from 'state/orders/mocks'
 import ThemeProvider, { FixedGlobalStyle, ThemedGlobalStyle } from 'theme'
 import getLibrary from 'utils/getLibrary'
@@ -63,7 +62,6 @@ function Updaters() {
       <GpOrdersUpdater />
       <GasUpdater />
       <LogsUpdater />
-      <ClaimsOnOtherChainsUpdater />
     </>
   )
 }


### PR DESCRIPTION
# Summary

Moving claim state updater to claim page

Since https://github.com/gnosis/cowswap/pull/2342 has been superseded, I'm re-using a fix I did there that's useful.

We don't need to check whether the active claim account has claim on mainnet and gchain unless we are on the claim page.

  # To Test

1. Claim in other network detection should behave the same as before