### PR TITLE
[🔥 🔥 Hotfix] 1.11.2 - Unfillable Orders quote issue

### DIFF
--- a/src/constants/wallet.ts
+++ b/src/constants/wallet.ts
@@ -53,7 +53,15 @@ export const SUPPORTED_WALLETS: { [key: string]: WalletInfo } = {
     description: 'Use Coinbase Wallet app on mobile device',
     href: null,
     color: '#315CF5',
+  },
+  COINBASE_LINK: {
+    name: 'Open in Coinbase Wallet',
+    iconURL: COINBASE_ICON_URL,
+    description: 'Open in Coinbase Wallet app.',
+    href: 'https://go.cb-w.com/mtUDhEZPy1',
+    color: '#315CF5',
     mobile: true,
+    mobileOnly: true,
   },
   FORTMATIC: {
     connector: fortmatic,

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -26,7 +26,13 @@ export const APP_DATA_HASH = getAppDataHash()
 export const PRODUCTION_URL = 'cowswap.exchange'
 export const BARN_URL = `barn.${PRODUCTION_URL}`
 
-const DISABLED_WALLETS = /^(?:Portis)$/i
+// Allow WALLET_LINK to be activated on mobile
+// since COINBASE_LINK is limited to use only 1 deeplink on mobile
+SUPPORTED_WALLETS_UNISWAP.WALLET_LINK = {
+  ...SUPPORTED_WALLETS_UNISWAP.WALLET_LINK,
+  mobile: true,
+}
+const DISABLED_WALLETS = /^(?:Portis|COINBASE_LINK)$/i
 
 // Re-export only the supported wallets
 export const SUPPORTED_WALLETS = Object.keys(SUPPORTED_WALLETS_UNISWAP).reduce((acc, key) => {
@@ -115,6 +121,7 @@ export const AMOUNT_OF_ORDERS_TO_FETCH = 100
 
 // last wallet provider key used in local storage
 export const STORAGE_KEY_LAST_PROVIDER = 'lastProvider'
+export const WAITING_TIME_RECONNECT_LAST_PROVIDER = 15000 // 15s
 
 // Default price strategy to use for getting app prices
 // COWSWAP = new quote endpoint

--- a/src/custom/hooks/useSwapCallback.ts
+++ b/src/custom/hooks/useSwapCallback.ts
@@ -192,6 +192,7 @@ async function _swap(params: SwapParams): Promise<string> {
     }),
     // unadjusted outputAmount
     outputAmount: outputAmountWithSlippage,
+    sellAmountBeforeFee: trade.inputAmountWithoutFee,
     // pass Trade feeAmount as raw string or give 0
     feeAmount: fee?.feeAsCurrency,
     sellToken,

--- a/src/custom/hooks/web3.ts
+++ b/src/custom/hooks/web3.ts
@@ -3,7 +3,7 @@ import { AbstractConnector } from '@web3-react/abstract-connector'
 import { useEffect, useState, useCallback } from 'react'
 import { isMobile } from 'react-device-detect'
 import { injected, walletconnect, getProviderType, WalletProvider, fortmatic, walletlink } from 'connectors'
-import { STORAGE_KEY_LAST_PROVIDER } from 'constants/index'
+import { STORAGE_KEY_LAST_PROVIDER, WAITING_TIME_RECONNECT_LAST_PROVIDER } from 'constants/index'
 
 // exports from the original file
 export { useActiveWeb3React, useInactiveListener } from '@src/hooks/web3'
@@ -58,7 +58,7 @@ export function useEagerConnect() {
         setTried(true)
       })
     },
