### PR TITLE
Fix avilable claims issue on rinkeby

### DIFF
--- a/src/custom/pages/Claim/InvestmentFlow/index.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/index.tsx
@@ -265,7 +265,11 @@ export default function InvestmentFlow({ claims, hasClaims, isAirdropOnly, modal
       {/* Invest flow: Step 2 > Review summary */}
       {investFlowStep === 2 ? (
         <InvestContent>
-          <ClaimSummaryView totalAvailableAmount={totalVCow} totalAvailableText={'Total amount to claim'} />
+          <ClaimSummaryView
+            activeClaimAccount={activeClaimAccount}
+            totalAvailableAmount={totalVCow}
+            totalAvailableText={'Total amount to claim'}
+          />
           <ClaimTable>
             <InvestSummaryTable>
               <thead>


### PR DESCRIPTION
# Summary

Fixes #2419

This scenario happens when there are no claimed or available claims but there is vCow balance, which means that user somehow has vCow balance but he didn't claim anything. So this probably shouldn't happen on Mainet or Gnosis Chain but happens on Rinkeby on accounts where you have vCow tokens from previous vCow contract deployments.