### PR TITLE
Add lazy loading for all pages

### DIFF
--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -16,7 +16,7 @@ import { IS_CLAIMING_ENABLED } from 'pages/Claim/const'
 const SENTRY_DSN = process.env.REACT_APP_SENTRY_DSN
 const SENTRY_TRACES_SAMPLE_RATE = process.env.REACT_APP_SENTRY_TRACES_SAMPLE_RATE
 
-const Swap = lazy(() => import('pages/Swap'))
+const Swap = lazy(() => import(/* webpackPrefetch: true */ 'pages/Swap'))
 const Claim = lazy(() => import('pages/Claim'))
 const PrivacyPolicy = lazy(() => import('pages/PrivacyPolicy'))
 const CookiePolicy = lazy(() => import('pages/CookiePolicy'))

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -1,18 +1,9 @@
 import AppMod from './AppMod'
 import styled from 'styled-components/macro'
 import { RedirectPathToSwapOnly, RedirectToSwap } from 'pages/Swap/redirects'
+import { Suspense, lazy } from 'react'
 import { Route, Switch } from 'react-router-dom'
-import Swap from 'pages/Swap'
-import Claim from 'pages/Claim'
-import PrivacyPolicy from 'pages/PrivacyPolicy'
-import CookiePolicy from 'pages/CookiePolicy'
-import TermsAndConditions from 'pages/TermsAndConditions'
-import About from 'pages/About'
-import Profile from 'pages/Profile'
-import Faq from 'pages/Faq'
-import NotFound from 'pages/error/NotFound'
-import CowRunner from 'pages/games/CowRunner'
-import MevSlicer from 'pages/games/MevSlicer'
+
 import AnySwapAffectedUsers from 'pages/error/AnySwapAffectedUsers'
 import * as Sentry from '@sentry/react'
 import { Integrations } from '@sentry/tracing'
@@ -24,6 +15,18 @@ import { IS_CLAIMING_ENABLED } from 'pages/Claim/const'
 
 const SENTRY_DSN = process.env.REACT_APP_SENTRY_DSN
 const SENTRY_TRACES_SAMPLE_RATE = process.env.REACT_APP_SENTRY_TRACES_SAMPLE_RATE
