### PR TITLE
Change warning on the profile page

### DIFF
--- a/src/custom/hooks/useFetchListCallback/useFetchListCallbackMod.ts
+++ b/src/custom/hooks/useFetchListCallback/useFetchListCallbackMod.ts
@@ -21,7 +21,7 @@ export function useFetchListCallback(): (listUrl: string, sendDispatch?: boolean
         if (networkLibrary && network.chainId === 1) {
           return resolveENSContentHash(ensName, networkLibrary)
         }
-        throw new Error('Could not construct mainnet ENS resolver')
+        throw new Error('Could not construct Ethereum ENS resolver')
       }
       return resolveENSContentHash(ensName, library)
     },

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -55,7 +55,7 @@ export default function Profile() {
       )}
       {chainId && chainId !== ChainId.MAINNET && (
         <NotificationBanner isVisible level="info" canClose={false}>
-          Profile data is only available for mainnet. Please change the network to see it.
+          Affiliate data is only available for Ethereum. Please change the network to see it.
         </NotificationBanner>
       )}
     </>

--- a/src/hooks/useFetchListCallback.ts
+++ b/src/hooks/useFetchListCallback.ts
@@ -21,7 +21,7 @@ export function useFetchListCallback(): (listUrl: string, sendDispatch?: boolean
         if (networkLibrary && network.chainId === 1) {
           return resolveENSContentHash(ensName, networkLibrary)
         }
-        throw new Error('Could not construct mainnet ENS resolver')
+        throw new Error('Could not construct Ethereum ENS resolver')
       }
       return resolveENSContentHash(ensName, library)
     },

--- a/src/hooks/useFetchListCallback.ts
+++ b/src/hooks/useFetchListCallback.ts
@@ -21,7 +21,7 @@ export function useFetchListCallback(): (listUrl: string, sendDispatch?: boolean
         if (networkLibrary && network.chainId === 1) {
           return resolveENSContentHash(ensName, networkLibrary)
         }
-        throw new Error('Could not construct Ethereum ENS resolver')
+        throw new Error('Could not construct mainnet ENS resolver')
       }
       return resolveENSContentHash(ensName, library)
     },


### PR DESCRIPTION
# Summary

Fixes #2513 
![image](https://user-images.githubusercontent.com/622217/158859027-3e67060e-0023-441d-b33b-34cb4b6dfc40.png)
  # To Test

1. Connect to a wallet in Rinkeby/GC
2. Open Profile page
3. Check the warning message. Should say: '**Affiliate** data is only available for **Ethereum**. Please change the network to see it.' 
