### PR TITLE
1867 - Add network if nonexistent

### DIFF
--- a/src/custom/constants/chains/chainsMod.ts
+++ b/src/custom/constants/chains/chainsMod.ts
@@ -168,9 +168,10 @@ export const CHAIN_INFO: ChainInfo = {
   }, */
   [SupportedChainId.XDAI]: {
     docs: 'https://docs.uniswap.org/',
-    explorer: 'https://blockscout.com/xdai/mainnet/  ',
+    explorer: 'https://blockscout.com/xdai/mainnet/',
     infoLink: '',
     label: 'Gnosis Chain',
+    rpcUrls: ['https://rpc.gnosischain.com/'],
     logoUrl: GnosisChainLogo, // mod
     nativeCurrency: { name: 'xDai', symbol: 'XDAI', decimals: 18 },
   },

--- a/src/custom/utils/addNetwork.ts
+++ b/src/custom/utils/addNetwork.ts
@@ -1,0 +1,36 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { hexStripZeros } from '@ethersproject/bytes'
+import { Web3Provider } from '@ethersproject/providers'
+import { L1ChainInfo, L2ChainInfo, SupportedChainId } from 'constants/chains'
+
+interface AddNetworkArguments {
+  library: Web3Provider
+  chainId: SupportedChainId
+  info: L1ChainInfo | L2ChainInfo
+}
+
+// provider.request returns Promise<any>, but wallet_switchEthereumChain must return null or throw
+// see https://github.com/rekmarks/EIPs/blob/3326-create/EIPS/eip-3326.md for more info on wallet_switchEthereumChain
+export async function addNetwork({ library, chainId, info }: AddNetworkArguments): Promise<null | void> {
+  if (!library?.provider?.request) {
+    return
+  }
+  const formattedChainId = hexStripZeros(BigNumber.from(chainId).toHexString())
+  try {
+    await library?.provider.request({
+      method: 'wallet_addEthereumChain',
+      params: [
+        {
+          chainId: formattedChainId,
+          chainName: info.label,
+          rpcUrls: info.rpcUrls,
+          nativeCurrency: info.nativeCurrency,
+          blockExplorerUrls: [info.explorer],
+        },
+      ],
+    })
+  } catch (error) {
+    console.error('error adding eth network: ', chainId, info, error)
+    throw new Error(error?.message)
+  }
+}

--- a/src/custom/utils/switchToNetwork.ts
+++ b/src/custom/utils/switchToNetwork.ts
@@ -1,0 +1,47 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { hexStripZeros } from '@ethersproject/bytes'
+import { Web3Provider } from '@ethersproject/providers'
+import { CHAIN_INFO, SupportedChainId } from 'constants/chains'
+
+import { addNetwork } from 'utils/addNetwork'
+
+interface SwitchNetworkArguments {
+  library: Web3Provider
+  chainId?: SupportedChainId
+}
+
+// provider.request returns Promise<any>, but wallet_switchEthereumChain must return null or throw
+// see https://github.com/rekmarks/EIPs/blob/3326-create/EIPS/eip-3326.md for more info on wallet_switchEthereumChain
+export async function switchToNetwork({ library, chainId }: SwitchNetworkArguments): Promise<null | void> {
+  if (!library?.provider?.request) {
+    return
+  }
+  if (!chainId && library?.getNetwork) {
+    ;({ chainId } = await library.getNetwork())
+  }
+  const formattedChainId = hexStripZeros(BigNumber.from(chainId).toHexString())
+  try {
+    await library?.provider.request({
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId: formattedChainId }],
+    })
+  } catch (error) {
+    // 4902 is the error code for attempting to switch to an unrecognized chainId
+    if (error.code === 4902 && chainId !== undefined) {
+      const info = CHAIN_INFO[chainId]
+
+      // MOD - need to handle these errors, else loops
+      try {
+        // metamask (only known implementer) automatically switches after a network is added
+        // the second call is done here because that behavior is not a part of the spec and cannot be relied upon in the future
+        // metamask's behavior when switching to the current network is just to return null (a no-op)
+        await addNetwork({ library, chainId, info })
+        await switchToNetwork({ library, chainId })
+      } catch (error) {
+        console.error(`Error in ADDING/SWITCHING ${chainId}:`, error)
+      }
+    } else {
+      throw error
+    }
+  }
+}


### PR DESCRIPTION
Closes #1867 

## Summary
Adds correct network adding logic when chain NOT in MM, fixes loop error and chain info object type (uni related)

## Screenies
<img width="1055" alt="image" src="https://user-images.githubusercontent.com/21335563/154079876-be385d1f-48b7-4dfc-afbe-079f0608b37e.png">

## TESTING
1. remove XDAI/Gnosis Chain from metamask
2. from ETHEREUM, change to Gnosis Chain
3. Should see what i screenshotted
4. Should switch to chain
5. Cancelling should not loop and log correctly