### PR TITLE
Update vcow blog links based on chain id

### DIFF
--- a/src/custom/pages/Claim/CanUserClaimMessage.tsx
+++ b/src/custom/pages/Claim/CanUserClaimMessage.tsx
@@ -2,7 +2,7 @@ import { Trans } from '@lingui/macro'
 import { ButtonSecondary } from 'components/Button'
 import { IntroDescription, BannerExplainer } from './styled'
 import { ClaimCommonTypes } from './types'
-import { useClaimState, useClaimTimeInfo, useCowLinks } from 'state/claim/hooks'
+import { useClaimState, useClaimTimeInfo, useClaimLinks } from 'state/claim/hooks'
 import { ClaimStatus } from 'state/claim/actions'
 import { formatDateWithTimezone } from 'utils/time'
 import useNetworkName from 'hooks/useNetworkName'
@@ -16,7 +16,7 @@ export default function CanUserClaimMessage({ hasClaims, isAirdropOnly, handleCh
   const { activeClaimAccount, claimStatus } = useClaimState()
   const network = useNetworkName()
 
-  const cowLinks = useCowLinks()
+  const claimLinks = useClaimLinks()
 
   const { airdropDeadline } = useClaimTimeInfo()
 
@@ -35,7 +35,7 @@ export default function CanUserClaimMessage({ hasClaims, isAirdropOnly, handleCh
             </Trans>
           </p>
         </IntroDescription>
-        <ExternalLink href={cowLinks.vCowPost}>
+        <ExternalLink href={claimLinks.vCowPost}>
           <BannerExplainer>
             <SVG src={CowProtocolImage} description="Questions? Read More." />
             <span>

--- a/src/custom/pages/Claim/CanUserClaimMessage.tsx
+++ b/src/custom/pages/Claim/CanUserClaimMessage.tsx
@@ -2,12 +2,11 @@ import { Trans } from '@lingui/macro'
 import { ButtonSecondary } from 'components/Button'
 import { IntroDescription, BannerExplainer } from './styled'
 import { ClaimCommonTypes } from './types'
-import { useClaimState, useClaimTimeInfo } from 'state/claim/hooks'
+import { useClaimState, useClaimTimeInfo, useCowLinks } from 'state/claim/hooks'
 import { ClaimStatus } from 'state/claim/actions'
 import { formatDateWithTimezone } from 'utils/time'
 import useNetworkName from 'hooks/useNetworkName'
 import { ExternalLink } from 'theme/index'
-import { COW_LINKS } from '.'
 import SVG from 'react-inlinesvg'
 import CowProtocolImage from 'assets/cow-swap/cowprotocol.svg'
 
@@ -16,6 +15,8 @@ type ClaimIntroductionProps = Pick<ClaimCommonTypes, 'hasClaims' | 'handleChange
 export default function CanUserClaimMessage({ hasClaims, isAirdropOnly, handleChangeAccount }: ClaimIntroductionProps) {
   const { activeClaimAccount, claimStatus } = useClaimState()
   const network = useNetworkName()
+
+  const cowLinks = useCowLinks()
 
   const { airdropDeadline } = useClaimTimeInfo()
 
@@ -34,7 +35,7 @@ export default function CanUserClaimMessage({ hasClaims, isAirdropOnly, handleCh
             </Trans>
           </p>
         </IntroDescription>
-        <ExternalLink href={COW_LINKS.vCowPost}>
+        <ExternalLink href={cowLinks.vCowPost}>
           <BannerExplainer>
             <SVG src={CowProtocolImage} description="Questions? Read More." />
             <span>

--- a/src/custom/pages/Claim/ClaimsTable.tsx
+++ b/src/custom/pages/Claim/ClaimsTable.tsx
@@ -1,4 +1,4 @@
-import { ClaimType, useClaimDispatchers, useClaimState, useClaimTimeInfo } from 'state/claim/hooks'
+import { ClaimType, useClaimDispatchers, useClaimState, useClaimTimeInfo, useCowLinks } from 'state/claim/hooks'
 import styled from 'styled-components/macro'
 import { ClaimTable, ClaimBreakdown, TokenLogo, BannerExplainer } from 'pages/Claim/styled'
 import CowProtocolLogo from 'components/CowProtocolLogo'
@@ -15,7 +15,6 @@ import { getPaidClaims, getIndexes } from 'state/claim/hooks/utils'
 import { useEffect } from 'react'
 import { AMOUNT_PRECISION } from 'constants/index'
 import { ExternalLink } from 'theme/index'
-import { COW_LINKS } from '.'
 import SVG from 'react-inlinesvg'
 import CowProtocolImage from 'assets/cow-swap/cowprotocol.svg'
 
@@ -119,6 +118,8 @@ export default function ClaimsTable({ isAirdropOnly, claims, hasClaims }: Claims
 
   const pendingClaimsSet = useAllClaimingTransactionIndices()
 
+  const cowLinks = useCowLinks()
+
   const { deployment: start, investmentDeadline, airdropDeadline } = useClaimTimeInfo()
 
   const handleSelect = (event: React.ChangeEvent<HTMLInputElement>, index: number) => {
@@ -182,7 +183,7 @@ export default function ClaimsTable({ isAirdropOnly, claims, hasClaims }: Claims
           </tbody>
         </table>
       </ClaimTable>
-      <ExternalLink href={COW_LINKS.vCowPost}>
+      <ExternalLink href={cowLinks.vCowPost}>
         <BannerExplainer>
           <SVG src={CowProtocolImage} description="Questions? Read More." />
           <span>

--- a/src/custom/pages/Claim/ClaimsTable.tsx
+++ b/src/custom/pages/Claim/ClaimsTable.tsx
@@ -1,4 +1,4 @@
-import { ClaimType, useClaimDispatchers, useClaimState, useClaimTimeInfo, useCowLinks } from 'state/claim/hooks'
+import { ClaimType, useClaimDispatchers, useClaimState, useClaimTimeInfo, useClaimLinks } from 'state/claim/hooks'
 import styled from 'styled-components/macro'
 import { ClaimTable, ClaimBreakdown, TokenLogo, BannerExplainer } from 'pages/Claim/styled'
 import CowProtocolLogo from 'components/CowProtocolLogo'
@@ -118,7 +118,7 @@ export default function ClaimsTable({ isAirdropOnly, claims, hasClaims }: Claims
 
   const pendingClaimsSet = useAllClaimingTransactionIndices()
 
-  const cowLinks = useCowLinks()
+  const claimLinks = useClaimLinks()
 
   const { deployment: start, investmentDeadline, airdropDeadline } = useClaimTimeInfo()
 
@@ -183,7 +183,7 @@ export default function ClaimsTable({ isAirdropOnly, claims, hasClaims }: Claims
           </tbody>
         </table>
       </ClaimTable>
-      <ExternalLink href={cowLinks.vCowPost}>
+      <ExternalLink href={claimLinks.vCowPost}>
         <BannerExplainer>
           <SVG src={CowProtocolImage} description="Questions? Read More." />
           <span>

--- a/src/custom/pages/Claim/InvestmentFlow/index.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/index.tsx
@@ -23,7 +23,7 @@ import {
   useClaimDispatchers,
   useHasClaimInvestmentFlowError,
   useSomeNotTouched,
-  useCowLinks,
+  useClaimLinks,
 } from 'state/claim/hooks'
 import { ClaimStatus } from 'state/claim/actions'
 import { InvestClaim } from 'state/claim/reducer'
@@ -153,7 +153,7 @@ export default function InvestmentFlow({ claims, hasClaims, isAirdropOnly, modal
   const { selected, activeClaimAccount, claimStatus, isInvestFlowActive, investFlowStep, investFlowData } =
     useClaimState()
   const { initInvestFlowData } = useClaimDispatchers()
-  const cowLinks = useCowLinks()
+  const claimLinks = useClaimLinks()
 
   const hasError = useHasClaimInvestmentFlowError()
   const someNotTouched = useSomeNotTouched()
@@ -204,7 +204,7 @@ export default function InvestmentFlow({ claims, hasClaims, isAirdropOnly, modal
           <p>
             You have chosen to exercise one or more investment opportunities alongside claiming your airdrop. Exercising
             your investment options will give you the chance to acquire vCOW tokens at a fixed price. Read{' '}
-            <ExternalLink href={cowLinks.stepGuide}> the step by step guide</ExternalLink> for more details on the
+            <ExternalLink href={claimLinks.stepGuide}> the step by step guide</ExternalLink> for more details on the
             claiming process.
           </p>
           <StepExplainer>
@@ -221,7 +221,7 @@ export default function InvestmentFlow({ claims, hasClaims, isAirdropOnly, modal
               </p>
             </span>
           </StepExplainer>
-          <ExternalLink href={cowLinks.vCowPost}>
+          <ExternalLink href={claimLinks.vCowPost}>
             <BannerExplainer>
               <SVG src={CowProtocolImage} description="Read more" />
               <span>

--- a/src/custom/pages/Claim/InvestmentFlow/index.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/index.tsx
@@ -23,6 +23,7 @@ import {
   useClaimDispatchers,
   useHasClaimInvestmentFlowError,
   useSomeNotTouched,
+  useCowLinks,
 } from 'state/claim/hooks'
 import { ClaimStatus } from 'state/claim/actions'
 import { InvestClaim } from 'state/claim/reducer'
@@ -32,7 +33,6 @@ import { useActiveWeb3React } from 'hooks/web3'
 
 import InvestOption from './InvestOption'
 import { ClaimCommonTypes, ClaimWithInvestmentData, EnhancedUserClaimData } from '../types'
-import { COW_LINKS } from 'pages/Claim'
 import { ExternalLink } from 'theme'
 import { ExplorerLink } from 'components/ExplorerLink'
 import { ExplorerDataType } from 'utils/getExplorerLink'
@@ -153,6 +153,7 @@ export default function InvestmentFlow({ claims, hasClaims, isAirdropOnly, modal
   const { selected, activeClaimAccount, claimStatus, isInvestFlowActive, investFlowStep, investFlowData } =
     useClaimState()
   const { initInvestFlowData } = useClaimDispatchers()
+  const cowLinks = useCowLinks()
 
   const hasError = useHasClaimInvestmentFlowError()
   const someNotTouched = useSomeNotTouched()
@@ -203,7 +204,7 @@ export default function InvestmentFlow({ claims, hasClaims, isAirdropOnly, modal
           <p>
             You have chosen to exercise one or more investment opportunities alongside claiming your airdrop. Exercising
             your investment options will give you the chance to acquire vCOW tokens at a fixed price. Read{' '}
-            <ExternalLink href={COW_LINKS.stepGuide}> the step by step guide</ExternalLink> for more details on the
+            <ExternalLink href={cowLinks.stepGuide}> the step by step guide</ExternalLink> for more details on the
             claiming process.
           </p>
           <StepExplainer>
@@ -220,7 +221,7 @@ export default function InvestmentFlow({ claims, hasClaims, isAirdropOnly, modal
               </p>
             </span>
           </StepExplainer>
-          <ExternalLink href={COW_LINKS.vCowPost}>
+          <ExternalLink href={cowLinks.vCowPost}>
             <BannerExplainer>
               <SVG src={CowProtocolImage} description="Read more" />
               <span>

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -29,12 +29,6 @@ import { ClaimSummary } from './ClaimSummary'
 
 import usePrevious from 'hooks/usePrevious'
 
-/* TODO: Replace URLs with the actual final URL destinations */
-export const COW_LINKS = {
-  vCowPost: 'https://cow.fi/',
-  stepGuide: 'https://cow.fi/',
-}
-
 export default function Claim() {
   const { account, chainId } = useActiveWeb3React()
   const { error } = useWeb3React()

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -983,7 +983,7 @@ function _getPrice({ token, amount }: { amount: string; token: Token | GpEther }
  * Returns vCow claim blog posts based on chainId
  */
 const COW_BLOG_LINKS_ROOT = 'https://cow-protocol.medium.com'
-export const useCowLinks = () => {
+export const useClaimLinks = () => {
   const { chainId } = useActiveWeb3React()
 
   return useMemo(

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -978,3 +978,19 @@ function _getPrice({ token, amount }: { amount: string; token: Token | GpEther }
     quoteAmount: CurrencyAmount.fromRawAmount(token, amount),
   }).invert()
 }
+
+/**
+ * Returns vCow claim blog posts based on chainId
+ */
+const COW_LINKS_ROOT = 'https://cow-protocol.medium.com'
+export const useCowLinks = () => {
+  const { chainId } = useActiveWeb3React()
+
+  return useMemo(
+    () => ({
+      vCowPost: `${COW_LINKS_ROOT}/7689c4391373`,
+      stepGuide: `${COW_LINKS_ROOT}/${chainId === SupportedChainId.XDAI ? 'b1a1442a3454' : '33ae0910d53f'}`,
+    }),
+    [chainId]
+  )
+}

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -982,14 +982,14 @@ function _getPrice({ token, amount }: { amount: string; token: Token | GpEther }
 /**
  * Returns vCow claim blog posts based on chainId
  */
-const COW_LINKS_ROOT = 'https://cow-protocol.medium.com'
+const COW_BLOG_LINKS_ROOT = 'https://cow-protocol.medium.com'
 export const useCowLinks = () => {
   const { chainId } = useActiveWeb3React()
 
   return useMemo(
     () => ({
-      vCowPost: `${COW_LINKS_ROOT}/7689c4391373`,
-      stepGuide: `${COW_LINKS_ROOT}/${chainId === SupportedChainId.XDAI ? 'b1a1442a3454' : '33ae0910d53f'}`,
+      vCowPost: `${COW_BLOG_LINKS_ROOT}/7689c4391373`,
+      stepGuide: `${COW_BLOG_LINKS_ROOT}/${chainId === SupportedChainId.XDAI ? 'b1a1442a3454' : '33ae0910d53f'}`,
     }),
     [chainId]
   )


### PR DESCRIPTION
# Summary

Claim blog links should point to correct articles now, as a reference see this msg https://gnosisinc.slack.com/archives/C025G521XQD/p1644256674411799

These links should lead to vCowPost https://cow-protocol.medium.com/7689c4391373
![Screenshot from 2022-02-09 11-30-01](https://user-images.githubusercontent.com/34926005/153180512-c5198039-7fdc-4c82-b5be-7a8137e22a64.png)
![Screenshot from 2022-02-09 11-30-34](https://user-images.githubusercontent.com/34926005/153180518-a9f5f116-ba9f-45c6-aa15-f1d260cc6091.png)
![Screenshot from 2022-02-09 11-32-21](https://user-images.githubusercontent.com/34926005/153180521-dccf6b89-f086-40ce-87b0-565a14aded08.png)

This link should lead to step by step guide and it should be different based on if the selected chain is Ethereum or Gnosis Chain
![Screenshot from 2022-02-09 11-30-49](https://user-images.githubusercontent.com/34926005/153180647-7a428715-1eb7-47ce-ae86-a81793308845.png)

