### PR TITLE
Test GIP-13 with Mainnet data in rinkeby

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -53,7 +53,7 @@ export const GP_VAULT_RELAYER: Partial<Record<number, string>> = {
 export const V_COW_CONTRACT_ADDRESS: Record<number, string> = {
   [ChainId.MAINNET]: '0x6d04B3ad33594978D0D4B01CdB7c3bA4a90a7DFe',
   [ChainId.XDAI]: '0xA3A674a40709A837A5E742C2866eda7d3b35a7c0',
-  [ChainId.RINKEBY]: '0x5Bf4d1f8d1cB35E0aeA69B220beb97b8807504eA',
+  [ChainId.RINKEBY]: '0xa46ad7f6669fAF6E80572Cc68c8A0148Cd3ac389',
 }
 
 // See https://github.com/gnosis/gp-v2-contracts/commit/821b5a8da213297b0f7f1d8b17c893c5627020af#diff-12bbbe13cd5cf42d639e34a39d8795021ba40d3ee1e1a8282df652eb161a11d6R13

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -60,7 +60,7 @@ import { supportedChainId } from 'utils/supportedChainId'
 import { AMOUNT_PRECISION } from 'constants/index'
 import useIsMounted from 'hooks/useIsMounted'
 
-const CLAIMS_REPO_BRANCH = '2022-01-22-test-deployment-all-networks'
+const CLAIMS_REPO_BRANCH = 'gip-13'
 export const CLAIMS_REPO = `https://raw.githubusercontent.com/gnosis/cow-merkle-drop/${CLAIMS_REPO_BRANCH}/`
 
 // Base amount = 1 VCOW

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -60,7 +60,7 @@ import { supportedChainId } from 'utils/supportedChainId'
 import { AMOUNT_PRECISION } from 'constants/index'
 import useIsMounted from 'hooks/useIsMounted'
 
-const CLAIMS_REPO_BRANCH = 'gip-13'
+const CLAIMS_REPO_BRANCH = 'gip-13-rinkeby-as-mainnet'
 export const CLAIMS_REPO = `https://raw.githubusercontent.com/gnosis/cow-merkle-drop/${CLAIMS_REPO_BRANCH}/`
 
 // Base amount = 1 VCOW


### PR DESCRIPTION
# Summary

Setup of a DEMO-able version with Mainnet data according to GIP-13 proposal, but available in Rinkeby.
In other words, you can claim in rinkeby what you would claim in Mainnet if the proposal passes.

Related PR: 
https://github.com/gnosis/cow-merkle-drop/pull/1