### PR TITLE
Enable Portis wallet

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -29,7 +29,7 @@ REACT_APP_NETWORK_URL_4=https://rinkeby.infura.io/v3/1221fd11e90849509afafd330ec
 REACT_APP_NETWORK_URL_100=https://rpc.xdaichain.com
 
 # Wallets
-REACT_APP_PORTIS_ID="c0e2bf01-4b08-4fd5-ac7b-8e26b58cd236"
+REACT_APP_PORTIS_ID="c591a488-8b86-41e1-8d2e-f4b169efd3aa"
 REACT_APP_FORTMATIC_KEY="pk_live_F937DF033A1666BF"
 
 # Domain regex (to detect environment)

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -17,7 +17,6 @@ import Identicon from 'components/Identicon'
 import { NETWORK_LABELS } from 'components/Header'
 import {
   WalletName,
-  MainWalletAction,
   WalletAction,
   AccountControl,
   AddressLink,
@@ -118,13 +117,6 @@ export function getStatusIcon(connector?: AbstractConnector, walletInfo?: Connec
       <>
         <IconWrapper size={16}>
           <img src={PortisIcon} alt={'portis logo'} />
-          <MainWalletAction
-            onClick={() => {
-              portis.portis.showPortis()
-            }}
-          >
-            Show Portis
-          </MainWalletAction>
         </IconWrapper>
       </>
     )

--- a/src/custom/components/Web3Status/Web3StatusMod.tsx
+++ b/src/custom/components/Web3Status/Web3StatusMod.tsx
@@ -88,19 +88,30 @@ const Web3StatusConnect = styled(Web3StatusGeneric)<{ faded?: boolean }>`
     `}
 `
 
-export const Web3StatusConnected = styled(Web3StatusGeneric)<{ pending?: boolean }>`
+export const Web3StatusConnected = styled(Web3StatusGeneric)<{ pending?: boolean; clickable?: boolean }>`
   background-color: ${({ pending, theme }) => (pending ? theme.primary1 : theme.bg2)};
   border: 1px solid ${({ pending, theme }) => (pending ? theme.primary1 : theme.bg3)};
   color: ${({ pending, theme }) => (pending ? theme.white : theme.text1)};
   font-weight: 500;
-  :hover,
-  :focus {
-    background-color: ${({ pending, theme }) => (pending ? darken(0.05, theme.primary1) : lighten(0.05, theme.bg2))};
 
-    :focus {
-      border: 1px solid ${({ pending, theme }) => (pending ? darken(0.1, theme.primary1) : darken(0.1, theme.bg3))};
-    }
-  }
+  ${({ clickable }) =>
+    clickable === false &&
+    css`
+      cursor: not-allowed;
+    `}
+
+  ${({ clickable, pending }) =>
+    clickable !== false &&
+    css`
+      :hover,
+      :focus {
+        background-color: ${({ theme }) => (pending ? darken(0.05, theme.primary1) : lighten(0.05, theme.bg2))};
+
+        :focus {
+          border: 1px solid ${({ theme }) => (pending ? darken(0.1, theme.primary1) : darken(0.1, theme.bg3))};
+        }
+      }
+    `}
 `
 
 export const Text = styled.p`
@@ -172,10 +183,12 @@ export function Web3StatusInner({
   pendingCount,
   StatusIconComponent,
   openOrdersPanel, // mod
+  thereWasAProvider, //mod
 }: {
   pendingCount?: number
   StatusIconComponent: (props: { connector: AbstractConnector }) => JSX.Element | null
   openOrdersPanel: () => void // mod
+  thereWasAProvider: boolean //mod
 }) {
   const { account, connector, error } = useWeb3React()
 
@@ -229,6 +242,17 @@ export function Web3StatusInner({
         <NetworkIcon />
         <Text>{error instanceof UnsupportedChainIdError ? <Trans>Wrong Network</Trans> : <Trans>Error</Trans>}</Text>
       </Web3StatusError>
+    )
+  } else if (thereWasAProvider) {
+    return (
+      <Web3StatusConnected pending={true} clickable={false}>
+        <RowBetween>
+          <Text>
+            <Trans>Connecting</Trans>...
+          </Text>{' '}
+          <Loader stroke="white" />
+        </RowBetween>
+      </Web3StatusConnected>
     )
   } else {
     return (

--- a/src/custom/components/Web3Status/index.tsx
+++ b/src/custom/components/Web3Status/index.tsx
@@ -8,6 +8,7 @@ import useRecentActivity, { TransactionAndOrder } from 'hooks/useRecentActivity'
 import { useWalletInfo } from 'hooks/useWalletInfo'
 import { ButtonSecondary } from 'components/Button'
 import { OrderStatus } from '@src/custom/state/orders/actions'
+import { STORAGE_KEY_LAST_PROVIDER } from 'constants/index'
 
 export const Wrapper = styled.div`
   color: ${({ theme }) => theme.wallet?.color};
@@ -72,7 +73,7 @@ interface Web3StatusProps {
 
 export default function Web3Status({ openOrdersPanel }: Web3StatusProps) {
   const walletInfo = useWalletInfo()
-
+  const latestProvider = localStorage.getItem(STORAGE_KEY_LAST_PROVIDER)
   // Returns all RECENT (last day) transaction and orders in 2 arrays: pending and confirmed
   const allRecentActivity = useRecentActivity()
 
@@ -88,7 +89,7 @@ export default function Web3Status({ openOrdersPanel }: Web3StatusProps) {
   }, [allRecentActivity])
 
   const { active, activeNetwork, ensName } = walletInfo
-  if (!activeNetwork && !active) {
+  if (!activeNetwork && !active && !latestProvider) {
     return null
   }
 
@@ -98,6 +99,7 @@ export default function Web3Status({ openOrdersPanel }: Web3StatusProps) {
         pendingCount={pendingActivity.length}
         StatusIconComponent={StatusIcon}
         openOrdersPanel={openOrdersPanel}
+        thereWasAProvider={!!latestProvider}
       />
       <WalletModal ENSName={ensName} pendingTransactions={pendingActivity} confirmedTransactions={confirmedActivity} />
     </Wrapper>

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -25,7 +25,7 @@ export const APP_DATA_HASH = getAppDataHash()
 export const PRODUCTION_URL = 'cowswap.exchange'
 export const BARN_URL = `barn.${PRODUCTION_URL}`
 
-const DISABLED_WALLETS = /^(?:WALLET_LINK|COINBASE_LINK|FORTMATIC|Portis)$/i
+const DISABLED_WALLETS = /^(?:)$/i
 
 // Re-export only the supported wallets
 export const SUPPORTED_WALLETS = Object.keys(SUPPORTED_WALLETS_UNISWAP).reduce((acc, key) => {

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -25,7 +25,7 @@ export const APP_DATA_HASH = getAppDataHash()
 export const PRODUCTION_URL = 'cowswap.exchange'
 export const BARN_URL = `barn.${PRODUCTION_URL}`
 
-const DISABLED_WALLETS = /^(?:)$/i
+const DISABLED_WALLETS = /^(?:WALLET_LINK|COINBASE_LINK|FORTMATIC)$/i
 
 // Re-export only the supported wallets
 export const SUPPORTED_WALLETS = Object.keys(SUPPORTED_WALLETS_UNISWAP).reduce((acc, key) => {


### PR DESCRIPTION
closes #434
Enable the ability to connect via `Portis`

## To Test
- Go to the [**Connect to a wallet**](https://pr2404--gpswapui.review.gnosisdev.com/) button and click on the `Portis` option.

## Background

*This PR is part of the activation of previously supported wallets #2165*