### PR TITLE
[SENTRY] - Report order submission errors and update ignore list

### DIFF
--- a/src/custom/api/gnosisProtocol/api.ts
+++ b/src/custom/api/gnosisProtocol/api.ts
@@ -1,7 +1,13 @@
 import { SupportedChainId as ChainId, SupportedChainId } from 'constants/chains'
 import { OrderKind, QuoteQuery } from '@gnosis.pm/gp-v2-contracts'
 import { stringify } from 'qs'
-import { getSigningSchemeApiValue, OrderCancellation, OrderCreation, SigningSchemeValue } from 'utils/signatures'
+import {
+  getSigningSchemeApiValue,
+  OrderCancellation,
+  OrderCreation,
+  SigningSchemeValue,
+  UnsignedOrder,
+} from 'utils/signatures'
 import { APP_DATA_HASH, GAS_FEE_ENDPOINTS } from 'constants/index'
 import { registerOnWindow } from 'utils/misc'
 import { isBarn, isDev, isLocal, isPr } from '../../utils/environments'
@@ -21,7 +27,7 @@ import { FeeQuoteParams, PriceInformation, PriceQuoteParams, SimpleGetQuoteRespo
 
 import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
 import * as Sentry from '@sentry/browser'
-import { constructSentryError } from 'utils/logging'
+import { checkAndThrowIfJsonSerialisableError, constructSentryError } from 'utils/logging'
 import { ZERO_ADDRESS } from 'constants/misc'
 import { getAppDataHash } from 'constants/appDataHash'
 import { GpPriceStrategy } from 'hooks/useGetGpPriceStrategy'
@@ -220,23 +226,15 @@ export async function sendOrder(params: { chainId: ChainId; order: OrderCreation
   const { chainId, order, owner } = params
   console.log(`[api:${API_NAME}] Post signed order for network`, chainId, order)
 
-  // Call API
-  const response = await _post(chainId, `/orders`, {
+  const orderParams = {
     ...order,
     signingScheme: getSigningSchemeApiValue(order.signingScheme),
     from: owner,
-  })
-
-  // Handle response
-  if (!response.ok) {
-    // Raise an exception
-    const errorMessage = await OperatorError.getErrorFromStatusCode(response, 'create')
-    throw new Error(errorMessage)
   }
+  // Call API
+  const response = await _post(chainId, `/orders`, orderParams)
 
-  const uid = (await response.json()) as string
-  console.log(`[api:${API_NAME}] Success posting the signed order`, uid)
-  return uid
+  return _handleOrderResponse<string, typeof orderParams>(response, orderParams)
 }
 
 type OrderCancellationParams = {
@@ -275,6 +273,56 @@ const UNHANDLED_ORDER_ERROR: ApiErrorObject = {
   description: ApiErrorCodeDetails.UNHANDLED_CREATE_ERROR,
 }
 
+async function _handleOrderResponse<T = any, P extends UnsignedOrder = UnsignedOrder>(
+  response: Response,
+  params: P
+): Promise<T> {
+  try {
+    // Handle response
+    if (!response.ok) {
+      // Raise an exception
+      const [errorObject, description] = await Promise.all<[Promise<ApiErrorObject>, Promise<string>]>([
+        response.json(),
+        OperatorError.getErrorFromStatusCode(response, 'create'),
+      ])
+      // create the OperatorError from the constructed error message and the original error
+      const orderError = new OperatorError(Object.assign({}, errorObject, { description }))
+
+      // we need to create a sentry error and keep the original mapped quote error
+      throw constructSentryError(orderError, response, {
+        message: `${orderError.description} [sellToken: ${params.sellToken}]//[buyToken: ${params.buyToken}]`,
+        name: `[${orderError.name}] - ${orderError.type}`,
+        optionalTags: {
+          orderErrorType: orderError.type,
+        },
+      })
+    } else {
+      const uid = await response.json()
+      console.log(`[api:${API_NAME}] Success posting the signed order`, JSON.stringify(uid))
+      return uid
+    }
+  } catch (error) {
+    // Create a new sentry error OR
+    // use the previously created and rethrown error from the try block
+    const sentryError =
+      error?.sentryError ||
+      constructSentryError(error, response, {
+        message: `Potential backend error detected - status code: ${response.status}`,
+        name: '[HandleOrderResponse] - Unhandled Order Error',
+      })
+    // Create the error tags or use the previously constructed ones from the try block
+    const tags = error?.tags || { errorType: 'handleOrderResponse', backendErrorCode: response.status }
+
+    // report to sentry
+    Sentry.captureException(sentryError, {
+      tags,
+      contexts: { params: { ...params } },
+    })
+
+    throw error?.baseError || error
+  }
+}
+
 async function _handleQuoteResponse<T = any, P extends FeeQuoteParams = FeeQuoteParams>(
   response: Response,
   params: P
@@ -282,9 +330,8 @@ async function _handleQuoteResponse<T = any, P extends FeeQuoteParams = FeeQuote
   try {
     if (!response.ok) {
       // don't attempt json parse if not json response...
-      if (response.headers.get('Content-Type') !== 'application/json') {
-        throw new Error(`${response.status} error occurred. ${response.statusText}`)
-      }
+      checkAndThrowIfJsonSerialisableError(response)
+
       const errorObj: ApiErrorObject = await response.json()
 
       // we need to map the backend error codes to match our own for quotes

--- a/src/custom/api/gnosisProtocol/api.ts
+++ b/src/custom/api/gnosisProtocol/api.ts
@@ -280,7 +280,7 @@ function _handleError<P extends Context>(error: any, response: Response, params:
   const sentryError =
     error?.sentryError ||
     constructSentryError(error, response, {
-      message: `Potential backend error detected - status code: ${response.status}`,
+      message: error?.message || error,
       name: `[${operation}-ERROR] - Unmapped ${operation} Error`,
     })
   // Create the error tags or use the previously constructed ones from the try block

--- a/src/custom/api/gnosisProtocol/errors/QuoteError.ts
+++ b/src/custom/api/gnosisProtocol/errors/QuoteError.ts
@@ -17,6 +17,8 @@ export enum GpQuoteErrorCodes {
   UNHANDLED_ERROR = 'UNHANDLED_ERROR',
 }
 
+export const SENTRY_IGNORED_GP_QUOTE_ERRORS = [GpQuoteErrorCodes.FeeExceedsFrom]
+
 export enum GpQuoteErrorDetails {
   UnsupportedToken = 'One of the tokens you are trading is unsupported. Please read the FAQ for more info.',
   InsufficientLiquidity = 'Token pair selected has insufficient liquidity.',

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -21,6 +21,7 @@ import { environmentName } from 'utils/environments'
 import { useFilterEmptyQueryParams } from 'hooks/useFilterEmptyQueryParams'
 import RedirectAnySwapAffectedUsers from 'pages/error/AnySwapAffectedUsers/RedirectAnySwapAffectedUsers'
 import { IS_CLAIMING_ENABLED } from 'pages/Claim/const'
+import { SENTRY_IGNORED_GP_QUOTE_ERRORS } from 'api/gnosisProtocol/errors/QuoteError'
 
 const SENTRY_DSN = process.env.REACT_APP_SENTRY_DSN
 const SENTRY_TRACES_SAMPLE_RATE = process.env.REACT_APP_SENTRY_TRACES_SAMPLE_RATE
@@ -31,6 +32,7 @@ if (SENTRY_DSN) {
     integrations: [new Integrations.BrowserTracing()],
     release: 'CowSwap@v' + version,
     environment: environmentName,
+    ignoreErrors: [...SENTRY_IGNORED_GP_QUOTE_ERRORS],
 
     // Set tracesSampleRate to 1.0 to capture 100%
     // of transactions for performance monitoring.

--- a/src/custom/utils/logging/index.ts
+++ b/src/custom/utils/logging/index.ts
@@ -27,3 +27,13 @@ export function constructSentryError(
 
   return { baseError, sentryError: constructedError, tags }
 }
+
+// checks response for non json/application return type and throw appropriate error
+export function checkAndThrowIfJsonSerialisableError(response: Response) {
+  // don't attempt json parse if not json response...
+  if (response.headers.get('Content-Type') !== 'application/json') {
+    throw new Error(
+      `Non JSON serialisable error detected with status code ${response.status}. ${JSON.stringify(response.statusText)}`
+    )
+  }
+}

--- a/src/custom/utils/logging/index.ts
+++ b/src/custom/utils/logging/index.ts
@@ -32,8 +32,6 @@ export function constructSentryError(
 export function checkAndThrowIfJsonSerialisableError(response: Response) {
   // don't attempt json parse if not json response...
   if (response.headers.get('Content-Type') !== 'application/json') {
-    throw new Error(
-      `Non JSON serialisable error detected with status code ${response.status}. ${JSON.stringify(response.statusText)}`
-    )
+    throw new Error(`Error code ${response.status} occurred`)
   }
 }


### PR DESCRIPTION
Part of #2519 

This PR does 2 things:
1. Properly handle order submission logic and report sentry errors related to order submission similar to the way we handle quotes in #2518 
2. Create an ignore errors list
  - ignores FeeExceedsFrom quote errors

## Testing
1. you'll need an `.env.development.local` or `.env.local` file with the sentry secrets. ping me if u need/want them
2. open sentry and set environment to local
3. try setting too low amount and getting fee exceeds from amount message - sentry will not report it
4. try changing https://github.com/gnosis/cowswap/blob/263fc83842f1a247a29785207e08b07455d5c389/src/custom/api/gnosisProtocol/api.ts#L381 to not use `toNativeBuyAddress` and instead use the same fn as the line 380 above it (except with buyToken) - submit a ERC20 sell // NATIVE buy order (e.g DAI/ETH on rinkeby) and you'll see the error reported