### PR TITLE
Show claimed context when already claimed

### DIFF
--- a/src/custom/pages/Claim/CanUserClaimMessage.tsx
+++ b/src/custom/pages/Claim/CanUserClaimMessage.tsx
@@ -10,9 +10,17 @@ import { ExternalLink } from 'theme/index'
 import SVG from 'react-inlinesvg'
 import CowProtocolImage from 'assets/cow-swap/cowprotocol.svg'
 
-type ClaimIntroductionProps = Pick<ClaimCommonTypes, 'hasClaims' | 'handleChangeAccount' | 'isAirdropOnly'>
+type ClaimIntroductionProps = Pick<
+  ClaimCommonTypes,
+  'hasClaims' | 'isClaimed' | 'handleChangeAccount' | 'isAirdropOnly'
+>
 
-export default function CanUserClaimMessage({ hasClaims, isAirdropOnly, handleChangeAccount }: ClaimIntroductionProps) {
+export default function CanUserClaimMessage({
+  hasClaims,
+  isClaimed,
+  isAirdropOnly,
+  handleChangeAccount,
+}: ClaimIntroductionProps) {
   const { activeClaimAccount, claimStatus } = useClaimState()
   const network = useNetworkName()
 
@@ -48,11 +56,14 @@ export default function CanUserClaimMessage({ hasClaims, isAirdropOnly, handleCh
     )
   }
 
-  if (!hasClaims) {
+  if (!hasClaims || isClaimed) {
     return (
       <IntroDescription center>
         <Trans>
-          Unfortunately this account is not eligible for any vCOW claims in {network}. <br />
+          {isClaimed
+            ? 'This account already claimed vCOW'
+            : 'Unfortunately this account is not eligible for any vCOW claims'}{' '}
+          in {network}. <br />
           <ButtonSecondary onClick={handleChangeAccount} padding="0">
             Try another account
           </ButtonSecondary>{' '}

--- a/src/custom/pages/Claim/CanUserClaimMessage.tsx
+++ b/src/custom/pages/Claim/CanUserClaimMessage.tsx
@@ -60,10 +60,13 @@ export default function CanUserClaimMessage({
     return (
       <IntroDescription center>
         <Trans>
-          {isClaimed
-            ? 'This account already claimed vCOW'
-            : 'Unfortunately this account is not eligible for any vCOW claims'}{' '}
-          in {network}. <br />
+          {isClaimed ? (
+            ''
+          ) : (
+            <>
+              Unfortunately this account is not eligible for any vCOW claims in {network}. <br />
+            </>
+          )}
           <ButtonSecondary onClick={handleChangeAccount} padding="0">
             Try another account
           </ButtonSecondary>{' '}

--- a/src/custom/pages/Claim/ClaimBanner.tsx
+++ b/src/custom/pages/Claim/ClaimBanner.tsx
@@ -5,12 +5,14 @@ import CheckCircle from 'assets/cow-swap/check.svg'
 import { ClaimStatus } from 'state/claim/actions'
 import SVG from 'react-inlinesvg'
 import { ClaimCommonTypes } from 'pages/Claim/types'
+import useNetworkName from 'hooks/useNetworkName'
 
 type ClaimBannerProps = Pick<ClaimCommonTypes, 'hasClaims'> & {
   isClaimed: boolean
 }
 
 export default function ClaimBanner({ hasClaims, isClaimed }: ClaimBannerProps) {
+  const networkName = useNetworkName()
   const { claimStatus, activeClaimAccount, isInvestFlowActive } = useClaimState()
 
   const shouldShowBanner =
@@ -24,7 +26,7 @@ export default function ClaimBanner({ hasClaims, isClaimed }: ClaimBannerProps) 
       <Trans>
         {hasClaims
           ? 'This account is eligible for vCOW token claims!'
-          : 'This account has already claimed vCOW tokens!'}
+          : `This account has already claimed vCOW tokens${networkName && ' on ' + networkName}!`}
       </Trans>
     </ClaimBannerWrapper>
   )

--- a/src/custom/pages/Claim/ClaimSummary.tsx
+++ b/src/custom/pages/Claim/ClaimSummary.tsx
@@ -7,23 +7,31 @@ import { ClaimSummary as ClaimSummaryWrapper, ClaimSummaryTitle, ClaimTotal } fr
 import { ClaimCommonTypes } from './types'
 import { ClaimStatus } from 'state/claim/actions'
 import { AMOUNT_PRECISION } from 'constants/index'
+import { useTokenBalance } from '@src/state/wallet/hooks'
+import { V_COW } from 'constants/tokens'
+import { useActiveWeb3React } from 'hooks'
 
-type ClaimSummaryProps = Pick<ClaimCommonTypes, 'hasClaims'> & {
+type ClaimSummaryProps = Pick<ClaimCommonTypes, 'hasClaims' | 'isClaimed'> & {
   unclaimedAmount: ClaimCommonTypes['tokenCurrencyAmount'] | undefined
 }
 
-export function ClaimSummary({ hasClaims, unclaimedAmount }: ClaimSummaryProps) {
+export function ClaimSummary({ hasClaims, isClaimed, unclaimedAmount }: ClaimSummaryProps) {
+  const { chainId } = useActiveWeb3React()
   const { activeClaimAccount, claimStatus, isInvestFlowActive } = useClaimState()
+
+  const vCowBalance = useTokenBalance(activeClaimAccount || undefined, chainId ? V_COW[chainId] : undefined)
 
   const hasClaimSummary = claimStatus === ClaimStatus.DEFAULT && !isInvestFlowActive
 
   if (!hasClaimSummary) return null
 
+  const totalAvailableAmount = hasClaims && activeClaimAccount && unclaimedAmount ? unclaimedAmount : vCowBalance
+
   return (
     <ClaimSummaryView
       showClaimText={!activeClaimAccount && !hasClaims}
-      totalAvailableAmount={(activeClaimAccount && unclaimedAmount) || undefined}
-      totalAvailableText={'Total available to claim'}
+      totalAvailableAmount={totalAvailableAmount}
+      totalAvailableText={isClaimed ? 'Total claimed' : 'Total available to claim'}
     />
   )
 }

--- a/src/custom/pages/Claim/ClaimSummary.tsx
+++ b/src/custom/pages/Claim/ClaimSummary.tsx
@@ -7,7 +7,7 @@ import { ClaimSummary as ClaimSummaryWrapper, ClaimSummaryTitle, ClaimTotal } fr
 import { ClaimCommonTypes } from './types'
 import { ClaimStatus } from 'state/claim/actions'
 import { AMOUNT_PRECISION } from 'constants/index'
-import { useTokenBalance } from '@src/state/wallet/hooks'
+import { useTokenBalance } from 'state/wallet/hooks'
 import { V_COW } from 'constants/tokens'
 import { useActiveWeb3React } from 'hooks'
 

--- a/src/custom/pages/Claim/FooterNavButtons.tsx
+++ b/src/custom/pages/Claim/FooterNavButtons.tsx
@@ -15,7 +15,7 @@ import { useActiveWeb3React } from 'hooks/web3'
 import { ClaimAddressProps } from './ClaimAddress'
 import { ClaimCommonTypes } from 'pages/Claim/types'
 
-type FooterNavButtonsProps = Pick<ClaimCommonTypes, 'hasClaims' | 'isAirdropOnly'> &
+type FooterNavButtonsProps = Pick<ClaimCommonTypes, 'hasClaims' | 'isClaimed' | 'isAirdropOnly'> &
   Pick<ClaimAddressProps, 'toggleWalletModal'> & {
     isPaidClaimsOnly: boolean
     resolvedAddress: string | null
@@ -25,6 +25,7 @@ type FooterNavButtonsProps = Pick<ClaimCommonTypes, 'hasClaims' | 'isAirdropOnly
 
 export default function FooterNavButtons({
   hasClaims,
+  isClaimed,
   isAirdropOnly,
   isPaidClaimsOnly,
   resolvedAddress,
@@ -69,8 +70,16 @@ export default function FooterNavButtons({
   }, [activeClaimAccount])
 
   let buttonContent: ReactNode = null
+  // Already claimed
+  if (isClaimed) {
+    buttonContent = (
+      <ButtonPrimary ref={buttonRef} onClick={toggleWalletModal} disabled>
+        <Trans>Already claimed</Trans>
+      </ButtonPrimary>
+    )
+  }
   // Disconnected, show wallet connect
-  if (!account && activeClaimAccount) {
+  else if (!account && activeClaimAccount) {
     buttonContent = (
       <ButtonPrimary ref={buttonRef} onClick={toggleWalletModal}>
         <Trans>Connect a wallet</Trans>

--- a/src/custom/pages/Claim/FooterNavButtons.tsx
+++ b/src/custom/pages/Claim/FooterNavButtons.tsx
@@ -70,19 +70,20 @@ export default function FooterNavButtons({
   }, [activeClaimAccount])
 
   let buttonContent: ReactNode = null
-  // Already claimed
-  if (isClaimed) {
-    buttonContent = (
-      <ButtonPrimary ref={buttonRef} onClick={toggleWalletModal} disabled>
-        <Trans>Already claimed</Trans>
-      </ButtonPrimary>
-    )
-  }
+
   // Disconnected, show wallet connect
-  else if (!account && activeClaimAccount) {
+  if (!account && activeClaimAccount) {
     buttonContent = (
       <ButtonPrimary ref={buttonRef} onClick={toggleWalletModal}>
         <Trans>Connect a wallet</Trans>
+      </ButtonPrimary>
+    )
+  }
+  // Already claimed
+  else if (isClaimed) {
+    buttonContent = (
+      <ButtonPrimary ref={buttonRef} onClick={toggleWalletModal} disabled>
+        <Trans>Already claimed</Trans>
       </ButtonPrimary>
     )
   }

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -254,6 +254,7 @@ export default function Claim() {
             {/* Is Airdrop only (simple) - does user have claims? Show messages dependent on claim state */}
             <CanUserClaimMessage
               hasClaims={hasClaims}
+              isClaimed={isClaimed}
               isAirdropOnly={isAirdropOnly}
               handleChangeAccount={handleChangeClick}
             />

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -248,7 +248,7 @@ export default function Claim() {
             {/* Show banner that tells if user has available claims or has already claimed all */}
             <ClaimBanner isClaimed={isClaimed} hasClaims={hasClaims} />
             {/* Show total to claim (user has airdrop or airdrop+investment) */}
-            <ClaimSummary hasClaims={hasClaims} unclaimedAmount={unclaimedAmount} />
+            <ClaimSummary hasClaims={hasClaims} unclaimedAmount={unclaimedAmount} isClaimed={isClaimed} />
             {/* Get address/ENS (user not connected yet or opted for checking 'another' account) */}
             <ClaimAddress account={account} toggleWalletModal={toggleWalletModal} />
             {/* Is Airdrop only (simple) - does user have claims? Show messages dependent on claim state */}

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -278,6 +278,7 @@ export default function Claim() {
               isAirdropOnly={isAirdropOnly}
               isPaidClaimsOnly={isPaidClaimsOnly}
               hasClaims={hasClaims}
+              isClaimed={isClaimed}
               resolvedAddress={resolvedAddress}
             />
           </>

--- a/src/custom/pages/Claim/types.ts
+++ b/src/custom/pages/Claim/types.ts
@@ -6,6 +6,7 @@ import { GpEther } from 'constants/tokens'
 export type ClaimCommonTypes = {
   account: string | null | undefined
   hasClaims: boolean
+  isClaimed: boolean
   claims: EnhancedUserClaimData[]
   isAirdropOnly: boolean
   tokenCurrencyAmount: CurrencyAmount<Token>


### PR DESCRIPTION
# Summary

Continues work started by Nenad adding a bit more context when claim is already claimed

![Screen Shot 2022-02-09 at 13 57 44](https://user-images.githubusercontent.com/43217/153298247-39e498ad-e2fc-479d-a3d7-886a6723fe7e.png)

  # To Test

1. Claim everything with one account
* You should see the amount of vCOW claimed for that account
* You should see an updated body and button text as well
2. Check other states (account with no claims and account with claims)
* Should remain as they where