### PR TITLE
Updated gas estimation for gchain

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -98,8 +98,7 @@ export const GAS_FEE_ENDPOINTS = {
   // [ChainId.GOERLI]: 'https://safe-relay.goerli.gnosis.io/api/v1/gas-station/',
   // no kovan = main
   // [ChainId.KOVAN]: 'https://safe-relay.kovan.gnosis.io/api/v1/gas-station/',
-  // TODO: xdai? = main
-  [ChainId.XDAI]: 'https://safe-relay.gnosis.io/api/v1/gas-station/',
+  [ChainId.XDAI]: 'https://blockscout.com/xdai/mainnet/api/v1/gas-price-oracle',
 }
 
 export const UNSUPPORTED_TOKENS_FAQ_URL = '/faq#what-token-pairs-does-cowswap-allow-to-trade'

--- a/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
@@ -14,6 +14,7 @@ import {
   WarningWrapper,
 } from '../styled'
 import { formatMax, formatSmartLocaleAware } from 'utils/format'
+import { calculateGasMargin } from 'utils/calculateGasMargin'
 import Row from 'components/Row'
 import CheckCircle from 'assets/cow-swap/check.svg'
 import { InvestmentFlowProps } from '.'
@@ -129,17 +130,20 @@ export default function InvestOption({ claim, optionIndex, openModal, closeModal
   }
 
   const gasCost = useMemo(() => {
-    if (!estimatedGas || !isNative) {
+    if (!estimatedGas || !isNative || !chainId) {
       return
     }
 
     // Based on how much gas will be used (estimatedGas) and current gas prices (if available)
     // calculate how much that would cost in native currency.
     // We pick `fast` to be conservative. Also, it's non-blocking, so the user is aware but can proceed
-    const amount = BigNumber.from(estimatedGas).mul(gasPrice?.fast || AVG_APPROVE_COST_GWEI)
+    const amount = calculateGasMargin(
+      chainId,
+      BigNumber.from(estimatedGas).mul(gasPrice?.fast || AVG_APPROVE_COST_GWEI)
+    )
 
     return CurrencyAmount.fromRawAmount(token, amount.toString())
-  }, [estimatedGas, gasPrice?.fast, isNative, token])
+  }, [chainId, estimatedGas, gasPrice?.fast, isNative, token])
 
   // on invest max amount click handler
   const setMaxAmount = useCallback(() => {

--- a/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState, useEffect } from 'react'
 import { CurrencyAmount, Percent } from '@uniswap/sdk-core'
 import { BigNumber } from '@ethersproject/bignumber'
+import SVG from 'react-inlinesvg'
 
 import CowProtocolLogo from 'components/CowProtocolLogo'
 import {
@@ -17,7 +18,7 @@ import { formatMax, formatSmartLocaleAware } from 'utils/format'
 import { calculateGasMargin } from 'utils/calculateGasMargin'
 import Row from 'components/Row'
 import CheckCircle from 'assets/cow-swap/check.svg'
-import { InvestmentFlowProps } from '.'
+import ImportantIcon from 'assets/cow-swap/important.svg'
 import { ApprovalState, useApproveCallbackFromClaim } from 'hooks/useApproveCallback'
 import { useCurrencyBalance } from 'state/wallet/hooks'
 import { useActiveWeb3React } from 'hooks/web3'
@@ -37,8 +38,7 @@ import { EnhancedUserClaimData } from '../types'
 import { OperationType } from 'components/TransactionConfirmationModal'
 import { ONE_HUNDRED_PERCENT } from 'constants/misc'
 import { IS_TESTING_ENV } from '../const'
-import ImportantIcon from 'assets/cow-swap/important.svg'
-import SVG from 'react-inlinesvg'
+import { InvestmentFlowProps } from '.'
 
 const ErrorMessages = {
   NoBalance: (symbol = '') =>


### PR DESCRIPTION
# Summary

Closes #2389 

Gas estimation for gchain now uses proper values

![Screen Shot 2022-02-03 at 16 04 11](https://user-images.githubusercontent.com/43217/152450011-d0fbb17f-4f32-48ed-877a-39aefeb3e3f8.png)

  # To Test

1. Try to use 100% of xDAI investment and not have enough to claim. Not easy!
2. I managed to do so with these 2 accounts: The account to claim on gchain `0xcbeAd39cC0b43d14c2f240c25f3D5234bbDFF10c` and the account to claim with `0x2F144ff590C94871f118583E61fdDd06b98120e4` (PK in on the spreadsheet)
* You should see the low xDAI warning