+
+const Swap = lazy(() => import('pages/Swap'))
+const Claim = lazy(() => import('pages/Claim'))
+const PrivacyPolicy = lazy(() => import('pages/PrivacyPolicy'))
+const CookiePolicy = lazy(() => import('pages/CookiePolicy'))
+const TermsAndConditions = lazy(() => import('pages/TermsAndConditions'))
+const About = lazy(() => import('pages/About'))
+const Profile = lazy(() => import('pages/Profile'))
+const Faq = lazy(() => import('pages/Faq'))
+const NotFound = lazy(() => import('pages/error/NotFound'))
+const CowRunner = lazy(() => import('pages/games/CowRunner'))
+const MevSlicer = lazy(() => import('pages/games/MevSlicer'))
 
 if (SENTRY_DSN) {
   Sentry.init({
@@ -76,32 +79,39 @@ export default function App() {
     <>
       <RedirectAnySwapAffectedUsers />
       <Wrapper>
-        <Switch>
-          <Route exact strict path="/swap" component={Swap} />
-          <Route exact strict path="/swap/:outputCurrency" component={RedirectToSwap} />
-          <Route exact strict path="/send" component={RedirectPathToSwapOnly} />
-          {IS_CLAIMING_ENABLED && <Route exact strict path="/claim" component={Claim} />}
-          <Route exact strict path="/about" component={About} />
-          <Route exact strict path="/profile" component={Profile} />
-          <Route exact strict path="/faq" component={Faq} />
-          <Route exact strict path="/play/cow-runner" component={CowRunner} />
-          <Route exact strict path="/play/mev-slicer" component={MevSlicer} />
-          <Route exact strict path="/anyswap-affected-users" component={AnySwapAffectedUsers} />
-          <Route exact strict path="/privacy-policy" component={PrivacyPolicy} />
-          <Route exact strict path="/cookie-policy" component={CookiePolicy} />
-          <Route exact strict path="/terms-and-conditions" component={TermsAndConditions} />
-          <Route exact strict path="/chat" component={createRedirectExternal('https://chat.cowswap.exchange')} />
-          <Route exact strict path="/docs" component={createRedirectExternal('https://docs.cow.fi')} />
-          <Route
-            exact
-            strict
-            path="/stats"
-            component={createRedirectExternal('https://dune.xyz/gnosis.protocol/Gnosis-Protocol-V2')}
-          />
-          <Route exact strict path="/twitter" component={createRedirectExternal('https://twitter.com/MEVprotection')} />
-          <Route exact strict path="/" component={RedirectPathToSwapOnly} />
-          <Route component={NotFound} />
-        </Switch>
+        <Suspense fallback={<div>Loading...</div>}>
+          <Switch>
+            <Route exact strict path="/swap" component={Swap} />
+            <Route exact strict path="/swap/:outputCurrency" component={RedirectToSwap} />
+            <Route exact strict path="/send" component={RedirectPathToSwapOnly} />
+            {IS_CLAIMING_ENABLED && <Route exact strict path="/claim" component={Claim} />}
+            <Route exact strict path="/about" component={About} />
+            <Route exact strict path="/profile" component={Profile} />
+            <Route exact strict path="/faq" component={Faq} />
+            <Route exact strict path="/play/cow-runner" component={CowRunner} />
+            <Route exact strict path="/play/mev-slicer" component={MevSlicer} />
+            <Route exact strict path="/anyswap-affected-users" component={AnySwapAffectedUsers} />
+            <Route exact strict path="/privacy-policy" component={PrivacyPolicy} />
+            <Route exact strict path="/cookie-policy" component={CookiePolicy} />
+            <Route exact strict path="/terms-and-conditions" component={TermsAndConditions} />
+            <Route exact strict path="/chat" component={createRedirectExternal('https://chat.cowswap.exchange')} />
+            <Route exact strict path="/docs" component={createRedirectExternal('https://docs.cow.fi')} />
+            <Route
+              exact
+              strict
+              path="/stats"
+              component={createRedirectExternal('https://dune.xyz/gnosis.protocol/Gnosis-Protocol-V2')}
+            />
+            <Route
+              exact
+              strict
+              path="/twitter"
+              component={createRedirectExternal('https://twitter.com/MEVprotection')}
+            />
+            <Route exact strict path="/" component={RedirectPathToSwapOnly} />
+            <Route component={NotFound} />
+          </Switch>
+        </Suspense>
       </Wrapper>
     </>
   )

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -16,17 +16,17 @@ import { IS_CLAIMING_ENABLED } from 'pages/Claim/const'
 const SENTRY_DSN = process.env.REACT_APP_SENTRY_DSN
 const SENTRY_TRACES_SAMPLE_RATE = process.env.REACT_APP_SENTRY_TRACES_SAMPLE_RATE
 
-const Swap = lazy(() => import(/* webpackPrefetch: true */ 'pages/Swap'))
-const Claim = lazy(() => import('pages/Claim'))
-const PrivacyPolicy = lazy(() => import('pages/PrivacyPolicy'))
-const CookiePolicy = lazy(() => import('pages/CookiePolicy'))
-const TermsAndConditions = lazy(() => import('pages/TermsAndConditions'))
-const About = lazy(() => import('pages/About'))
-const Profile = lazy(() => import('pages/Profile'))
-const Faq = lazy(() => import('pages/Faq'))
-const NotFound = lazy(() => import('pages/error/NotFound'))
-const CowRunner = lazy(() => import('pages/games/CowRunner'))
-const MevSlicer = lazy(() => import('pages/games/MevSlicer'))
+const Swap = lazy(() => import(/* webpackPrefetch: true,  webpackChunkName: "swap" */ 'pages/Swap'))
+const Claim = lazy(() => import(/* webpackChunkName: "claim" */ 'pages/Claim'))
+const PrivacyPolicy = lazy(() => import(/* webpackChunkName: "privacy_policy" */ 'pages/PrivacyPolicy'))
+const CookiePolicy = lazy(() => import(/* webpackChunkName: "cookie_policy" */ 'pages/CookiePolicy'))
+const TermsAndConditions = lazy(() => import(/* webpackChunkName: "terms" */ 'pages/TermsAndConditions'))
+const About = lazy(() => import(/* webpackChunkName: "about" */ 'pages/About'))
+const Profile = lazy(() => import(/* webpackChunkName: "profile" */ 'pages/Profile'))
+const Faq = lazy(() => import(/* webpackChunkName: "faq" */ 'pages/Faq'))
+const NotFound = lazy(() => import(/* webpackChunkName: "not_found" */ 'pages/error/NotFound'))
+const CowRunner = lazy(() => import(/* webpackChunkName: "cow_runner" */ 'pages/games/CowRunner'))
+const MevSlicer = lazy(() => import(/* webpackChunkName: "mev_slicer" */ 'pages/games/MevSlicer'))
 
 if (SENTRY_DSN) {
   Sentry.init({


### PR DESCRIPTION
# Summary

Lazy loading partition per page.

Makes partition per page, reducing drastically the main JS file size. 

Before, the main was 2MB:
<img width="1791" alt="Screenshot at Feb 28 19-35-18" src="https://user-images.githubusercontent.com/2352112/156050693-7b4d7a2c-e7cc-4fea-9474-e8d329a75214.png">

After 700KB (follow PRs can further break it down):
<img width="1789" alt="Screenshot at Feb 28 19-49-02" src="https://user-images.githubusercontent.com/2352112/156050810-0f295ed2-c46b-462b-b963-1fe4420caa90.png">

Additionally it names all the chunks of the pages. This makes it way easier to analize the problems and optimize. For example, the Swap page is now easy to spot, and you can now see how we depend on IPFS. We can see IPFS shouldn't be a hard dependency, so now we have another point where we can further use code splitting:
<img width="1473" alt="Screenshot at Feb 28 20-02-02" src="https://user-images.githubusercontent.com/2352112/156050915-4d52829d-fa25-44a9-a71c-db9516f8c4ab.png">

## Not included
Nice Loader, right now shows this. But we can make something way nicer. 

<img width="1791" alt="Screenshot at Feb 28 19-51-03" src="https://user-images.githubusercontent.com/2352112/156050982-dc75e2ba-1d93-4070-b1ea-8544bfed1e71.png">


# To Test
Run `yarn build:analyze`