### PR TITLE
[Technical Debt] Conditional logging

### DIFF
--- a/src/custom/api/coingecko/index.ts
+++ b/src/custom/api/coingecko/index.ts
@@ -1,3 +1,4 @@
+import { devLog } from 'utils/logging'
 import { SupportedChainId as ChainId } from 'constants/chains'
 import { PriceInformation } from 'utils/price'
 
@@ -77,7 +78,7 @@ export async function getUSDPriceQuote(params: CoinGeckoUsdPriceParams): Promise
     return null
   }
 
-  console.log(`[api:${API_NAME}] Get USD price from ${API_NAME}`, params)
+  devLog(`[api:${API_NAME}] Get USD price from ${API_NAME}`, params)
 
   const response = await _get(
     chainId,

--- a/src/custom/api/gnosisProtocol/api.ts
+++ b/src/custom/api/gnosisProtocol/api.ts
@@ -27,7 +27,7 @@ import { FeeQuoteParams, PriceInformation, PriceQuoteParams, SimpleGetQuoteRespo
 
 import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
 import * as Sentry from '@sentry/browser'
-import { checkAndThrowIfJsonSerialisableError, constructSentryError } from 'utils/logging'
+import { checkAndThrowIfJsonSerialisableError, constructSentryError, devInfo, devLog } from 'utils/logging'
 import { ZERO_ADDRESS } from 'constants/misc'
 import { getAppDataHash } from 'constants/appDataHash'
 import { GpPriceStrategy } from 'hooks/useGetGpPriceStrategy'
@@ -224,7 +224,7 @@ function _delete(chainId: ChainId, url: string, data: any): Promise<Response> {
 
 export async function sendOrder(params: { chainId: ChainId; order: OrderCreation; owner: string }): Promise<OrderID> {
   const { chainId, order, owner } = params
-  console.log(`[api:${API_NAME}] Post signed order for network`, chainId, order)
+  devLog(`[api:${API_NAME}] Post signed order for network`, chainId, order)
 
   const orderParams = {
     ...order,
@@ -246,7 +246,7 @@ type OrderCancellationParams = {
 export async function sendSignedOrderCancellation(params: OrderCancellationParams): Promise<void> {
   const { chainId, cancellation, owner: from } = params
 
-  console.log(`[api:${API_NAME}] Delete signed order for network`, chainId, cancellation)
+  devLog(`[api:${API_NAME}] Delete signed order for network`, chainId, cancellation)
 
   const response = await _delete(chainId, `/orders/${cancellation.orderUid}`, {
     signature: cancellation.signature,
@@ -260,7 +260,7 @@ export async function sendSignedOrderCancellation(params: OrderCancellationParam
     throw new Error(errorMessage)
   }
 
-  console.log(`[api:${API_NAME}] Cancelled order`, cancellation.orderUid, chainId)
+  devLog(`[api:${API_NAME}] Cancelled order`, cancellation.orderUid, chainId)
 }
 
 const UNHANDLED_QUOTE_ERROR: GpQuoteErrorObject = {
@@ -298,7 +298,7 @@ async function _handleOrderResponse<T = any, P extends UnsignedOrder = UnsignedO
       })
     } else {
       const uid = await response.json()
-      console.log(`[api:${API_NAME}] Success posting the signed order`, JSON.stringify(uid))
+      devLog(`[api:${API_NAME}] Success posting the signed order`, JSON.stringify(uid))
       return uid
     }
   } catch (error) {
@@ -413,7 +413,7 @@ export async function getQuote(params: FeeQuoteParams) {
 
 export async function getPriceQuoteLegacy(params: PriceQuoteParams): Promise<PriceInformation | null> {
   const { baseToken, quoteToken, amount, kind, chainId } = params
-  console.log(`[api:${API_NAME}] Get price from API`, params)
+  devLog(`[api:${API_NAME}] Get price from API`, params)
 
   if (!ENABLED) {
     return null
@@ -435,7 +435,7 @@ export async function getPriceQuoteLegacy(params: PriceQuoteParams): Promise<Pri
 }
 
 export async function getOrder(chainId: ChainId, orderId: string): Promise<OrderMetaData | null> {
-  console.log(`[api:${API_NAME}] Get order for `, chainId, orderId)
+  devLog(`[api:${API_NAME}] Get order for `, chainId, orderId)
   try {
     const response = await _get(chainId, `/orders/${orderId}`)
 
@@ -452,7 +452,7 @@ export async function getOrder(chainId: ChainId, orderId: string): Promise<Order
 }
 
 export async function getOrders(chainId: ChainId, owner: string, limit = 1000, offset = 0): Promise<OrderMetaData[]> {
-  console.log(`[api:${API_NAME}] Get orders for `, chainId, owner, limit, offset)
+  devLog(`[api:${API_NAME}] Get orders for `, chainId, owner, limit, offset)
 
   const queryString = stringify({ limit, offset }, { addQueryPrefix: true })
 
@@ -479,7 +479,7 @@ type GetTradesParams = {
 export async function getTrades(params: GetTradesParams): Promise<TradeMetaData[]> {
   const { chainId, owner, limit, offset } = params
   const qsParams = stringify({ owner, limit, offset })
-  console.log('[util:operator] Get trades for', chainId, owner, { limit, offset })
+  devLog('[util:operator] Get trades for', chainId, owner, { limit, offset })
   try {
     const response = await _get(chainId, `/trades?${qsParams}`)
 
@@ -504,9 +504,9 @@ export type ProfileData = {
 }
 
 export async function getProfileData(chainId: ChainId, address: string): Promise<ProfileData | null> {
-  console.log(`[api:${API_NAME}] Get profile data for`, chainId, address)
+  devLog(`[api:${API_NAME}] Get profile data for`, chainId, address)
   if (chainId !== ChainId.MAINNET) {
-    console.info('Profile data is only available for mainnet')
+    devInfo('Profile data is only available for mainnet')
     return null
   }
 
@@ -515,7 +515,7 @@ export async function getProfileData(chainId: ChainId, address: string): Promise
   // TODO: Update the error handler when the openAPI profile spec is defined
   if (!response.ok) {
     const errorResponse = await response.json()
-    console.log(errorResponse)
+    devLog(errorResponse)
     throw new Error(errorResponse?.description)
   } else {
     return response.json()
@@ -528,13 +528,13 @@ export type PriceStrategy = {
 }
 
 export async function getPriceStrategy(chainId: ChainId): Promise<PriceStrategy> {
-  console.log(`[api:${API_NAME}] Get GP price strategy for`, chainId)
+  devLog(`[api:${API_NAME}] Get GP price strategy for`, chainId)
 
   const response = await _fetchPriceStrategy(chainId)
 
   if (!response.ok) {
     const errorResponse = await response.json()
-    console.log(errorResponse)
+    devLog(errorResponse)
     throw new Error(errorResponse?.description)
   } else {
     return response.json()

--- a/src/custom/api/gnosisProtocol/mock.ts
+++ b/src/custom/api/gnosisProtocol/mock.ts
@@ -1,7 +1,8 @@
+import { devLog } from 'utils/logging'
 import { ProfileData } from './api'
 
 export async function getProfileData(): Promise<ProfileData | null> {
-  console.log('[utils:operatorMock] Get profile data')
+  devLog('[utils:operatorMock] Get profile data')
   return {
     lastUpdated: new Date(2021, 9, 4, 7).toUTCString(),
     referralVolumeUsd: 250_000,

--- a/src/custom/api/gnosisSafe/index.ts
+++ b/src/custom/api/gnosisSafe/index.ts
@@ -1,6 +1,7 @@
 import SafeServiceClient, { SafeInfoResponse, SafeMultisigTransactionResponse } from '@gnosis.pm/safe-service-client'
 import { registerOnWindow } from 'utils/misc'
 import { ChainId } from '@uniswap/sdk'
+import { devLog } from 'utils/logging'
 
 const SAFE_TRANSACTION_SERVICE_URL: Partial<Record<number, string>> = {
   [ChainId.MAINNET]: 'https://safe-transaction.gnosis.io',
@@ -54,13 +55,13 @@ export function getSafeWebUrl(chaindId: number, safeAddress: string): string | n
 }
 
 export function getSafeTransaction(chainId: number, safeTxHash: string): Promise<SafeMultisigTransactionResponse> {
-  console.log('[api/gnosisSafe] getSafeTransaction', chainId, safeTxHash)
+  devLog('[api/gnosisSafe] getSafeTransaction', chainId, safeTxHash)
   const client = _getClientOrThrow(chainId)
   return client.getTransaction(safeTxHash)
 }
 
 export function getSafeInfo(chainId: number, safeAddress: string): Promise<SafeInfoResponse> {
-  console.log('[api/gnosisSafe] getSafeInfo', chainId, safeAddress)
+  devLog('[api/gnosisSafe] getSafeInfo', chainId, safeAddress)
   const client = _getClientOrThrow(chainId)
 
   return client.getSafeInfo(safeAddress)

--- a/src/custom/api/matcha-0x/index.ts
+++ b/src/custom/api/matcha-0x/index.ts
@@ -4,6 +4,7 @@ import { NetworkID } from 'paraswap'
 import { SupportedChainId as ChainId } from 'constants/chains'
 import { getTokensFromMarket } from 'utils/misc'
 import { getValidParams, PriceInformation, PriceQuoteParams } from 'utils/price'
+import { devLog } from 'utils/logging'
 
 // copy/pasting as the library types correspond to the internal types, not API response
 // e.g "price: BigNumber" when we want the API response type: "price: string"
@@ -113,7 +114,7 @@ export async function getPriceQuote(params: PriceQuoteParams): Promise<MatchaPri
     return null
   }
 
-  console.log(`[pricesApi:${API_NAME}] Get price from ${API_NAME}`, params)
+  devLog(`[pricesApi:${API_NAME}] Get price from ${API_NAME}`, params)
 
   // Buy/sell token and side (sell/buy)
   const { sellToken, buyToken } = getTokensFromMarket({ baseToken, quoteToken, kind })

--- a/src/custom/api/paraswap/index.ts
+++ b/src/custom/api/paraswap/index.ts
@@ -7,6 +7,7 @@ import { SupportedChainId as ChainId } from 'constants/chains'
 import { getTokensFromMarket } from 'utils/misc'
 import { getValidParams, PriceInformation, PriceQuoteParams } from 'utils/price'
 import { SOLVER_ADDRESS as defaultUserAddress } from 'constants/index'
+import { devLog } from 'utils/logging'
 
 type ParaSwapPriceQuote = OptimalRate
 
@@ -81,7 +82,7 @@ export async function getPriceQuote(params: PriceQuoteParams): Promise<ParaSwapP
     paraSwapLibs.set(chainId, paraSwap)
   }
 
-  console.log(`[pricesApi:${API_NAME}] Get price from Paraswap`, params)
+  devLog(`[pricesApi:${API_NAME}] Get price from Paraswap`, params)
 
   // Buy/sell token and side (sell/buy)
   const { sellToken, buyToken } = getTokensFromMarket({ baseToken, quoteToken, kind })

--- a/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
+++ b/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
@@ -14,6 +14,7 @@ import { ActivityDerivedState, determinePillColour } from './index'
 import { CancellationModal } from './CancelationModal'
 import { getSafeWebUrl } from 'api/gnosisSafe'
 import { SafeMultisigTransactionResponse } from '@gnosis.pm/safe-service-client'
+import { devLog } from 'utils/logging'
 
 export function GnosisSafeLink(props: {
   chainId: number
@@ -49,7 +50,7 @@ function _getStateLabel({
 }: ActivityDerivedState) {
   if (isPending) {
     if (enhancedTransaction) {
-      console.log('enhancedTransaction', enhancedTransaction)
+      devLog('enhancedTransaction', enhancedTransaction)
       const { safeTransaction, transactionHash } = enhancedTransaction
       if (safeTransaction && !transactionHash) {
         return 'Signing...'

--- a/src/custom/components/Header/URLWarning/index.tsx
+++ b/src/custom/components/Header/URLWarning/index.tsx
@@ -9,6 +9,7 @@ import { Markdown } from 'components/Markdown'
 import { useActiveWeb3React } from '@src/hooks/web3'
 import { ChainId } from '@uniswap/sdk'
 import { isBarn } from 'utils/environments'
+import { devDebug } from 'utils/logging'
 
 export * from './URLWarningMod'
 
@@ -69,7 +70,7 @@ export default function URLWarning() {
   if (error) {
     console.error('[URLWarning] Error getting the announcement text: ', error)
   } else {
-    console.debug('[URLWarning] Announcement text', announcementText, contentHash)
+    devDebug('[URLWarning] Announcement text', announcementText, contentHash)
   }
 
   const announcementVisible = useAnnouncementVisible(contentHash)

--- a/src/custom/hooks/useApproveCallback/useApproveCallbackMod.ts
+++ b/src/custom/hooks/useApproveCallback/useApproveCallbackMod.ts
@@ -15,6 +15,7 @@ import { useActiveWeb3React } from 'hooks/web3'
 import { OptionalApproveCallbackParams } from '.'
 import { useCurrency } from 'hooks/Tokens'
 import { OperationType } from 'components/TransactionConfirmationModal'
+import { devDebug, devLog } from 'utils/logging'
 
 // Use a 150K gas as a fallback if there's issue calculating the gas estimation (fixes some issues with some nodes failing to calculate gas costs for SC wallets)
 export const APPROVE_GAS_LIMIT_DEFAULT = BigNumber.from('150000')
@@ -51,7 +52,7 @@ export function useApproveCallback({
   // TODO: Nice to have, can be deleted
   {
     process.env.NODE_ENV !== 'production' &&
-      console.debug(`
+      devDebug(`
     $$$$Approval metrics:
     ====
     CurrentAllowance: ${currentAllowance?.toExact()}
@@ -126,7 +127,7 @@ export function useApproveCallback({
         // general fallback for tokens who restrict approval amounts
         useExact = true
         return tokenContract.estimateGas.approve(spender, amountToApprove.quotient.toString()).catch((error) => {
-          console.log(
+          devLog(
             '[useApproveCallbackMod] Error estimating gas for approval. Using default gas limit ' +
               APPROVE_GAS_LIMIT_DEFAULT.toString(),
             error
@@ -153,7 +154,7 @@ export function useApproveCallback({
             })
           })
           // .catch((error: Error) => {
-          //   console.debug('Failed to approve token', error)
+          //   devDebug('Failed to approve token', error)
           //   throw error
           // })
           .finally(closeModals)
@@ -201,7 +202,7 @@ export function useApproveCallback({
       const estimatedGas = await tokenContract.estimateGas.approve(spender, MaxUint256).catch(() => {
         // general fallback for tokens who restrict approval amounts
         return tokenContract.estimateGas.approve(spender, '0').catch((error) => {
-          console.log(
+          devLog(
             '[useApproveCallbackMod] Error estimating gas for revoking approval. Using default gas limit ' +
               APPROVE_GAS_LIMIT_DEFAULT.toString(),
             error
@@ -227,7 +228,7 @@ export function useApproveCallback({
             })
           })
           // .catch((error: Error) => {
-          //   console.debug('Failed to approve token', error)
+          //   devDebug('Failed to approve token', error)
           //   throw error
           // })
           .finally(closeModals)

--- a/src/custom/hooks/useFetchListCallback/useFetchListCallbackMod.ts
+++ b/src/custom/hooks/useFetchListCallback/useFetchListCallbackMod.ts
@@ -8,6 +8,7 @@ import { fetchTokenList } from 'state/lists/actions'
 import getTokenList from 'utils/getTokenList'
 import resolveENSContentHash from 'utils/resolveENSContentHash'
 import { useActiveWeb3React } from 'hooks/web3'
+import { devDebug } from 'utils/logging'
 
 export function useFetchListCallback(): (listUrl: string, sendDispatch?: boolean) => Promise<TokenList> {
   const { chainId, library } = useActiveWeb3React()
@@ -41,7 +42,7 @@ export function useFetchListCallback(): (listUrl: string, sendDispatch?: boolean
           return tokenList
         })
         .catch((error) => {
-          console.debug(`Failed to get list at url ${listUrl}`, error)
+          devDebug(`Failed to get list at url ${listUrl}`, error)
           sendDispatch &&
             // Mod: add chainId
             dispatch(fetchTokenList.rejected({ url: listUrl, requestId, errorMessage: error.message, chainId }))

--- a/src/custom/hooks/useGetGpPriceStrategy.ts
+++ b/src/custom/hooks/useGetGpPriceStrategy.ts
@@ -5,6 +5,7 @@ import { getPriceStrategy, PriceStrategy } from 'api/gnosisProtocol/api'
 import { useActiveWeb3React } from 'hooks'
 import { supportedChainId } from 'utils/supportedChainId'
 import { SupportedChainId } from 'constants/chains'
+import { devDebug } from 'utils/logging'
 
 export type GpPriceStrategy = 'COWSWAP' | 'LEGACY'
 
@@ -19,7 +20,7 @@ export default function useGetGpPriceStrategy(): GpPriceStrategy {
 
   useEffect(() => {
     const chainId = supportedChainId(preChainId)
-    console.debug('[useGetGpPriceStrategy::GP Price Strategy]::', gpPriceStrategy)
+    devDebug('[useGetGpPriceStrategy::GP Price Strategy]::', gpPriceStrategy)
 
     const getStrategy = () => {
       // default to MAINNET if not connected, or incorrect network

--- a/src/custom/hooks/useGetReceipt.ts
+++ b/src/custom/hooks/useGetReceipt.ts
@@ -3,6 +3,7 @@ import { useActiveWeb3React } from 'hooks/web3'
 import { retry, RetryableError, RetryOptions } from 'utils/retry'
 import { TransactionReceipt } from '@ethersproject/abstract-provider'
 import { RetryResult } from 'types/index'
+import { devDebug } from 'utils/logging'
 
 const DEFAULT_RETRY_OPTIONS: RetryOptions = { n: 3, minWait: 1000, maxWait: 3000 }
 const RETRY_OPTIONS_BY_CHAIN_ID: { [chainId: number]: RetryOptions } = {
@@ -24,7 +25,7 @@ export function useGetReceipt(): GetReceipt {
 
         return library.getTransactionReceipt(hash).then((receipt) => {
           if (receipt === null) {
-            console.debug('[useGetReceipt] Retrying for hash', hash)
+            devDebug('[useGetReceipt] Retrying for hash', hash)
             throw new RetryableError()
           }
           return receipt

--- a/src/custom/hooks/useMarkdown.ts
+++ b/src/custom/hooks/useMarkdown.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { devLog } from 'utils/logging'
 
 export default function useMarkdown(file: string) {
   const [content, setContent] = useState('')
@@ -11,7 +12,7 @@ export default function useMarkdown(file: string) {
           setContent(text)
         })
         .catch((error) => {
-          console.log(`Error fetching markdown content file ${file}: `, error)
+          devLog(`Error fetching markdown content file ${file}: `, error)
           return null
         })
     }

--- a/src/custom/hooks/useMonitoringEventCallback.ts
+++ b/src/custom/hooks/useMonitoringEventCallback.ts
@@ -3,6 +3,7 @@ import { initializeApp } from 'firebase/app'
 // import { getDatabase, push, ref } from 'firebase/database'
 import { useCallback } from 'react'
 import { TransactionInfo, TransactionType } from 'state/transactions/actions'
+import { devDebug } from 'utils/logging'
 
 import { useActiveWeb3React } from './web3'
 
@@ -37,7 +38,7 @@ function useMonitoringEventCallback() {
       // const db = getDatabase()
 
       if (!walletAddress) {
-        console.debug('Wallet address required to log monitoring events.')
+        devDebug('Wallet address required to log monitoring events.')
         return
       }
       try {
@@ -50,7 +51,7 @@ function useMonitoringEventCallback() {
         //   walletAddress,
         // })
       } catch (e) {
-        console.debug('Error adding document: ', e)
+        devDebug('Error adding document: ', e)
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/custom/hooks/usePresignOrder.ts
+++ b/src/custom/hooks/usePresignOrder.ts
@@ -5,6 +5,7 @@ import { ContractTransaction } from '@ethersproject/contracts'
 import { BigNumber } from '@ethersproject/bignumber'
 import { calculateGasMargin } from 'utils/calculateGasMargin'
 import { useActiveWeb3React } from 'hooks/web3'
+import { devLog } from 'utils/logging'
 
 // Use a 150K gas as a fallback if there's issue calculating the gas estimation (fixes some issues with some nodes failing to calculate gas costs for SC wallets)
 const PRESIGN_GAS_LIMIT_DEFAULT = BigNumber.from('150000')
@@ -17,7 +18,7 @@ export function usePresignOrder(): PresignOrder | null {
 
   const presignOrder = useCallback<PresignOrder>(
     async (orderId) => {
-      console.log('Pre-signing order', orderId)
+      devLog('Pre-signing order', orderId)
       if (!chainId) {
         throw Error('Not connected to any chain')
       }
@@ -38,7 +39,7 @@ export function usePresignOrder(): PresignOrder | null {
         gasLimit: calculateGasMargin(chainId, estimatedGas),
       })
 
-      console.log('Sent transaction for presigning', orderId, txReceipt)
+      devLog('Sent transaction for presigning', orderId, txReceipt)
 
       return txReceipt
     },

--- a/src/custom/hooks/useRefetchPriceCallback.tsx
+++ b/src/custom/hooks/useRefetchPriceCallback.tsx
@@ -23,6 +23,7 @@ import { CancelableResult, onlyResolvesLast } from 'utils/async'
 import useGetGpPriceStrategy from 'hooks/useGetGpPriceStrategy'
 import { calculateValidTo } from 'hooks/useSwapCallback'
 import { useUserTransactionTTL } from 'state/user/hooks'
+import { devDebug } from 'utils/logging'
 
 interface HandleQuoteErrorParams {
   quoteData: QuoteInformationObject | FeeQuoteParams
@@ -151,7 +152,7 @@ export function useRefetchQuoteCallback() {
 
         if (cancelled) {
           // Cancellation can happen if a new request is made, then any ongoing query is canceled
-          console.debug('[useRefetchPriceCallback] Canceled get quote price for', params)
+          devDebug('[useRefetchPriceCallback] Canceled get quote price for', params)
           return
         }
 
@@ -183,7 +184,7 @@ export function useRefetchQuoteCallback() {
         // can be a previously unsupported token which is now valid
         // so we check against map and remove it
         if (previouslyUnsupportedToken) {
-          console.debug('[useRefetchPriceCallback]::Previously unsupported token now supported - re-enabling.')
+          devDebug('[useRefetchPriceCallback]::Previously unsupported token now supported - re-enabling.')
 
           removeGpUnsupportedToken({
             chainId,

--- a/src/custom/hooks/useSwapCallback.ts
+++ b/src/custom/hooks/useSwapCallback.ts
@@ -22,6 +22,7 @@ import { useWalletInfo } from './useWalletInfo'
 import { usePresignOrder, PresignOrder } from 'hooks/usePresignOrder'
 import { Web3Provider } from '@ethersproject/providers'
 import { useAppDataHash } from 'state/affiliate/hooks'
+import { devLog } from 'utils/logging'
 
 export const MAX_VALID_TO_EPOCH = BigNumber.from('0xFFFFFFFF').toNumber() // Max uint32 (Feb 07 2106 07:28:15 GMT+0100)
 
@@ -211,7 +212,7 @@ async function _swap(params: SwapParams): Promise<string> {
     if (wrapPromise) {
       // Wait for order and the wrap
       const [orderAux, wrapTx] = await Promise.all([postOrderPromise, wrapPromise])
-      console.log('[useSwapCallback] Wrapped ETH successfully. Tx: ', wrapTx)
+      devLog('[useSwapCallback] Wrapped ETH successfully. Tx: ', wrapTx)
       pendingOrderParams = orderAux
     } else {
       // Wait just for the order
@@ -227,7 +228,7 @@ async function _swap(params: SwapParams): Promise<string> {
   let presignGnosisSafeTxHash: string | undefined
   if (!allowsOffchainSigning) {
     const presignTx = await presignOrder(orderId)
-    console.log('Pre-sign order has been sent with: ', pendingOrderParams, presignTx)
+    devLog('Pre-sign order has been sent with: ', pendingOrderParams, presignTx)
 
     if (isGnosisSafeWallet) {
       presignGnosisSafeTxHash = presignTx.hash

--- a/src/custom/hooks/useTokenLazy.ts
+++ b/src/custom/hooks/useTokenLazy.ts
@@ -10,6 +10,7 @@ import { parseStringOrBytes32 } from 'hooks/Tokens'
 import { useAddUserToken } from 'state/user/hooks'
 import { Erc20 } from 'abis/types'
 import { retry } from 'utils/retry'
+import { devDebug } from 'utils/logging'
 
 const contractsCache: Record<string, Erc20> = {}
 const bytes32ContractsCache: Record<string, Contract> = {}
@@ -50,7 +51,7 @@ async function _getBytes32NameAndSymbol(
   symbolSettled: PromiseFulfilledResult<string> | PromiseRejectedResult,
   params: GetTokenInfoParams
 ) {
-  console.debug(
+  devDebug(
     `[useTokenLazy::callback] name or symbol failed, trying bytes32`,
     address,
     account,
@@ -109,7 +110,7 @@ async function _getNameAndSymbol(
 
 async function _getTokenInfo(params: GetTokenInfoParams): Promise<TokenInfo | null> {
   const { address, account, chainId } = params
-  console.debug(`[useTokenLazy::callback] input is valid`, address, account, chainId)
+  devDebug(`[useTokenLazy::callback] input is valid`, address, account, chainId)
 
   const contract = await _getTokenContract(params)
 
@@ -124,7 +125,7 @@ async function _getTokenInfo(params: GetTokenInfoParams): Promise<TokenInfo | nu
     // If no decimals, stop here
     decimals = await decimalsPromise
   } catch (e) {
-    console.debug(`[useTokenLazy::callback] no decimals, stopping`, address, account, chainId, e)
+    devDebug(`[useTokenLazy::callback] no decimals, stopping`, address, account, chainId, e)
 
     cancelNamePromise()
     cancelSymbolPromise()
@@ -147,7 +148,7 @@ export function useTokenLazy() {
 
   return useCallback(
     async (address: string): Promise<Token | null> => {
-      console.debug(`[useTokenLazy::callback] callback called`, address, account, chainId)
+      devDebug(`[useTokenLazy::callback] callback called`, address, account, chainId)
 
       if (!account || !chainId || !address || !library) {
         return null
@@ -162,7 +163,7 @@ export function useTokenLazy() {
       const { decimals, symbol, name } = tokenInfo
       const token = new Token(chainId, address, decimals, symbol, name)
 
-      console.debug(`[useTokenLazy::callback] loaded token`, address, account, chainId, token)
+      devDebug(`[useTokenLazy::callback] loaded token`, address, account, chainId, token)
 
       addUserToken(token)
 

--- a/src/custom/hooks/useUSDCPrice/index.ts
+++ b/src/custom/hooks/useUSDCPrice/index.ts
@@ -23,6 +23,7 @@ import { MAX_VALID_TO_EPOCH } from 'hooks/useSwapCallback'
 import { useIsQuoteLoading } from 'state/price/hooks'
 import { onlyResolvesLast } from 'utils/async'
 import { getGpUsdcPrice } from 'utils/price'
+import { devDebug } from 'utils/logging'
 
 export * from '@src/hooks/useUSDCPrice'
 
@@ -123,7 +124,7 @@ export default function useUSDCPrice(currency?: Currency) {
               baseAmount,
               quoteAmount: stringToCurrency(quote, stablecoin),
             })
-            console.debug(
+            devDebug(
               '[useBestUSDCPrice] Best USDC price amount',
               price.toSignificant(12),
               price.invert().toSignificant(12)
@@ -224,7 +225,7 @@ export function useCoingeckoUsdPrice(currency?: Currency) {
           quoteAmount,
         }).invert()
 
-        console.debug(
+        devDebug(
           '[useCoingeckoUsdPrice] Best Coingecko USD price amount',
           usdPrice.toSignificant(12),
           usdPrice.invert().toSignificant(12)

--- a/src/custom/hooks/useWrapCallback.ts
+++ b/src/custom/hooks/useWrapCallback.ts
@@ -18,6 +18,7 @@ import { useWalletInfo } from './useWalletInfo'
 import { SafeInfoResponse } from '@gnosis.pm/safe-service-client'
 import { OperationType } from '../components/TransactionConfirmationModal'
 import { calculateGasMargin } from '@src/utils/calculateGasMargin'
+import { devLog } from 'utils/logging'
 
 // Use a 180K gas as a fallback if there's issue calculating the gas estimation (fixes some issues with some nodes failing to calculate gas costs for SC wallets)
 const WRAP_UNWRAP_GAS_LIMIT_DEFAULT = BigNumber.from('180000')
@@ -51,7 +52,7 @@ interface GetWrapUnwrapCallback {
 const NOT_APPLICABLE = { wrapType: WrapType.NOT_APPLICABLE }
 
 function _handleGasEstimateError(error: any) {
-  console.log(
+  devLog(
     '[useWrapCallback] Error estimating gas for wrap/unwrap. Using default gas limit ' +
       WRAP_UNWRAP_GAS_LIMIT_DEFAULT.toString(),
     error

--- a/src/custom/hooks/useWrapEther.ts
+++ b/src/custom/hooks/useWrapEther.ts
@@ -7,6 +7,7 @@ import { useWETHContract } from 'hooks/useContract'
 import { ContractTransaction } from '@ethersproject/contracts'
 import { formatSmart } from '../utils/format'
 import { AMOUNT_PRECISION } from 'constants/index'
+import { devLog } from 'utils/logging'
 
 export type Wrap = (amount: CurrencyAmount<Currency>) => Promise<ContractTransaction | string>
 
@@ -16,7 +17,7 @@ export function useWrapEther() {
 
   const wrapCallback = useCallback<Wrap>(
     async (amount) => {
-      console.log('Wrapping ETH!', amount.quotient.toString(), weth)
+      devLog('Wrapping ETH!', amount.quotient.toString(), weth)
 
       if (!weth) {
         // callback not reachable anyway when `weth` is not set
@@ -30,7 +31,7 @@ export function useWrapEther() {
           hash: txReceipt.hash,
           summary: `Wrap ${formatSmart(amount, AMOUNT_PRECISION)} ETH to WETH`,
         })
-        console.log('Wrapped!', amount)
+        devLog('Wrapped!', amount)
         return txReceipt
       } catch (error) {
         console.error('Could not WRAP', error)

--- a/src/custom/pages/Claim/index.tsx
+++ b/src/custom/pages/Claim/index.tsx
@@ -29,6 +29,7 @@ import InvestmentFlow from './InvestmentFlow'
 import { ClaimSummary } from './ClaimSummary'
 
 import usePrevious from 'hooks/usePrevious'
+import { devLog } from 'utils/logging'
 
 export default function Claim() {
   const { account, chainId } = useActiveWeb3React()
@@ -169,10 +170,10 @@ export default function Claim() {
 
     // check if there are any selected (paid) claims
     if (!selected.length) {
-      console.log('Starting claiming with', claimInputData)
+      devLog('Starting claiming with', claimInputData)
       sendTransaction(claimInputData)
     } else if (investFlowStep == 2) {
-      console.log('Starting claiming with', claimInputData)
+      devLog('Starting claiming with', claimInputData)
       sendTransaction(claimInputData)
     } else {
       setIsInvestFlowActive(true)

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -35,6 +35,7 @@ import { V_COW } from 'constants/tokens'
 import VCOWDropdown from './VCOWDropdown'
 
 import { IS_CLAIMING_ENABLED } from 'pages/Claim/const'
+import { devLog } from 'utils/logging'
 
 export default function Profile() {
   const referralLink = useReferralLink()
@@ -200,7 +201,7 @@ export default function Profile() {
               </FlexWrap>
             </ChildWrapper>
           </GridWrap>
-          {!account && <Web3Status openOrdersPanel={() => console.log('TODO')} />}
+          {!account && <Web3Status openOrdersPanel={() => devLog('TODO')} />}
         </GridWrap>
       </Wrapper>
     </Container>

--- a/src/custom/state/claim/hooks/index.ts
+++ b/src/custom/state/claim/hooks/index.ts
@@ -61,6 +61,7 @@ import { AMOUNT_PRECISION } from 'constants/index'
 import useIsMounted from 'hooks/useIsMounted'
 import { ChainId } from '@uniswap/sdk'
 import { ClaimInfo } from 'state/claim/reducer'
+import { devLog, devDebug } from 'utils/logging'
 
 const CLAIMS_REPO_BRANCH = 'gip-13'
 export const CLAIMS_REPO = `https://raw.githubusercontent.com/gnosis/cow-merkle-drop/${CLAIMS_REPO_BRANCH}/`
@@ -283,7 +284,7 @@ function fetchDeploymentTimestamp(vCowContract: VCowType, chainId: ChainId): Pro
 
   if (!deploymentTimePromise) {
     deploymentTimePromise = vCowContract.deploymentTimestamp().then((ts) => {
-      console.log(`Deployment timestamp in seconds: ${ts.toString()}`)
+      devLog(`Deployment timestamp in seconds: ${ts.toString()}`)
       return ts.mul('1000').toNumber()
     })
     FETCH_DEPLOYMENT_TIME_PROMISES.set(chainId, deploymentTimePromise)
@@ -398,7 +399,7 @@ function _useVCowPriceForToken(priceFnName: VCowPriceFnNames): string | null {
     if (!chainId || !vCowContract) {
       return
     }
-    console.debug(`_useVCowPriceForToken::fetching price for `, priceFnName)
+    devDebug(`_useVCowPriceForToken::fetching price for `, priceFnName)
 
     vCowContract[priceFnName]().then((price: BigNumber) => setPrice(price.toString()))
   }, [chainId, priceFnName, vCowContract])
@@ -516,7 +517,7 @@ export function useClaimCallback(account: string | null | undefined): {
         }
 
         if (!args) {
-          console.debug('Failed to estimate gas for claiming: There were no valid claims selected')
+          devDebug('Failed to estimate gas for claiming: There were no valid claims selected')
           return
         }
 
@@ -525,7 +526,7 @@ export function useClaimCallback(account: string | null | undefined): {
         // Not awaiting means the caller will have to deal with that, which I don't want in this case
         return await vCowContract.estimateGas.claimMany(...args)
       } catch (e) {
-        console.debug('Failed to estimate gas for claiming:', e.message)
+        devDebug('Failed to estimate gas for claiming:', e.message)
         return
       }
     },
@@ -834,7 +835,7 @@ export function fetchClaims(account: string, chainId: number): Promise<UserClaim
         throw new Error(`Claim for ${claimKey} was not found in claim file!`)
       })
       .catch((error) => {
-        console.debug(`Claim fetch failed for ${claimKey}`, error)
+        devDebug(`Claim fetch failed for ${claimKey}`, error)
         throw error
       }))
   )

--- a/src/custom/state/claim/middleware.ts
+++ b/src/custom/state/claim/middleware.ts
@@ -3,6 +3,7 @@ import { getCowSoundSend, getCowSoundSuccessClaim } from 'utils/sound'
 import { AppState } from 'state'
 import { addTransaction, finalizeTransaction } from '../enhancedTransactions/actions'
 import { ClaimStatus, setClaimStatus } from './actions'
+import { devDebug } from 'utils/logging'
 
 const isFinalizeTransaction = isAnyOf(finalizeTransaction)
 const isAddTransaction = isAnyOf(addTransaction)
@@ -17,7 +18,7 @@ export const claimMinedMiddleware: Middleware<Record<string, unknown>, AppState>
     const transaction = store.getState().transactions[chainId][hash]
 
     if (transaction.claim) {
-      console.debug('[stat:claim:middleware] Claim transaction sent', transaction.hash, transaction.claim)
+      devDebug('[stat:claim:middleware] Claim transaction sent', transaction.hash, transaction.claim)
       cowSound = getCowSoundSend()
     }
   } else if (isFinalizeTransaction(action)) {
@@ -26,7 +27,7 @@ export const claimMinedMiddleware: Middleware<Record<string, unknown>, AppState>
 
     if (transaction.claim) {
       const status = transaction.receipt?.status
-      console.debug(
+      devDebug(
         `[stat:claim:middleware] Claim transaction finalized withs status ${status}`,
         transaction.hash,
         transaction.claim

--- a/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
+++ b/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
@@ -15,6 +15,7 @@ import { useAllTransactionsDetails } from 'state/enhancedTransactions/hooks'
 import { Dispatch } from 'redux'
 import { TransactionReceipt } from '@ethersproject/abstract-provider'
 import { GetSafeInfo, useGetSafeInfo } from 'hooks/useGetSafeInfo'
+import { devLog } from 'utils/logging'
 
 type TxInterface = Pick<
   EnhancedTransactionDetails,
@@ -61,7 +62,7 @@ function finalizeEthereumTransaction(
   const { chainId, lastBlockNumber, addPopup, dispatch } = params
   const { hash } = transaction
 
-  console.log(`[FinalizeTxUpdater] Transaction ${receipt.transactionHash} has been mined`, receipt)
+  devLog(`[FinalizeTxUpdater] Transaction ${receipt.transactionHash} has been mined`, receipt)
 
   dispatch(
     finalizeTransaction({
@@ -115,7 +116,7 @@ function checkEthereumTransactions(params: CheckEthereumTransactions): Cancel[] 
           // If the safe transaction is executed, but we don't have a tx receipt yet
           if (isExecuted && !receipt) {
             // Get the ethereum tx receipt
-            console.log(
+            devLog(
               '[FinalizeTxUpdater] Safe transaction is executed, but we have not fetched the receipt yet. Tx: ',
               transactionHash
             )

--- a/src/custom/state/lists/updater/updaterMod.ts
+++ b/src/custom/state/lists/updater/updaterMod.ts
@@ -14,6 +14,7 @@ import { useActiveListUrls } from 'state/lists/hooks'
 
 // MOD: add updateVersion for chainId change init
 import { updateVersion } from 'state/global/actions'
+import { devDebug } from 'utils/logging'
 
 export default function Updater(): null {
   const { chainId: connectedChainId, library } = useActiveWeb3React() // MOD: chainId
@@ -31,7 +32,7 @@ export default function Updater(): null {
   const fetchAllListsCallback = useCallback(() => {
     if (!isWindowVisible) return
     Object.keys(lists).forEach((url) =>
-      fetchList(url).catch((error) => console.debug('interval list fetching error', error))
+      fetchList(url).catch((error) => devDebug('interval list fetching error', error))
     )
   }, [fetchList, isWindowVisible, lists])
 
@@ -53,7 +54,7 @@ export default function Updater(): null {
     Object.keys(lists).forEach((listUrl) => {
       const list = lists[listUrl]
       if (!list.current && !list.loadingRequestId && !list.error) {
-        fetchList(listUrl).catch((error) => console.debug('list added fetching error', error))
+        fetchList(listUrl).catch((error) => devDebug('list added fetching error', error))
       }
     })
   }, [dispatch, fetchList, library, lists])
@@ -63,7 +64,7 @@ export default function Updater(): null {
     Object.keys(UNSUPPORTED_LIST_URLS[chainId]).forEach((listUrl) => {
       const list = lists[listUrl]
       if (!list || (!list.current && !list.loadingRequestId && !list.error)) {
-        fetchList(listUrl).catch((error) => console.debug('list added fetching error', error))
+        fetchList(listUrl).catch((error) => devDebug('list added fetching error', error))
       }
     })
   }, [chainId, dispatch, fetchList, library, lists])

--- a/src/custom/state/orders/hooks.ts
+++ b/src/custom/state/orders/hooks.ts
@@ -41,6 +41,7 @@ import { isTruthy } from 'utils/misc'
 import { OrderID } from 'api/gnosisProtocol'
 import { ContractDeploymentBlocks } from './consts'
 import { deserializeToken, serializeToken } from '@src/state/user/hooks'
+import { devDebug } from 'utils/logging'
 
 export interface AddOrUpdateUnserialisedOrdersParams extends Omit<AddOrUpdateOrdersParams, 'orders'> {
   orders: Order[]
@@ -135,8 +136,7 @@ function _deserializeOrder(orderObject: OrderObject | V2OrderObject | undefined)
       outputToken: deserialisedOutputToken,
     }
   } else {
-    orderObject?.order &&
-      console.debug('[Order::hooks] - V2 Order detected, skipping serialisation.', orderObject.order)
+    orderObject?.order && devDebug('[Order::hooks] - V2 Order detected, skipping serialisation.', orderObject.order)
   }
 
   return order

--- a/src/custom/state/orders/updaters/CancelledOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/CancelledOrdersUpdater.ts
@@ -48,7 +48,7 @@ export function CancelledOrdersUpdater(): null {
       }
 
       // const startTime = Date.now()
-      // console.debug('[CancelledOrdersUpdater] Checking recently canceled orders....')
+      // devDebug('[CancelledOrdersUpdater] Checking recently canceled orders....')
       try {
         isUpdating.current = true
 
@@ -62,10 +62,10 @@ export function CancelledOrdersUpdater(): null {
         })
 
         if (pending.length === 0) {
-          // console.debug(`[CancelledOrdersUpdater] No orders are being cancelled`)
+          // devDebug(`[CancelledOrdersUpdater] No orders are being cancelled`)
           return
         } /* else {
-          console.debug(`[CancelledOrdersUpdater] Checking ${pending.length} recently canceled orders...`)
+          devDebug(`[CancelledOrdersUpdater] Checking ${pending.length} recently canceled orders...`)
         }*/
 
         // Iterate over pending orders fetching operator order data, async
@@ -99,7 +99,7 @@ export function CancelledOrdersUpdater(): null {
           })
       } finally {
         isUpdating.current = false
-        // console.debug(`[CancelledOrdersUpdater] Checked recently canceled orders in ${Date.now() - startTime}ms`)
+        // devDebug(`[CancelledOrdersUpdater] Checked recently canceled orders in ${Date.now() - startTime}ms`)
       }
     },
     [fulfillOrdersBatch]

--- a/src/custom/state/orders/updaters/GpOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/GpOrdersUpdater.ts
@@ -14,6 +14,7 @@ import { classifyOrder, OrderTransitionStatus } from 'state/orders/utils'
 import { computeOrderSummary } from 'state/orders/updaters/utils'
 import { useTokenLazy } from 'hooks/useTokenLazy'
 import { useGpOrders } from 'api/gnosisProtocol/hooks'
+import { devDebug } from 'utils/logging'
 
 function _getTokenFromMapping(
   address: string,
@@ -155,7 +156,7 @@ export function GpOrdersUpdater(): null {
   const updateOrders = useCallback(
     async (chainId: ChainId, account: string): Promise<void> => {
       const tokens = allTokensRef.current
-      console.debug(
+      devDebug(
         `GpOrdersUpdater:: updating orders. Network ${chainId}, account ${account}, loaded tokens count ${
           Object.keys(tokens).length
         }`
@@ -166,11 +167,11 @@ export function GpOrdersUpdater(): null {
         }
 
         const tokensToFetch = _getMissingTokensAddresses(gpOrders, tokens, chainId)
-        console.debug(`GpOrdersUpdater::will try to fetch ${tokensToFetch.length} tokens`)
+        devDebug(`GpOrdersUpdater::will try to fetch ${tokensToFetch.length} tokens`)
 
         // Fetch them from the chain
         const fetchedTokens = await _fetchTokens(tokensToFetch, getToken)
-        console.debug(
+        devDebug(
           `GpOrdersUpdater::fetched ${Object.keys(fetchedTokens).filter(Boolean).length} out of ${
             tokensToFetch.length
           } tokens`
@@ -182,7 +183,7 @@ export function GpOrdersUpdater(): null {
         // Build store order objects, for all orders which we found both input/output tokens
         // Don't add order for those we didn't
         const orders = _filterOrders(gpOrders, reallyAllTokens, chainId)
-        console.debug(`GpOrdersUpdater::will add/update ${orders.length} out of ${gpOrders.length}`)
+        devDebug(`GpOrdersUpdater::will add/update ${orders.length} out of ${gpOrders.length}`)
 
         // Add orders to redux state
         orders.length && addOrUpdateOrders({ orders, chainId })

--- a/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
@@ -25,6 +25,7 @@ import { OrderID } from 'api/gnosisProtocol'
 
 import { fetchOrderPopupData, OrderLogPopupMixData } from 'state/orders/updaters/utils'
 import { GetSafeInfo, useGetSafeInfo } from 'hooks/useGetSafeInfo'
+import { devLog } from 'utils/logging'
 
 /**
  * Return the ids of the orders that we are not yet aware that are signed.
@@ -62,14 +63,14 @@ async function _updatePresignGnosisSafeTx(
     .map((order): Promise<void> => {
       // Get safe info and receipt
       const presignGnosisSafeTxHash = order.presignGnosisSafeTxHash as string
-      console.log('[PendingOrdersUpdater] Get Gnosis Transaction info for tx:', presignGnosisSafeTxHash)
+      devLog('[PendingOrdersUpdater] Get Gnosis Transaction info for tx:', presignGnosisSafeTxHash)
 
       const { promise: safeTransactionPromise } = getSafeInfo(presignGnosisSafeTxHash)
 
       // Get safe info
       return safeTransactionPromise
         .then((safeTransaction) => {
-          console.log('[PendingOrdersUpdater] Update Gnosis Safe transaction info: ', safeTransaction)
+          devLog('[PendingOrdersUpdater] Update Gnosis Safe transaction info: ', safeTransaction)
           updatePresignGnosisSafeTx({ orderId: order.id, chainId, safeTransaction })
         })
         .catch((error) => {
@@ -118,10 +119,10 @@ async function _updateOrders({
 
   // Exit early when there are no pending orders
   if (pending.length === 0) {
-    // console.debug('[PendingOrdersUpdater] No orders to update')
+    // devDebug('[PendingOrdersUpdater] No orders to update')
     return
   } /* else {
-    console.debug(
+    devDebug(
       `[PendingOrdersUpdater] Update ${pending.length} orders for account ${account} and network ${chainId}`
     )
   }*/
@@ -207,7 +208,7 @@ export function PendingOrdersUpdater(): null {
       if (!isUpdating.current) {
         isUpdating.current = true
         // const startTime = Date.now()
-        // console.debug('[PendingOrdersUpdater] Updating orders....')
+        // devDebug('[PendingOrdersUpdater] Updating orders....')
         return _updateOrders({
           account,
           chainId,
@@ -220,7 +221,7 @@ export function PendingOrdersUpdater(): null {
           getSafeInfo,
         }).finally(() => {
           isUpdating.current = false
-          // console.debug(`[PendingOrdersUpdater] Updated orders in ${Date.now() - startTime}ms`)
+          // devDebug(`[PendingOrdersUpdater] Updated orders in ${Date.now() - startTime}ms`)
         })
       }
     },

--- a/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -13,6 +13,7 @@ import { getBestQuote, PriceInformation } from 'utils/price'
 import { isOrderUnfillable } from 'state/orders/utils'
 import useGetGpPriceStrategy, { GpPriceStrategy } from 'hooks/useGetGpPriceStrategy'
 import { getPromiseFulfilledValue } from 'utils/misc'
+import { devDebug } from 'utils/logging'
 
 /**
  * Thin wrapper around `getBestPrice` that builds the params and returns null on failure
@@ -84,7 +85,7 @@ export function UnfillableOrdersUpdater(): null {
     }
 
     const startTime = Date.now()
-    console.debug('[UnfillableOrdersUpdater] Checking new market price for orders....')
+    devDebug('[UnfillableOrdersUpdater] Checking new market price for orders....')
     try {
       isUpdating.current = true
 
@@ -93,10 +94,10 @@ export function UnfillableOrdersUpdater(): null {
       const pending = pendingRef.current.filter(({ owner }) => owner.toLowerCase() === lowerCaseAccount)
 
       if (pending.length === 0) {
-        // console.debug('[UnfillableOrdersUpdater] No orders to update')
+        // devDebug('[UnfillableOrdersUpdater] No orders to update')
         return
       } else {
-        console.debug(
+        devDebug(
           `[UnfillableOrdersUpdater] Checking new market price for ${pending.length} orders, account ${account} and network ${chainId}`
         )
       }
@@ -106,19 +107,19 @@ export function UnfillableOrdersUpdater(): null {
           if (quote) {
             const [promisedPrice] = quote
             const price = getPromiseFulfilledValue(promisedPrice, null)
-            console.debug(
+            devDebug(
               `[UnfillableOrdersUpdater::updateUnfillable] did we get any price? ${order.id.slice(0, 8)}|${index}`,
               price ? price.amount : 'no :('
             )
             price?.amount && updateIsUnfillableFlag(chainId, order, price)
           } else {
-            console.debug('[UnfillableOrdersUpdater::updateUnfillable] No price quote for', order.id.slice(0, 8))
+            devDebug('[UnfillableOrdersUpdater::updateUnfillable] No price quote for', order.id.slice(0, 8))
           }
         })
       )
     } finally {
       isUpdating.current = false
-      console.debug(`[UnfillableOrdersUpdater] Checked canceled orders in ${Date.now() - startTime}ms`)
+      devDebug(`[UnfillableOrdersUpdater] Checked canceled orders in ${Date.now() - startTime}ms`)
     }
   }, [account, chainId, strategy, updateIsUnfillableFlag])
 

--- a/src/custom/state/orders/updaters/utils.ts
+++ b/src/custom/state/orders/updaters/utils.ts
@@ -5,6 +5,7 @@ import { formatSmart } from 'utils/format'
 import { AMOUNT_PRECISION } from 'constants/index'
 import { OrderTransitionStatus, classifyOrder } from 'state/orders/utils'
 import { SupportedChainId as ChainId } from 'constants/chains'
+import { devLog } from 'utils/logging'
 
 export type OrderLogPopupMixData = OrderFulfillmentData | OrderID
 
@@ -42,7 +43,7 @@ export function computeOrderSummary({
       summary = `Swap ${sellToken} for ${buyToken}`
     }
   } else {
-    console.log(`[state:orders:updater] computeFulfilledSummary::API data not yet in sync with blockchain`)
+    devLog(`[state:orders:updater] computeFulfilledSummary::API data not yet in sync with blockchain`)
   }
 
   return summary

--- a/src/custom/state/orders/utils.ts
+++ b/src/custom/state/orders/utils.ts
@@ -9,6 +9,7 @@ import { PriceInformation } from 'utils/price'
 import { OUT_OF_MARKET_PRICE_DELTA_PERCENTAGE } from 'state/orders/consts'
 import { calculatePrice, invertPrice, ZERO_BIG_NUMBER } from '@gnosis.pm/dex-js'
 import { BigNumber } from 'bignumber.js'
+import { devDebug } from 'utils/logging'
 
 export type OrderTransitionStatus =
   | 'unknown'
@@ -76,33 +77,30 @@ export function classifyOrder(
   > | null
 ): OrderTransitionStatus {
   if (!order) {
-    console.debug(`[state::orders::classifyOrder] unknown order`)
+    devDebug(`[state::orders::classifyOrder] unknown order`)
     return 'unknown'
   } else if (isOrderFulfilled(order)) {
-    console.debug(
+    devDebug(
       `[state::orders::classifyOrder] fulfilled order ${order.uid.slice(0, 10)} ${order.executedBuyAmount} | ${
         order.executedSellAmount
       }`
     )
     return 'fulfilled'
   } else if (isOrderCancelled(order)) {
-    console.debug(`[state::orders::classifyOrder] cancelled order ${order.uid.slice(0, 10)}`)
+    devDebug(`[state::orders::classifyOrder] cancelled order ${order.uid.slice(0, 10)}`)
     return 'cancelled'
   } else if (isOrderExpired(order)) {
-    console.debug(
-      `[state::orders::classifyOrder] expired order ${order.uid.slice(0, 10)}`,
-      new Date(order.validTo * 1000)
-    )
+    devDebug(`[state::orders::classifyOrder] expired order ${order.uid.slice(0, 10)}`, new Date(order.validTo * 1000))
     return 'expired'
   } else if (isPresignPending(order)) {
-    console.debug(`[state::orders::classifyOrder] presignPending order ${order.uid.slice(0, 10)}`)
+    devDebug(`[state::orders::classifyOrder] presignPending order ${order.uid.slice(0, 10)}`)
     return 'presignaturePending'
   } else if (isOrderPresigned(order)) {
-    console.debug(`[state::orders::classifyOrder] presigned order ${order.uid.slice(0, 10)}`)
+    devDebug(`[state::orders::classifyOrder] presigned order ${order.uid.slice(0, 10)}`)
     return 'presigned'
   }
 
-  console.debug(`[state::orders::classifyOrder] pending order ${order.uid.slice(0, 10)}`)
+  devDebug(`[state::orders::classifyOrder] pending order ${order.uid.slice(0, 10)}`)
   return 'pending'
 }
 
@@ -227,7 +225,7 @@ export function isOrderUnfillable(order: Order, price: Required<PriceInformation
   // Calculate the percentage of the current price in regards to the order price
   const percentageDifference = ONE_HUNDRED_PERCENT.subtract(currentPrice.divide(orderPrice))
 
-  console.debug(
+  devDebug(
     `[UnfillableOrdersUpdater::isOrderUnfillable] ${order.kind} [${order.id.slice(0, 8)}]:`,
     orderPrice.toSignificant(10),
     currentPrice.toSignificant(10),

--- a/src/custom/state/price/updater.ts
+++ b/src/custom/state/price/updater.ts
@@ -43,7 +43,7 @@ function isExpiringSoon(quoteExpirationIsoDate: string, threshold: number): bool
   const needRefetch = feeExpirationDate <= Date.now() + threshold
 
   // const secondsLeft = (feeExpirationDate.valueOf() - Date.now()) / 1000
-  // console.log(`[state:price:updater] Fee isExpiring in ${secondsLeft}. Refetch?`, needRefetch)
+  // devLog(`[state:price:updater] Fee isExpiring in ${secondsLeft}. Refetch?`, needRefetch)
 
   return needRefetch
 }

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -41,6 +41,7 @@ import { WETH9_EXTENDED as WETH, GpEther as ETHER } from 'constants/tokens'
 import { useIsExpertMode, useUserSlippageToleranceWithDefault } from '@src/state/user/hooks'
 import { PriceImpact } from 'hooks/usePriceImpact'
 import { isWrappingTrade } from './utils'
+import { devDebug } from 'utils/logging'
 
 export * from '@src/state/swap/hooks'
 
@@ -113,7 +114,7 @@ interface DerivedSwapInfo {
     }
   } catch (error) {
     // should fail if the user specifies too many decimal places of precision (or maybe exceed max uint?)
-    console.debug(`Failed to parse input amount: "${value}"`, error)
+    devDebug(`Failed to parse input amount: "${value}"`, error)
   }
   // necessary for all paths to return a value
   return undefined
@@ -297,8 +298,8 @@ export function useDerivedSwapInfo(): /* {
 
   // purely for debugging
   useEffect(() => {
-    console.debug('[useDerivedSwapInfo] Price quote: ', quote?.price?.amount)
-    console.debug('[useDerivedSwapInfo] Fee quote: ', quote?.fee?.amount)
+    devDebug('[useDerivedSwapInfo] Price quote: ', quote?.price?.amount)
+    devDebug('[useDerivedSwapInfo] Fee quote: ', quote?.fee?.amount)
   }, [quote])
 
   const isWrapping = isWrappingTrade(inputCurrency, outputCurrency, chainId)

--- a/src/custom/state/swap/utils.ts
+++ b/src/custom/state/swap/utils.ts
@@ -2,6 +2,7 @@ import { SupportedChainId } from 'constants/chains'
 import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
 import TradeGp from './TradeGp'
 import { WETH9_EXTENDED } from 'constants/tokens'
+import { devDebug } from 'utils/logging'
 
 export function isWrappingTrade(
   sellCurrency: Currency | null | undefined,
@@ -23,7 +24,7 @@ export function logTradeDetails(trade: TradeGp | undefined, allowedSlippage: Per
 
   // Log Exact In Trade info
   if (exactIn) {
-    console.debug(
+    devDebug(
       `[SwapMod::[SELL] Trade Constructed]`,
       `
       Type: SELL
@@ -41,7 +42,7 @@ export function logTradeDetails(trade: TradeGp | undefined, allowedSlippage: Per
     )
   } else {
     // Log Exact Out Trade info
-    console.debug(
+    devDebug(
       `[SwapMod::[BUY] Trade Constructed]`,
       `
       Type: BUY

--- a/src/custom/utils/blocknative.ts
+++ b/src/custom/utils/blocknative.ts
@@ -1,5 +1,6 @@
 import BlocknativeSdk from 'bnc-sdk'
 import { getSupportedChainIds } from 'connectors'
+import { devInfo, devLog } from './logging'
 
 const BLOCKNATIVE_API_KEY = process.env.REACT_APP_BLOCKNATIVE_API_KEY
 
@@ -19,14 +20,14 @@ export const sdk = !BLOCKNATIVE_API_KEY
           networkId,
           name: 'bnc_' + networkId,
           onerror: (error: SDKError) => {
-            console.log(error)
+            devLog(error)
           },
         })
       } catch (error) {
         console.error('Instantiating BlocknativeSdk failed', error)
       }
 
-      console.info(`BlocknativeSdk initialized on chain ${networkId}`)
+      devInfo(`BlocknativeSdk initialized on chain ${networkId}`)
 
       return acc
     }, {})

--- a/src/custom/utils/getLibrary.ts
+++ b/src/custom/utils/getLibrary.ts
@@ -1,6 +1,7 @@
 import { Web3Provider } from '@ethersproject/providers'
 import ms from 'ms.macro'
 import { SupportedChainId } from 'constants/chains'
+import { devDebug } from './logging'
 
 const NETWORK_POLLING_INTERVALS: { [chainId: number]: number } = {
   // [SupportedChainId.ARBITRUM_ONE]: ms`1s`,
@@ -23,7 +24,7 @@ export default function getLibrary(provider: any): Web3Provider {
   library.detectNetwork().then((network) => {
     const networkPollingInterval = NETWORK_POLLING_INTERVALS[network.chainId]
     if (networkPollingInterval) {
-      console.debug('Setting polling interval', networkPollingInterval)
+      devDebug('Setting polling interval', networkPollingInterval)
       library.pollingInterval = networkPollingInterval
     }
   })

--- a/src/custom/utils/logging/index.ts
+++ b/src/custom/utils/logging/index.ts
@@ -37,3 +37,20 @@ export function checkAndThrowIfJsonSerialisableError(response: Response) {
     )
   }
 }
+
+// Curried fn base
+// Logs a choice from LogType in any env except Production. Else noop
+type LogType = keyof Pick<Console, 'debug' | 'log' | 'error' | 'warn' | 'info'>
+export const devConsole =
+  (type: LogType) =>
+  (...args: any[]) => {
+    if (process.env.NODE_ENV !== 'production') {
+      return console[type](...args)
+    }
+  }
+
+export const devLog = devConsole('log')
+export const devWarn = devConsole('warn')
+export const devInfo = devConsole('info')
+export const devError = devConsole('error')
+export const devDebug = devConsole('debug')

--- a/src/custom/utils/signatures.ts
+++ b/src/custom/utils/signatures.ts
@@ -15,6 +15,7 @@ import { SupportedChainId as ChainId } from 'constants/chains'
 import { GP_SETTLEMENT_CONTRACT_ADDRESS } from 'constants/index'
 import { TypedDataDomain, Signer } from '@ethersproject/abstract-signer'
 import { registerOnWindow } from 'utils/misc'
+import { devLog } from './logging'
 
 // For error codes, see:
 // - https://eth.wiki/json-rpc/json-rpc-error-codes-improvement-proposal
@@ -105,7 +106,7 @@ async function _signOrder(params: SignOrderParams): Promise<Signature> {
   const { chainId, signer, order, signingScheme } = params
 
   const domain = _getDomain(chainId)
-  console.log('[utils:signature] signOrder', {
+  devLog('[utils:signature] signOrder', {
     domain,
     order,
     signer,
@@ -119,7 +120,7 @@ async function _signOrderCancellation(params: SingOrderCancellationParams): Prom
 
   const domain = _getDomain(chainId)
 
-  console.log('[utils:signature] signOrderCancellation', {
+  devLog('[utils:signature] signOrderCancellation', {
     domain,
     orderId,
     signer,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,6 +34,7 @@ import getLibrary from 'utils/getLibrary'
 import AppziButton from 'components/AppziButton'
 import RadialGradientByChainUpdater from 'theme/RadialGradientByChainUpdater'
 import { nodeRemoveChildFix } from 'utils/node'
+import { devLog } from 'utils/logging'
 
 // Node removeChild hackaround
 // based on: https://github.com/facebook/react/issues/11538#issuecomment-417504600
@@ -99,7 +100,7 @@ async function deleteAllCaches() {
   const cacheNames = (await caches.keys()) || []
 
   cacheNames.map((cacheName) => {
-    console.log('[worker] Delete cache', cacheName)
+    devLog('[worker] Delete cache', cacheName)
     // Delete old caches
     // https://developers.google.com/web/ilt/pwa/caching-files-with-service-worker#removing_outdated_caches
     return caches.delete(cacheName)
@@ -115,16 +116,16 @@ async function unregisterAllWorkers() {
 }
 
 if ('serviceWorker' in navigator) {
-  console.log('[worker] Unregister worker...')
+  devLog('[worker] Unregister worker...')
   serviceWorkerRegistration.unregister()
 
-  console.log('[worker] Deleting all caches...')
+  devLog('[worker] Deleting all caches...')
   deleteAllCaches()
-    .then(() => console.log('[worker] All caches have been deleted'))
+    .then(() => devLog('[worker] All caches have been deleted'))
     .catch(console.error)
 
-  console.log('[worker] Unregistering all workers...')
+  devLog('[worker] Unregistering all workers...')
   unregisterAllWorkers()
-    .then(() => console.log('[worker] All workers have been unregistered'))
+    .then(() => devLog('[worker] All workers have been unregistered'))
     .catch(console.error)
 }

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -5,13 +5,14 @@ import { clientsClaim, setCacheNameDetails } from 'workbox-core'
 import { createHandlerBoundToURL, precacheAndRoute } from 'workbox-precaching'
 import { registerRoute } from 'workbox-routing'
 import { version as WEB_VERSION } from '@src/../package.json'
+import { devLog } from 'utils/logging'
 
 declare const self: ServiceWorkerGlobalScope
 
 const DNS_DOMAINS = ['cowswap.exchange', 'barn.cowswap.exchange']
 const DEV_DOMAINS_SUFFIX = '.gnosisdev.com'
 
-console.log(`[worker] registerRoutes for v${WEB_VERSION}`)
+devLog(`[worker] registerRoutes for v${WEB_VERSION}`)
 
 // Set Cache name
 //  See https://dev.to/atonchev/flawless-and-silent-upgrade-of-the-service-worker-2o95
@@ -25,13 +26,13 @@ setCacheNameDetails({
 self.addEventListener('message', (event) => {
   // Regular skip waiting
   if (event.data && event.data.type === 'SKIP_WAITING') {
-    console.log('[worker] Skip waiting')
+    devLog('[worker] Skip waiting')
     self.skipWaiting()
   }
 
   // Our special skip waiting function!
   if (event.data && event.data.type === 'SKIP_WAITING_WHEN_SOLO') {
-    console.log('[worker] Skip waiting when solo')
+    devLog('[worker] Skip waiting when solo')
     self.clients
       .matchAll({
         includeUncontrolled: true,
@@ -44,7 +45,7 @@ self.addEventListener('message', (event) => {
   }
 
   if (event.data && event.data.type === 'PREPARE_CACHES_FOR_UPDATE') {
-    console.log('[worker] Prepare cache for update')
+    devLog('[worker] Prepare cache for update')
     prepareCachesForUpdate().then()
   }
 })
@@ -53,7 +54,7 @@ self.addEventListener('activate', (event) => {
   event.waitUntil(
     getCacheStorageNames().then(({ outdatedCacheNames }) =>
       outdatedCacheNames.map((cacheName) => {
-        console.log('[worker] Delete cache', cacheName)
+        devLog('[worker] Delete cache', cacheName)
         // Delete old caches
         // https://developers.google.com/web/ilt/pwa/caching-files-with-service-worker#removing_outdated_caches
         return caches.delete(cacheName)
@@ -138,28 +139,28 @@ type IndexRegisterParams = { request: Request; url: URL }
 registerRoute((params: IndexRegisterParams) => {
   const { request, url } = params
 
-  // console.log('[worker] Index.html', request, url, params)
+  // devLog('[worker] Index.html', request, url, params)
   // return false
   // If this isn't a DNS domain skip. IPFS gateways may not have domain
   // separation, so they cannot use App Shell-style routing.
   const hostName = url.hostname
   if (!DNS_DOMAINS.includes(hostName) && !hostName.endsWith(DEV_DOMAINS_SUFFIX)) {
-    // console.log('[worker] FALSE. hostname', hostName)
+    // devLog('[worker] FALSE. hostname', hostName)
     return false
   }
 
   // If this isn't a navigation, skip.
   if (request.mode !== 'navigate') {
-    // console.log('[worker] FALSE. No navigate', request.mode)
+    // devLog('[worker] FALSE. No navigate', request.mode)
     return false
   }
 
   // If this looks like a URL for a resource, skip.
   if (url.pathname.match(fileExtensionRegexp)) {
-    // console.log('[worker] FALSE. If this looks like a URL for a resource, skip.', request.mode)
+    // devLog('[worker] FALSE. If this looks like a URL for a resource, skip.', request.mode)
     return false
   }
 
-  // console.log('[worker] TRUE!')
+  // devLog('[worker] TRUE!')
   return true
 }, createHandlerBoundToURL(process.env.PUBLIC_URL + '/index.html'))

--- a/src/serviceWorkerRegistration.ts
+++ b/src/serviceWorkerRegistration.ts
@@ -1,6 +1,8 @@
 // This optional code is used to register a service worker.
 // register() is not called by default.
 
+import { devLog } from 'utils/logging'
+
 // This lets the app load faster on subsequent visits in production, and gives
 // it offline capabilities. However, it also means that developers (and users)
 // will only see deployed updates on subsequent visits to a page, after all the
@@ -41,7 +43,7 @@ const SWHelper = {
   },
 
   async prepareCachesForUpdate() {
-    console.log('[worker] prepareCachesForUpdate')
+    devLog('[worker] prepareCachesForUpdate')
     return (await SWHelper.getWaitingWorker())?.postMessage({ type: 'PREPARE_CACHES_FOR_UPDATE' })
   },
 }
@@ -51,7 +53,7 @@ function registerValidSW(swUrl: string, config?: Config) {
     .register(swUrl)
     .then((registration) => {
       if (registration.waiting && registration.active) {
-        console.log('[worker] Needs update (waiting & active)')
+        devLog('[worker] Needs update (waiting & active)')
         window.swNeedUpdate = true
       }
 
@@ -63,7 +65,7 @@ function registerValidSW(swUrl: string, config?: Config) {
         installingWorker.onstatechange = () => {
           if (installingWorker.state === 'installed') {
             if (navigator.serviceWorker.controller) {
-              console.log('[worker] Needs update (installed)')
+              devLog('[worker] Needs update (installed)')
               window.swNeedUpdate = true
 
               SWHelper.prepareCachesForUpdate().then()
@@ -71,7 +73,7 @@ function registerValidSW(swUrl: string, config?: Config) {
               // At this point, the updated precached content has been fetched,
               // but the previous service worker will still serve the older
               // content until all client tabs are closed.
-              console.log(
+              devLog(
                 '[worker] New content is available and will be used when all tabs for this page are closed. See https://cra.link/PWA.'
               )
 
@@ -83,7 +85,7 @@ function registerValidSW(swUrl: string, config?: Config) {
               // At this point, everything has been precached.
               // It's the perfect time to display a
               // "Content is cached for offline use." message.
-              console.log('[worker] Content is cached for offline use.')
+              devLog('[worker] Content is cached for offline use.')
 
               // Execute callback
               if (config && config.onSuccess) {
@@ -120,7 +122,7 @@ function checkValidServiceWorker(swUrl: string, config?: Config) {
       }
     })
     .catch(() => {
-      console.log('No internet connection found. App is running in offline mode.')
+      devLog('No internet connection found. App is running in offline mode.')
     })
 }
 
@@ -145,7 +147,7 @@ export function register(config?: Config) {
         // Add some additional logging to localhost, pointing developers to the
         // service worker/PWA documentation.
         navigator.serviceWorker.ready.then(() => {
-          console.log(
+          devLog(
             '[worker] This web app is being served cache-first by a service worker. To learn more, visit https://cra.link/PWA'
           )
         })


### PR DESCRIPTION
Part of #1887 - logging reduction

Create and use `dev<'Debug' | 'Log' | 'Info'>` instead of console equivalent, which only logs outside of `production` environment

Contains 3 non-custom changes: service-workers, service-workers-registration, and src/index (happy to discuss not doing this)

Dev logging functions are here: https://github.com/gnosis/cowswap/pull/2532/files#diff-719cf671e223d85af227c1001fefb49d0d83bbc63a5c37e1c67e78d82b24ea1e

## Testing
- open the PRaul link and check the console (only the default console logs from outside `/custom/` are there)