### PR TITLE
gip-13 data - Update contract

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -51,8 +51,8 @@ export const GP_VAULT_RELAYER: Partial<Record<number, string>> = {
 }
 
 export const V_COW_CONTRACT_ADDRESS: Record<number, string> = {
-  [ChainId.MAINNET]: '0x6d04B3ad33594978D0D4B01CdB7c3bA4a90a7DFe',
-  [ChainId.XDAI]: '0xA3A674a40709A837A5E742C2866eda7d3b35a7c0',
+  [ChainId.MAINNET]: '0xd057b63f5e69cf1b929b356b579cba08d7688048',
+  [ChainId.XDAI]: '0xc20C9C13E853fc64d054b73fF21d3636B2d97eaB',
   [ChainId.RINKEBY]: '0x5Bf4d1f8d1cB35E0aeA69B220beb97b8807504eA',
 }
 

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -60,7 +60,7 @@ import { supportedChainId } from 'utils/supportedChainId'
 import { AMOUNT_PRECISION } from 'constants/index'
 import useIsMounted from 'hooks/useIsMounted'
 
-const CLAIMS_REPO_BRANCH = '2022-01-22-test-deployment-all-networks'
+const CLAIMS_REPO_BRANCH = 'gip-13'
 export const CLAIMS_REPO = `https://raw.githubusercontent.com/gnosis/cow-merkle-drop/${CLAIMS_REPO_BRANCH}/`
 
 // Base amount = 1 VCOW


### PR DESCRIPTION
# Summary

Update the claiming data and contract to GIP-13 proposal. Meant to be used only if it passes and is executed. 

Related to https://github.com/gnosis/cow-merkle-drop/pull/1

## Tasks
- [x] Update the claiming data and Merkle proofs
- [x] Update the address of vCOW 
- [x] Image in trust wallet is ready ---> @biocom 
