### PR TITLE
Menu: view all orders position

### DIFF
--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -222,7 +222,7 @@ export default function AccountDetails({
             <h5>
               Recent Activity <span>{`(${activityTotalCount})`}</span>
             </h5>
-            {explorerOrdersLink && <ExternalLink href={explorerOrdersLink}>View all orders</ExternalLink>}
+            {explorerOrdersLink && <ExternalLink href={explorerOrdersLink}>View all orders ↗</ExternalLink>}
           </span>
 
           <div>

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -233,7 +233,7 @@ export default function AccountDetails({
                 {renderActivities(activities)}
               </Fragment>
             ))}
-            {explorerOrdersLink && <ExternalLink href={explorerOrdersLink}>View all orders</ExternalLink>}
+            {explorerOrdersLink && <ExternalLink href={explorerOrdersLink}>View all orders ↗</ExternalLink>}
           </div>
         </LowerSection>
       ) : (

--- a/src/custom/components/Menu/index.tsx
+++ b/src/custom/components/Menu/index.tsx
@@ -214,11 +214,10 @@ const MenuFlyout = styled(MenuFlyoutUni)`
     height: 18px;
     object-fit: contain;
     margin: 0 8px 0 0;
-
-    > path {
-      fill: ${({ theme }) => theme.text1};
-    }
   }
+`
+export const StyledSVG = styled(SVG)`
+  fill: ${({ theme }) => theme.text1};
 `
 
 export const Separator = styled(SeparatorBase)`
@@ -333,19 +332,27 @@ export function Menu({ darkMode, toggleDarkMode, isClaimPage }: MenuProps) {
             Code
           </span>
         </MenuItem>
+        {showOrdersLink && (
+          <MenuItem id="link" href={getExplorerAddressLink(chainId || 1, account)}>
+            <span aria-hidden="true" onClick={close} onKeyDown={close}>
+              <ExternalLink size={14} />
+              View all orders
+            </span>
+          </MenuItem>
+        )}
 
         <Separator />
 
         <MenuItem id="link" href={DISCORD_LINK}>
           <span aria-hidden="true" onClick={close} onKeyDown={close}>
-            <SVG src={discordImage} description="Find CowSwap on Discord!" />
+            <StyledSVG src={discordImage} description="Find CowSwap on Discord!" />
             Discord
           </span>
         </MenuItem>
 
         <MenuItem id="link" href={TWITTER_LINK}>
           <span aria-hidden="true" onClick={close} onKeyDown={close}>
-            <SVG src={twitterImage} description="Follow CowSwap on Twitter!" /> Twitter
+            <StyledSVG src={twitterImage} description="Follow CowSwap on Twitter!" /> Twitter
           </span>
         </MenuItem>
 
@@ -364,14 +371,6 @@ export function Menu({ darkMode, toggleDarkMode, isClaimPage }: MenuProps) {
           </span>{' '}
           Cow Runner
         </InternalMenuItem>
-        {showOrdersLink && (
-          <MenuItem id="link" href={getExplorerAddressLink(chainId || 1, account)}>
-            <span aria-hidden="true" onClick={close} onKeyDown={close}>
-              <ExternalLink size={14} />
-              View all orders
-            </span>
-          </MenuItem>
-        )}
         <MenuItemResponsive onClick={() => toggleDarkMode()}>
           {darkMode ? (
             <>


### PR DESCRIPTION
# Summary

Fixes #2149 
![image](https://user-images.githubusercontent.com/622217/152845927-e2ae310e-8f00-48d6-bedc-f109f60f0d62.png)


  # To Test

1.  Open the [...] Menu and see the "View all order" link position. 
(this link appears to a connected user who has done a trade in the platform.)


# Extra:

- External link arrow added on activity modal:
![image](https://user-images.githubusercontent.com/622217/152846134-040480d8-a4cc-437d-bea3-cac25fe10685.png)
- Icon style (Before -> After):
![image](https://user-images.githubusercontent.com/622217/152846643-b83fec26-7b48-4d81-ab22-490980e6f955.png) ![image](https://user-images.githubusercontent.com/622217/152846698-9f88b0aa-704d-47b2-9168-021d616fa224.png)
