### PR TITLE
Fix race condition when replacing/cancelling on-chain txs

### DIFF
--- a/src/custom/state/enhancedTransactions/updater/CancelReplaceTxUpdater.tsx
+++ b/src/custom/state/enhancedTransactions/updater/CancelReplaceTxUpdater.tsx
@@ -60,7 +60,7 @@ export default function CancelReplaceTxUpdater(): null {
   useEffect(() => {
     if (!chainId || !library) return
 
-    // Watch the mempool for cancelation/replacement of tx
+    // Watch the mempool for cancellation/replacement of tx
     watchTxChanges(pendingHashes, chainId, dispatch)
 
     return () => {


### PR DESCRIPTION
# Summary

Close #1832 

This fixes the case where an on-chain tx (wrap/unwrap/approve) is sent and then the user decides to either Cancel or Speed-up that tx. Two things can happen:
1. The Cancel/Speed-up tx wins and gets mined before the original tx. This scenario was already working fine
2. The original tx gets mined before the Cancel/Speed-up one. This scenario was causing issues

The solution avoids removing the old tx from the transactions state, so the perceived UI change is that now both transactions are going to be visible in the Recent Activities modal, and after one gets mined, the other is removed.
