### PR TITLE
Remove "cross" icon from claims available banner

### DIFF
--- a/src/custom/pages/Claim/ClaimsOnOtherChainsBanner.tsx
+++ b/src/custom/pages/Claim/ClaimsOnOtherChainsBanner.tsx
@@ -97,7 +97,7 @@ function ClaimsOnOtherChainsBanner({ className }: { className?: string }) {
   }
 
   return (
-    <NotificationBanner className={className} isVisible id={account ?? undefined} level="info">
+    <NotificationBanner className={className} isVisible id={account ?? undefined} level="info" canClose={false}>
       <Wrapper>
         <AlertTriangle />
         <div>This account has available claims on</div>


### PR DESCRIPTION
# Summary

Closes #2418

<img width="890" alt="image" src="https://user-images.githubusercontent.com/21335563/154294248-38ca0acf-1689-41c6-971b-67e4890fcded.png">
