### PR TITLE
Fix token display in dark/light mode for transactions.

### DIFF
--- a/src/custom/components/AccountDetails/Transaction/styled.ts
+++ b/src/custom/components/AccountDetails/Transaction/styled.ts
@@ -481,13 +481,14 @@ export const ActivityVisual = styled.div`
     padding: 2px;
     box-sizing: content-box;
     box-shadow: none;
-    background: ${({ theme }) => theme.card.background2};
+    background: ${({ theme }) => theme.transaction.tokenBackground};
     color: ${({ theme }) =>
-      theme.text1}!important; // Todo: Re-factor StyledLogo to prevent inline style and needing to use !important here
+      theme.transaction.tokenColor}!important; // TODO: Fix MOD file to not require this !important property value.
+    border: 2px solid ${({ theme }) => theme.transaction.tokenBorder};
   }
 
   ${StyledLogo}:not(:first-child):last-child {
-    margin: 0 0 0 -8px;
+    margin: 0 0 0 -9px;
   }
 
   &:hover ${StyledLogo} {

--- a/src/custom/theme/baseTheme.tsx
+++ b/src/custom/theme/baseTheme.tsx
@@ -155,6 +155,11 @@ export function themeVariables(darkMode: boolean, colorsTheme: Colors) {
         content: '680px',
       },
     },
+    transaction: {
+      tokenBackground: colorsTheme.bg2,
+      tokenColor: '#1d4373',
+      tokenBorder: darkMode ? '#01182a' : colorsTheme.bg3,
+    },
     neumorphism: {
       boxShadow: css`
         box-shadow: inset 2px -2px 4px ${darkMode ? '#1d4373' : '#ffffff'},

--- a/src/custom/theme/styled.d.ts
+++ b/src/custom/theme/styled.d.ts
@@ -81,6 +81,11 @@ declare module 'styled-components' {
         content: string
       }
     }
+    transaction: {
+      tokenBackground: string
+      tokenColor: string
+      tokenBorder: string
+    }
     neumorphism: {
       boxShadow: FlattenSimpleInterpolation
     }


### PR DESCRIPTION
# Summary

- Fixes https://github.com/gnosis/cowswap/issues/1913
- Instead of detecting colors it simply applies a lighter background to the token image, in dark mode.
- This solution has been chosen because I believe it provides more predictable results (instead of inverting images) and keeps the token images at its original resemblance.
<img width="814" alt="Screen Shot 2022-02-03 at 13 12 33" src="https://user-images.githubusercontent.com/31534717/152355086-e5b5cd8a-2c71-4aa3-8448-ea35fc3419f8.png">
<img width="812" alt="Screen Shot 2022-02-03 at 13 12 21" src="https://user-images.githubusercontent.com/31534717/152355103-15e7c59a-4dd0-4862-9908-4e30a5df082d.png">

