### PR TITLE
Hotfix 1.10.4 - Fix network switch hard error

### DIFF
--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -966,7 +966,7 @@ function _enhanceClaimData(claim: UserClaimData, chainId: SupportedChainId, pric
 
   // Free claims will have tokenAndAmount === undefined
   // If it's not a free claim, store the price and calculate cost in investment token
-  if (tokenAndAmount?.amount) {
+  if (tokenAndAmount?.amount && Number(tokenAndAmount.amount) > 0) {
     data.price = _getPrice(tokenAndAmount)
     // get the currency amount using the price base currency (remember price was inverted)
     data.currencyAmount = CurrencyAmount.fromRawAmount(data.price.baseCurrency, claim.amount)


### PR DESCRIPTION
# Summary

Closes issue discovered in #2426 by @elena-zh 
On network switch price for USDC was returning 0 breaking the price sdk

Error in prod:
![image](https://user-images.githubusercontent.com/21335563/155717343-202e2e84-dfe9-4249-a38a-33060aca3813.png)

  # To Test
1. Claim for 0x3A184b6f604d5bb98d224367641D62d8ca8C072d
2. switch to gnosis chain
3. click the banner saying there are claims on Ethereum!
4. it shouldn't error
5. it SHOULD error in prod