-    [activate, setTried]
+    [activate]
   )
 
   useEffect(() => {
@@ -85,9 +85,18 @@ export function useEagerConnect() {
 
   // if the connection worked, wait until we get confirmation of that to flip the flag
   useEffect(() => {
+    let timeout: NodeJS.Timeout | undefined
+
     if (active) {
       setTried(true)
+    } else {
+      timeout = setTimeout(() => {
+        localStorage.removeItem(STORAGE_KEY_LAST_PROVIDER)
+        setTried(true)
+      }, WAITING_TIME_RECONNECT_LAST_PROVIDER)
     }
+
+    return () => timeout && clearTimeout(timeout)
   }, [active])
 
   useEffect(() => {

--- a/src/custom/state/orders/actions.ts
+++ b/src/custom/state/orders/actions.ts
@@ -5,6 +5,7 @@ import { Token } from '@uniswap/sdk-core'
 import { SupportedChainId as ChainId } from 'constants/chains'
 import { SerializedToken } from '@src/state/user/actions'
 import { SafeMultisigTransactionResponse } from '@gnosis.pm/safe-service-client'
+import { BigNumberish } from '@ethersproject/bignumber'
 export { OrderKind } from '@gnosis.pm/gp-v2-contracts'
 
 export enum OrderStatus {
@@ -20,6 +21,7 @@ export enum OrderStatus {
 //  - Additional information available in the API
 //  - Derived/additional information that is handy for this app
 // Doesn't have input/output tokens, these are declared in the subtypes of this base type
+// includes sellAmountBeforeFee as this is required for checking unfillable orders
 export interface BaseOrder extends Omit<OrderCreation, 'signingScheme'> {
   id: OrderID // Unique identifier for the order: 56 bytes encoded as hex without 0x
   owner: string // Address, without '0x' prefix
@@ -39,6 +41,9 @@ export interface BaseOrder extends Omit<OrderCreation, 'signingScheme'> {
   // Wallet specific
   presignGnosisSafeTxHash?: string // Gnosis Safe tx
   presignGnosisSafeTx?: SafeMultisigTransactionResponse // Gnosis Safe transaction info
+
+  // Sell amount before the fee applied - necessary for later calculations (unfilled orders)
+  sellAmountBeforeFee: BigNumberish
 }
 
 /**

--- a/src/custom/state/orders/mocks.ts
+++ b/src/custom/state/orders/mocks.ts
@@ -67,6 +67,7 @@ export const generateOrder = ({ owner, sellToken, buyToken }: GenerateOrderParam
     sellToken: sellToken.address.replace('0x', ''), // address, without '0x' prefix
     buyToken: buyToken.address.replace('0x', ''), // address, without '0x' prefix
     sellAmount: sellAmount.toString(RADIX_DECIMAL), // in atoms
+    sellAmountBeforeFee: sellAmount.toString(RADIX_DECIMAL), // in atoms
     buyAmount: buyAmount.toString(RADIX_DECIMAL), // in atoms
     // 20sec - 4min
     validTo: Date.now() / 1000 + randomIntInRangeExcept(20, 240), // uint32. unix timestamp, seconds, use new Date(validTo * 1000)

--- a/src/custom/state/orders/updaters/GpOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/GpOrdersUpdater.ts
@@ -65,6 +65,7 @@ function _transformGpOrderToStoreOrder(
 
   const storeOrder: Order = {
     ...order,
+    sellAmountBeforeFee: order.executedSellAmountBeforeFees,
     inputToken,
     outputToken,
     id,

--- a/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -50,15 +50,7 @@ async function _getOrderPrice(chainId: ChainId, order: Order, strategy: GpPriceS
     toDecimals: order.outputToken.decimals,
     validTo: timestamp(order.validTo),
   }
-  // console.debug('[UNFILLABLE]::BEFORE PRICE::', quoteParams.amount)
   try {
-    // if (order.kind === 'sell') {
-    //   // we need to calculate the fee separately to add to the sellAmount here
-    //   const { quote } = await getQuote(quoteParams)
-    //   const { feeAmount } = quote
-    //   quoteParams.amount = BigNumber.from(quoteParams.amount).add(BigNumber.from(feeAmount)).toString()
-    //   console.debug('[UNFILLABLE]::AFTER PRICE::', quoteParams.amount)
-    // }
     return getBestQuote({ strategy, quoteParams, fetchFee: false, isPriceRefresh: false })
   } catch (e) {
     return null

--- a/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -13,7 +13,6 @@ import { getBestQuote, PriceInformation } from 'utils/price'
 import { isOrderUnfillable } from 'state/orders/utils'
 import useGetGpPriceStrategy, { GpPriceStrategy } from 'hooks/useGetGpPriceStrategy'
 import { getPromiseFulfilledValue } from 'utils/misc'
-import { BigNumber } from '@ethersproject/bignumber'
 
 /**
  * Thin wrapper around `getBestPrice` that builds the params and returns null on failure
@@ -33,14 +32,6 @@ async function _getOrderPrice(chainId: ChainId, order: Order, strategy: GpPriceS
     amount = order.sellAmountBeforeFee.toString()
     baseToken = order.sellToken
     quoteToken = order.buyToken
-
-    console.debug('[UNFILLABLES]::SELL AMOUNT', order.sellAmount.toString())
-    console.debug('[UNFILLABLES]::FEE AMOUNT', order.feeAmount.toString())
-    console.debug(
-      '[UNFILLABLES]::SELL AMOUNT + FEE AMOUNT',
-      BigNumber.from(order.sellAmount).add(BigNumber.from(order.feeAmount)).toString()
-    )
-    console.debug('[UNFILLABLES]::EXECUTED SELL AMOUNT BEFORE FEES', amount)
   } else {
     amount = order.buyAmount.toString()
     baseToken = order.buyToken

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -19,6 +19,7 @@ export interface PostOrderParams {
   kind: OrderKind
   inputAmount: CurrencyAmount<Currency>
   outputAmount: CurrencyAmount<Currency>
+  sellAmountBeforeFee: CurrencyAmount<Currency>
   feeAmount: CurrencyAmount<Currency> | undefined
   sellToken: Token
   buyToken: Token
@@ -70,6 +71,7 @@ export async function signAndPostOrder(params: PostOrderParams): Promise<AddUnse
     recipient,
     allowsOffchainSigning,
     appDataHash,
+    sellAmountBeforeFee,
   } = params
 
   // fee adjusted input amount
@@ -138,6 +140,9 @@ export async function signAndPostOrder(params: PostOrderParams): Promise<AddUnse
 
     // Additional API info
     apiAdditionalInfo: undefined,
+
+    // sell amount BEFORE fee - necessary for later calculations (unfilled orders)
+    sellAmountBeforeFee: sellAmountBeforeFee.quotient.toString(),
   }
 
   return {


### PR DESCRIPTION
# Summary

Closes #2522 - unfillable orders using the wrong sell amount input.

Detailed in #2522 - big shout to @nlordell for the help. Confirmed with him this only affects sell orders

Logs showing working logic:
<img width="388" alt="image" src="https://user-images.githubusercontent.com/21335563/158198313-81d9374c-60be-4614-b7c8-8f18344161a4.png">

  # To Test
1. easiest on rinkeby
2. select a token pair
3. make trade and set low gas for long mining time (not super low)
4. check networks tab and filter for `quote` (do this maybe before steps 1-3)
5. see that initial quote and following quote checks during pending order are same `sellAmountBeforeFee`