### PR TITLE
Fix inverted invested amounts

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -53,7 +53,7 @@ export const GP_VAULT_RELAYER: Partial<Record<number, string>> = {
 export const V_COW_CONTRACT_ADDRESS: Record<number, string> = {
   [ChainId.MAINNET]: '0xd057b63f5e69cf1b929b356b579cba08d7688048',
   [ChainId.XDAI]: '0xc20C9C13E853fc64d054b73fF21d3636B2d97eaB',
-  [ChainId.RINKEBY]: '0x5Bf4d1f8d1cB35E0aeA69B220beb97b8807504eA',
+  [ChainId.RINKEBY]: '0xa87bEa56b614Cf9b04f528B0E320Fb427B716709',
 }
 
 // See https://github.com/gnosis/gp-v2-contracts/commit/821b5a8da213297b0f7f1d8b17c893c5627020af#diff-12bbbe13cd5cf42d639e34a39d8795021ba40d3ee1e1a8282df652eb161a11d6R13

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -53,7 +53,7 @@ export const GP_VAULT_RELAYER: Partial<Record<number, string>> = {
 export const V_COW_CONTRACT_ADDRESS: Record<number, string> = {
   [ChainId.MAINNET]: '0xd057b63f5e69cf1b929b356b579cba08d7688048',
   [ChainId.XDAI]: '0xc20C9C13E853fc64d054b73fF21d3636B2d97eaB',
-  [ChainId.RINKEBY]: '0xa87bEa56b614Cf9b04f528B0E320Fb427B716709',
+  [ChainId.RINKEBY]: '0x5Bf4d1f8d1cB35E0aeA69B220beb97b8807504eA',
 }
 
 // See https://github.com/gnosis/gp-v2-contracts/commit/821b5a8da213297b0f7f1d8b17c893c5627020af#diff-12bbbe13cd5cf42d639e34a39d8795021ba40d3ee1e1a8282df652eb161a11d6R13

--- a/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/InvestOption.tsx
@@ -62,13 +62,12 @@ const WarningMessages = {
 
 type InvestOptionProps = {
   claim: EnhancedUserClaimData
-  optionIndex: number
   openModal: InvestmentFlowProps['modalCbs']['openModal']
   closeModal: InvestmentFlowProps['modalCbs']['closeModal']
 }
 
-export default function InvestOption({ claim, optionIndex, openModal, closeModal }: InvestOptionProps) {
-  const { currencyAmount, price, cost: maxCost } = claim
+export default function InvestOption({ claim, openModal, closeModal }: InvestOptionProps) {
+  const { currencyAmount, price, cost: maxCost, index } = claim
 
   const { account, chainId } = useActiveWeb3React()
   const { updateInvestAmount, updateInvestError, setIsTouched } = useClaimDispatchers()
@@ -93,26 +92,20 @@ export default function InvestOption({ claim, optionIndex, openModal, closeModal
   const [typedValue, setTypedValue] = useState<string>('')
   const [inputWarnings, setInputWarnings] = useState<string[]>([])
 
-  const investedAmount = investFlowData[optionIndex].investedAmount
-  const inputError = investFlowData[optionIndex].error
-  const isTouched = investFlowData[optionIndex].isTouched
+  const investedAmount = investFlowData[index].investedAmount
+  const inputError = investFlowData[index].error
+  const isTouched = investFlowData[index].isTouched
 
   // Syntactic sugar fns for setting/resetting global state
   const setInvestedAmount = useCallback(
-    (amount: string) => updateInvestAmount({ index: optionIndex, amount }),
-    [optionIndex, updateInvestAmount]
+    (amount: string) => updateInvestAmount({ index, amount }),
+    [index, updateInvestAmount]
   )
-  const setInputError = useCallback(
-    (error: string) => updateInvestError({ index: optionIndex, error }),
-    [optionIndex, updateInvestError]
-  )
-  const resetInputError = useCallback(
-    () => updateInvestError({ index: optionIndex, error: undefined }),
-    [optionIndex, updateInvestError]
-  )
+  const setInputError = useCallback((error: string) => updateInvestError({ index, error }), [index, updateInvestError])
+  const resetInputError = useCallback(() => updateInvestError({ index, error: undefined }), [index, updateInvestError])
   const setInputTouched = useCallback(
-    (value: boolean) => setIsTouched({ index: optionIndex, isTouched: value }),
-    [optionIndex, setIsTouched]
+    (value: boolean) => setIsTouched({ index, isTouched: value }),
+    [index, setIsTouched]
   )
 
   const token = currencyAmount?.currency

--- a/src/custom/pages/Claim/InvestmentFlow/index.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/index.tsx
@@ -94,11 +94,9 @@ function _classifyAndFilterClaimData(claimData: EnhancedUserClaimData[], selecte
 
 function _enhancedUserClaimToClaimWithInvestment(
   claim: EnhancedUserClaimData,
-  investFlowData: InvestClaim[]
+  investFlowData: Record<number, InvestClaim>
 ): ClaimWithInvestmentData {
-  const investmentAmount = claim.isFree
-    ? undefined
-    : investFlowData.find(({ index }) => index === claim.index)?.investedAmount
+  const investmentAmount = claim.isFree ? undefined : investFlowData[claim.index]?.investedAmount
 
   return { ...claim, ...calculateInvestmentAmounts(claim, investmentAmount) }
 }

--- a/src/custom/pages/Claim/InvestmentFlow/index.tsx
+++ b/src/custom/pages/Claim/InvestmentFlow/index.tsx
@@ -242,8 +242,8 @@ export default function InvestmentFlow({ claims, hasClaims, isAirdropOnly, modal
             up to a predefined maximum amount of tokens{' '}
           </p>
 
-          {selectedClaims.map((claim, index) => (
-            <InvestOption key={claim.index} optionIndex={index} claim={claim} {...modalCbs} />
+          {selectedClaims.map((claim) => (
+            <InvestOption key={claim.index} claim={claim} {...modalCbs} />
           ))}
 
           {hasError && (

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -887,7 +887,7 @@ export function useHasClaimInvestmentFlowError(): boolean {
   const { investFlowData } = useClaimState()
 
   return useMemo(() => {
-    return investFlowData.some(({ error }) => Boolean(error))
+    return Object.values(investFlowData).some(({ error }) => Boolean(error))
   }, [investFlowData])
 }
 
@@ -898,7 +898,7 @@ export function useSomeNotTouched(): boolean {
   const { investFlowData } = useClaimState()
 
   return useMemo(() => {
-    return investFlowData.some(({ isTouched }) => !isTouched)
+    return Object.values(investFlowData).some(({ isTouched }) => !isTouched)
   }, [investFlowData])
 }
 
@@ -909,7 +909,7 @@ export function useHasZeroInvested(): boolean {
   const { investFlowData } = useClaimState()
 
   return useMemo(() => {
-    return investFlowData.some(({ investedAmount }) => investedAmount === '0')
+    return Object.values(investFlowData).some(({ investedAmount }) => investedAmount === '0')
   }, [investFlowData])
 }
 

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -62,7 +62,7 @@ import useIsMounted from 'hooks/useIsMounted'
 import { ChainId } from '@uniswap/sdk'
 import { ClaimInfo } from 'state/claim/reducer'
 
-const CLAIMS_REPO_BRANCH = 'gip-13'
+const CLAIMS_REPO_BRANCH = '2022-02-15_Rinkeby-full'
 export const CLAIMS_REPO = `https://raw.githubusercontent.com/gnosis/cow-merkle-drop/${CLAIMS_REPO_BRANCH}/`
 
 // Base amount = 1 VCOW

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -62,7 +62,7 @@ import useIsMounted from 'hooks/useIsMounted'
 import { ChainId } from '@uniswap/sdk'
 import { ClaimInfo } from 'state/claim/reducer'
 
-const CLAIMS_REPO_BRANCH = '2022-02-15_Rinkeby-full'
+const CLAIMS_REPO_BRANCH = 'gip-13'
 export const CLAIMS_REPO = `https://raw.githubusercontent.com/gnosis/cow-merkle-drop/${CLAIMS_REPO_BRANCH}/`
 
 // Base amount = 1 VCOW

--- a/src/custom/state/claim/hooks/utils.ts
+++ b/src/custom/state/claim/hooks/utils.ts
@@ -184,8 +184,11 @@ export function calculateInvestmentAmounts(
 /**
  * Helper function that prepares investFlowData for claiming by calculating vCowAmount from investedAmounts
  */
-export function prepareInvestClaims(investFlowData: InvestClaim[], userClaimData: EnhancedUserClaimData[]) {
-  return investFlowData.reduce<ClaimInput[]>((acc, { index, investedAmount }) => {
+export function prepareInvestClaims(
+  investFlowData: Record<number, InvestClaim>,
+  userClaimData: EnhancedUserClaimData[]
+) {
+  return Object.values(investFlowData).reduce<ClaimInput[]>((acc, { index, investedAmount }) => {
     const claim = userClaimData.find(({ index: idx }) => idx === index)
 
     if (claim) {

--- a/src/custom/state/claim/reducer.ts
+++ b/src/custom/state/claim/reducer.ts
@@ -58,7 +58,7 @@ export const initialState: ClaimState = {
   // investment
   isInvestFlowActive: false,
   investFlowStep: 0,
-  investFlowData: [],
+  investFlowData: {},
   // table select change
   selected: [],
   selectedAll: false,
@@ -88,7 +88,7 @@ export type ClaimState = {
   // investment
   isInvestFlowActive: boolean
   investFlowStep: number
-  investFlowData: InvestClaim[]
+  investFlowData: Record<number, InvestClaim>
   // table select change
   selected: number[]
   selectedAll: boolean
@@ -147,12 +147,13 @@ export default createReducer(initialState, (builder) =>
     .addCase(initInvestFlowData, (state) => {
       const { selected, isInvestFlowActive } = current(state)
 
-      const data = selected.map((index) => ({ index, investedAmount: '0' }))
-
       if (isInvestFlowActive) {
-        state.investFlowData.push(...data)
+        state.investFlowData = selected.reduce<Record<number, InvestClaim>>((acc, index) => {
+          acc[index] = { index, investedAmount: '0' }
+          return acc
+        }, {})
       } else {
-        state.investFlowData.length = 0
+        state.investFlowData = {}
       }
     })
     .addCase(updateInvestAmount, (state, { payload: { index, amount } }) => {


### PR DESCRIPTION
# Summary

Closes #2423

Fixing issue that under some circumstances will result in the investment amounts being inverted.

Keep in mind this only happens when there are at least 2 investment options selected.

  # To Test

1. With any account that has 2 or more investment options, load it in the claim ui
2. When selecting the claims, start ticking the boxes from bottom up of at least 2 claims
3. On investment screen, opt to invest max amount on all
4. Proceed to review screen
* Amounts selected should match the previous screen

If you test the same thing on Prod or anywhere else that doesn't have this fix, it'll have the amounts inverted, like in this video

https://user-images.githubusercontent.com/43217/154154098-519c0f2a-c04c-4d14-a3d1-50dae2a7ee3b.mov

