### PR TITLE
Add twitter metatag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,7 @@
   <meta name="twitter:site" content="@MEVprotection">
   <meta name="twitter:title" content="CowSwap | Meta DEX aggregator">
   <meta name="twitter:image" content="https://cowswap.exchange/images/og-meta-cowswap.png?v=1">
+  <meta name="twitter:image:src" content="https://cowswap.exchange/images/og-meta-cowswap.png?v=1">
 
   <!-- Other tags -->
   <meta name="fortmatic-site-verification" content="%REACT_APP_FORTMATIC_SITE_VERIFICATION%" />


### PR DESCRIPTION
# Summary

As suggested by @avsavsavs adding a new metatag for `twitter:image:url` 

See https://stackoverflow.com/questions/41740110/twitter-twitter-cards-not-showing-image-after-tweet-post for context