### PR TITLE
Fix referrer being removed from ls after a wrap/unwrap/approval tx

### DIFF
--- a/src/custom/components/AffiliateStatusCheck/index.tsx
+++ b/src/custom/components/AffiliateStatusCheck/index.tsx
@@ -37,7 +37,9 @@ export default function AffiliateStatusCheck() {
   const [affiliateState, setAffiliateState] = useState<AffiliateStatus | null>()
   const [error, setError] = useState('')
   const isFirstTrade = useRef(false)
-  const fulfilledActivity = allRecentActivity.filter((data) => data.status === OrderStatus.FULFILLED)
+  const fulfilledOrders = allRecentActivity.filter((data) => {
+    return 'appData' in data && data.status === OrderStatus.FULFILLED
+  })
 
   const notificationBannerId = useMemo(() => {
     if (!referralAddress?.value) {
@@ -61,7 +63,7 @@ export default function AffiliateStatusCheck() {
       return
     }
 
-    if (fulfilledActivity.length >= 1 && isFirstTrade.current) {
+    if (fulfilledOrders.length >= 1 && isFirstTrade.current) {
       setAffiliateState(null)
       isFirstTrade.current = false
       history.replace({ search: '' })
@@ -83,7 +85,7 @@ export default function AffiliateStatusCheck() {
 
     setAffiliateState('ACTIVE')
     isFirstTrade.current = true
-  }, [referralAddress, chainId, account, fulfilledActivity.length, history, resetReferralAddress])
+  }, [referralAddress, chainId, account, fulfilledOrders.length, history, resetReferralAddress])
 
   useEffect(() => {
     async function handleReferralAddress(referralAddress: { value: string; isValid: boolean } | undefined) {


### PR DESCRIPTION
# Summary

Close #1869 

The referrer address was being removed from storage after a successful wrap/unwrap/approval, instead of only after a successful order being executed. The solution was to filter only orders from the recent activity array.
