### PR TITLE
Get deployment time per network

### DIFF
--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -285,6 +285,7 @@ function fetchDeploymentTimestamp(vCowContract: VCowType, chainId: ChainId): Pro
       console.log(`Deployment timestamp in seconds: ${ts.toString()}`)
       return ts.mul('1000').toNumber()
     })
+    FETCH_DEPLOYMENT_TIME_PROMISES.set(chainId, deploymentTimePromise)
   }
 
   return deploymentTimePromise

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import JSBI from 'jsbi'
 import ms from 'ms.macro'
 import { CurrencyAmount, Price, Token } from '@uniswap/sdk-core'
@@ -59,6 +59,7 @@ import { EnhancedUserClaimData } from 'pages/Claim/types'
 import { supportedChainId } from 'utils/supportedChainId'
 import { AMOUNT_PRECISION } from 'constants/index'
 import useIsMounted from 'hooks/useIsMounted'
+import { ChainId } from '@uniswap/sdk'
 
 const CLAIMS_REPO_BRANCH = '2022-01-22-test-deployment-all-networks'
 export const CLAIMS_REPO = `https://raw.githubusercontent.com/gnosis/cow-merkle-drop/${CLAIMS_REPO_BRANCH}/`
@@ -275,16 +276,18 @@ export function useUserClaims(account: Account, optionalChainId?: SupportedChain
   return { claims: claimKey ? claimInfo[claimKey] : null, isLoading }
 }
 
-let fetch_deployment_timestamp_promise: Promise<number> | null = null
-function fetchDeploymentTimestamp(vCowContract: VCowType) {
-  if (!fetch_deployment_timestamp_promise) {
-    fetch_deployment_timestamp_promise = vCowContract.deploymentTimestamp().then((ts) => {
+const FETCH_DEPLOYMENT_TIME_PROMISES: Map<ChainId, Promise<number>> = new Map()
+function fetchDeploymentTimestamp(vCowContract: VCowType, chainId: ChainId): Promise<number> {
+  let deploymentTimePromise = FETCH_DEPLOYMENT_TIME_PROMISES.get(chainId)
+
+  if (!deploymentTimePromise) {
+    deploymentTimePromise = vCowContract.deploymentTimestamp().then((ts) => {
       console.log(`Deployment timestamp in seconds: ${ts.toString()}`)
       return ts.mul('1000').toNumber()
     })
   }
 
-  return fetch_deployment_timestamp_promise
+  return deploymentTimePromise
 }
 
 /**
@@ -298,13 +301,21 @@ function useDeploymentTimestamp(): number | null {
   const isMounted = useIsMounted()
 
   const [timestamp, setTimestamp] = useState<number | null>(null)
+  const oldChainId = useRef(chainId)
 
   useEffect(() => {
     if (!chainId || !vCowContract) {
       return
     }
 
-    fetchDeploymentTimestamp(vCowContract)
+    // Invalidate timestamp
+    if (chainId != oldChainId.current) {
+      setTimestamp(null)
+      oldChainId.current = chainId
+    }
+
+    // Fetch timestamp
+    fetchDeploymentTimestamp(vCowContract, chainId)
       .then((timestamp) => {
         if (isMounted.current) {
           setTimestamp(timestamp)


### PR DESCRIPTION
# Summary

This PR addresses the issue @elena-zh described here https://github.com/gnosis/cowswap/pull/2395#issuecomment-1032383617

Basically we had an issue with how we get the deployment time. We assumed the date was the same per network, when is not true. We never realised this because in our tests the 3 deployments were close enough. 

Now is more evident, because mainnnet/xdai passed the 2 weeks, and rinkeby deployment is fresh  


  # To Test

1. Load the app fresh in Gnosis Chain
2. Change to rinkeby 
3. Claim for one account with investment options

