### PR TITLE
2382/already claimed

### DIFF
--- a/src/custom/pages/Claim/ClaimsOnOtherChainsBanner.tsx
+++ b/src/custom/pages/Claim/ClaimsOnOtherChainsBanner.tsx
@@ -75,11 +75,13 @@ function ClaimsOnOtherChainsBanner({ className }: { className?: string }) {
   const { claimInfoPerAccount, activeClaimAccount } = useClaimState()
 
   const chainsWithClaims: SupportedChainId[] = useMemo(() => {
-    if (!activeClaimAccount || !claimInfoPerAccount[activeClaimAccount]) return []
+    const claimInfoPerChain = claimInfoPerAccount[activeClaimAccount]
 
-    return Object.keys(claimInfoPerAccount[activeClaimAccount]).reduce<SupportedChainId[]>((acc, chain) => {
+    if (!claimInfoPerChain) return []
+
+    return Object.keys(claimInfoPerChain).reduce<SupportedChainId[]>((acc, chain) => {
       const checkedChain = chain as unknown as SupportedChainId
-      const claimsCountOnChain = claimInfoPerAccount[activeClaimAccount][checkedChain]
+      const claimsCountOnChain = claimInfoPerChain[checkedChain]
 
       if (_shouldNotDisplayBannerForChain(checkedChain, chainId, claimsCountOnChain)) {
         return acc

--- a/src/custom/state/claim/actions.ts
+++ b/src/custom/state/claim/actions.ts
@@ -1,5 +1,6 @@
 import { createAction } from '@reduxjs/toolkit'
 import { SupportedChainId } from 'constants/chains'
+import { ChainClaimsCount } from 'state/claim/reducer'
 
 export enum ClaimStatus {
   DEFAULT = 'DEFAULT',
@@ -71,6 +72,7 @@ export const setSelectedAll = createAction<boolean>('claim/setSelectedAll')
 // Claim UI reset sugar
 export const resetClaimUi = createAction('claims/resetClaimUi')
 // Claims on other chains
-export const setHasClaimsOnOtherChains = createAction<{ chain: SupportedChainId; hasClaims: boolean }>(
-  'claims/setHasClaimsOnOtherChains'
-)
+export const setClaimsCount = createAction<{
+  chain: SupportedChainId
+  claimsCount: Partial<ChainClaimsCount>
+}>('claims/setClaimsCount')

--- a/src/custom/state/claim/actions.ts
+++ b/src/custom/state/claim/actions.ts
@@ -1,6 +1,6 @@
 import { createAction } from '@reduxjs/toolkit'
 import { SupportedChainId } from 'constants/chains'
-import { ChainClaimsCount } from 'state/claim/reducer'
+import { ClaimInfo } from 'state/claim/reducer'
 
 export enum ClaimStatus {
   DEFAULT = 'DEFAULT',
@@ -74,5 +74,6 @@ export const resetClaimUi = createAction('claims/resetClaimUi')
 // Claims on other chains
 export const setClaimsCount = createAction<{
   chain: SupportedChainId
-  claimsCount: Partial<ChainClaimsCount>
+  claimInfo: Partial<ClaimInfo>
+  account: string
 }>('claims/setClaimsCount')

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -53,12 +53,13 @@ import {
   updateInvestError,
   setEstimatedGas,
   setIsTouched,
-  setHasClaimsOnOtherChains,
+  setClaimsCount,
 } from '../actions'
 import { EnhancedUserClaimData } from 'pages/Claim/types'
 import { supportedChainId } from 'utils/supportedChainId'
 import { AMOUNT_PRECISION } from 'constants/index'
 import useIsMounted from 'hooks/useIsMounted'
+import { ChainClaimsCount } from 'state/claim/reducer'
 
 const CLAIMS_REPO_BRANCH = '2022-01-22-test-deployment-all-networks'
 export const CLAIMS_REPO = `https://raw.githubusercontent.com/gnosis/cow-merkle-drop/${CLAIMS_REPO_BRANCH}/`
@@ -118,7 +119,7 @@ type Account = string | null | undefined
 export type UserClaims = UserClaimData[]
 export type RepoClaims = RepoClaimData[]
 
-type ClassifiedUserClaims = {
+export type ClassifiedUserClaims = {
   available: UserClaims
   expired: UserClaims
   claimed: UserClaims
@@ -856,8 +857,8 @@ export function useClaimDispatchers() {
       // reset claim ui
       resetClaimUi: () => dispatch(resetClaimUi()),
       // has claims on other chains
-      setHasClaimsOnOtherChains: (payload: { chain: SupportedChainId; hasClaims: boolean }) =>
-        dispatch(setHasClaimsOnOtherChains(payload)),
+      setClaimsCount: (payload: { chain: SupportedChainId; claimsCount: Partial<ChainClaimsCount> }) =>
+        dispatch(setClaimsCount(payload)),
     }),
     [dispatch]
   )

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -59,7 +59,7 @@ import { EnhancedUserClaimData } from 'pages/Claim/types'
 import { supportedChainId } from 'utils/supportedChainId'
 import { AMOUNT_PRECISION } from 'constants/index'
 import useIsMounted from 'hooks/useIsMounted'
-import { ChainClaimsCount } from 'state/claim/reducer'
+import { ClaimInfo } from 'state/claim/reducer'
 
 const CLAIMS_REPO_BRANCH = '2022-01-22-test-deployment-all-networks'
 export const CLAIMS_REPO = `https://raw.githubusercontent.com/gnosis/cow-merkle-drop/${CLAIMS_REPO_BRANCH}/`
@@ -857,7 +857,7 @@ export function useClaimDispatchers() {
       // reset claim ui
       resetClaimUi: () => dispatch(resetClaimUi()),
       // has claims on other chains
-      setClaimsCount: (payload: { chain: SupportedChainId; claimsCount: Partial<ChainClaimsCount> }) =>
+      setClaimsCount: (payload: { chain: SupportedChainId; claimInfo: ClaimInfo; account: string }) =>
         dispatch(setClaimsCount(payload)),
     }),
     [dispatch]

--- a/src/custom/state/claim/reducer.ts
+++ b/src/custom/state/claim/reducer.ts
@@ -18,17 +18,31 @@ import {
   updateInvestError,
   setEstimatedGas,
   setIsTouched,
-  setHasClaimsOnOtherChains,
+  setClaimsCount,
 } from './actions'
 
-export type ClaimsOnOtherChains = {
-  [chain in SupportedChainId]: boolean
+export type ChainClaimsCount = {
+  total: number
+  available: number
+  claimed: number
+  expired: number
 }
 
-const DEFAULT_CLAIMS_ON_OTHER_CHAINS_STATE = {
-  [SupportedChainId.MAINNET]: false,
-  [SupportedChainId.RINKEBY]: false,
-  [SupportedChainId.XDAI]: false,
+export type ClaimsOnOtherChains = {
+  [chain in SupportedChainId]: ChainClaimsCount
+}
+
+const DEFAULT_CHAIN_CLAIMS_COUNT: ChainClaimsCount = {
+  available: 0,
+  claimed: 0,
+  expired: 0,
+  total: 0,
+}
+
+const DEFAULT_CLAIMS_ON_OTHER_CHAINS_STATE: ClaimsOnOtherChains = {
+  [SupportedChainId.MAINNET]: DEFAULT_CHAIN_CLAIMS_COUNT,
+  [SupportedChainId.RINKEBY]: DEFAULT_CHAIN_CLAIMS_COUNT,
+  [SupportedChainId.XDAI]: DEFAULT_CHAIN_CLAIMS_COUNT,
 }
 
 export const initialState: ClaimState = {
@@ -51,7 +65,7 @@ export const initialState: ClaimState = {
   selected: [],
   selectedAll: false,
   // claims on other networks
-  hasClaimsOnOtherChains: DEFAULT_CLAIMS_ON_OTHER_CHAINS_STATE,
+  claimsCount: DEFAULT_CLAIMS_ON_OTHER_CHAINS_STATE,
 }
 
 export type InvestClaim = {
@@ -81,13 +95,16 @@ export type ClaimState = {
   selected: number[]
   selectedAll: boolean
   // claims on other chains
-  hasClaimsOnOtherChains: ClaimsOnOtherChains
+  claimsCount: ClaimsOnOtherChains
 }
 
 export default createReducer(initialState, (builder) =>
   builder
-    .addCase(setHasClaimsOnOtherChains, (state, { payload }) => {
-      state.hasClaimsOnOtherChains[payload.chain] = payload.hasClaims
+    .addCase(setClaimsCount, (state, { payload }) => {
+      state.claimsCount[payload.chain] = {
+        ...state.claimsCount[payload.chain],
+        ...payload.claimsCount,
+      }
     })
     .addCase(setInputAddress, (state, { payload }) => {
       state.inputAddress = payload

--- a/src/custom/state/claim/updater.tsx
+++ b/src/custom/state/claim/updater.tsx
@@ -1,24 +1,61 @@
 import { useEffect } from 'react'
 import { SupportedChainId } from 'constants/chains'
-import { useClaimDispatchers, useClaimState, useUserAvailableClaims } from './hooks'
+import { ClassifiedUserClaims, useClaimDispatchers, useClaimState, useClassifiedUserClaims } from './hooks'
+import { useActiveWeb3React } from 'hooks'
+import { ChainClaimsCount } from 'state/claim/reducer'
 
 export default function Updater() {
+  const { chainId } = useActiveWeb3React()
   const { activeClaimAccount } = useClaimState()
-  const { setHasClaimsOnOtherChains } = useClaimDispatchers()
+  const { setClaimsCount } = useClaimDispatchers()
 
-  const { claims: mainnetAvailable } = useUserAvailableClaims(activeClaimAccount, SupportedChainId.MAINNET)
-  const { claims: gnosisAvailable } = useUserAvailableClaims(activeClaimAccount, SupportedChainId.XDAI)
+  // Fetches all classified claims for mainnet and gchain
+  const mainnetClaims = useClassifiedUserClaims(activeClaimAccount, SupportedChainId.MAINNET)
+  const gChainClaims = useClassifiedUserClaims(activeClaimAccount, SupportedChainId.XDAI)
 
   useEffect(() => {
-    setHasClaimsOnOtherChains({
+    // Counts the claims, based on which is the current network
+    const mainnetCount = _countClaims(mainnetClaims, chainId, SupportedChainId.MAINNET)
+    const gChainCount = _countClaims(gChainClaims, chainId, SupportedChainId.XDAI)
+
+    // Stores it on redux
+    setClaimsCount({
       chain: SupportedChainId.MAINNET,
-      hasClaims: Boolean(mainnetAvailable && mainnetAvailable.length > 0),
+      claimsCount: mainnetCount,
     })
-    setHasClaimsOnOtherChains({
+    setClaimsCount({
       chain: SupportedChainId.XDAI,
-      hasClaims: Boolean(gnosisAvailable && gnosisAvailable.length > 0),
+      claimsCount: gChainCount,
     })
-  }, [setHasClaimsOnOtherChains, mainnetAvailable, gnosisAvailable])
+  }, [setClaimsCount, chainId, mainnetClaims, gChainClaims])
 
   return null
+}
+
+/**
+ * Counts claims per network
+ */
+function _countClaims(
+  mainnetClaims: ClassifiedUserClaims,
+  currentChainId: number | undefined,
+  chainId: SupportedChainId
+) {
+  const { available, claimed, expired } = mainnetClaims
+
+  const count: Partial<ChainClaimsCount> = {
+    // Total is easy, just add everything up
+    // This will always be accurate.
+    // When we only have airdrop repo as reference, everything will be `available`
+    // Otherwise the sum of all categories
+    total: claimed.length + available.length + expired.length,
+  }
+  // Only if we are in the network we want to check we are able to do smart contract calls
+  // and fetch contract data
+  // Otherwise the count would be replaced with outdated info
+  if (currentChainId === chainId) {
+    count.available = available.length
+    count.expired = expired.length
+    count.claimed = claimed.length
+  }
+  return count
 }


### PR DESCRIPTION
# Summary

Closes #2382 

Once you load the network you have claims on, and all claims are gone, remove the banner on other networks


https://user-images.githubusercontent.com/43217/152618830-7e925ea5-2548-454d-9f43-f5d2d504b82e.mov



  # To Test

1. Load one account that has claims on other networks
2. Go to the other network
3. Claim everything on that network
4. Go to other network
* The banner about the network you claimed everything should no longer be displayed