### PR TITLE
Optimize bn.js package

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -48,6 +48,7 @@ module.exports = {
     plugins,
     alias: {
       '@src': path.resolve(__dirname, 'src'),
+      'bn.js': path.resolve(__dirname, 'node_modules/bn.js/lib/bn.js'),
     },
     // https://webpack.js.org/configuration
     configure: (webpackConfig) => ({


### PR DESCRIPTION
# Summary

Fixes #2449

This will make sure the bn.js package is included only once in production build instead of multiple times and reduce the size of the bundle

For reference https://stackoverflow.com/a/65119222/4620771

 Before
![Screenshot from 2022-02-20 15-59-42](https://user-images.githubusercontent.com/34926005/154849130-e1865cfa-2ef5-4834-93ff-c757a18bf7ea.png)

After
![Screenshot from 2022-02-20 16-00-33](https://user-images.githubusercontent.com/34926005/154849135-73aa9a6c-c9fe-4584-a515-197e7a0a06ba.png)


### To test
- you can run `yarn build:analyze` to start webpack bundle analyzer