### PR TITLE
Remove hide claim on barn

### DIFF
--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -45,7 +45,6 @@ import Modal from 'components/Modal'
 // import ClaimModal from 'components/claim/ClaimModal'
 import UniBalanceContent from 'components/Header/UniBalanceContent'
 import CowClaimButton from 'components/CowClaimButton'
-import { IS_CLAIMING_ENABLED } from 'pages/Claim/const'
 
 export const NETWORK_LABELS: { [chainId in ChainId]?: string } = {
   [ChainId.RINKEBY]: 'Rinkeby',
@@ -276,16 +275,14 @@ export default function Header() {
             <NetworkSelector />
           </HeaderElement>
           <HeaderElement>
-            {IS_CLAIMING_ENABLED && (
-              <VCowWrapper>
-                <CowClaimButton
-                  isClaimPage={isClaimPage}
-                  account={account}
-                  chainId={chainId}
-                  handleOnClickClaim={handleOnClickClaim}
-                />
-              </VCowWrapper>
-            )}
+            <VCowWrapper>
+              <CowClaimButton
+                isClaimPage={isClaimPage}
+                account={account}
+                chainId={chainId}
+                handleOnClickClaim={handleOnClickClaim}
+              />
+            </VCowWrapper>
 
             <AccountElement active={!!account} style={{ pointerEvents: 'auto' }}>
               {account && userEthBalance && (

--- a/src/custom/components/Menu/index.tsx
+++ b/src/custom/components/Menu/index.tsx
@@ -20,7 +20,6 @@ import { getExplorerAddressLink } from 'utils/explorer'
 import { useHasOrders } from 'api/gnosisProtocol/hooks'
 import { useHistory } from 'react-router-dom'
 import CowClaimButton, { Wrapper as ClaimButtonWrapper } from 'components/CowClaimButton'
-import { IS_CLAIMING_ENABLED } from 'pages/Claim/const'
 
 import twitterImage from 'assets/cow-swap/twitter.svg'
 import discordImage from 'assets/cow-swap/discord.svg'
@@ -291,14 +290,12 @@ export function Menu({ darkMode, toggleDarkMode, isClaimPage }: MenuProps) {
   return (
     <StyledMenu isClaimPage={isClaimPage}>
       <MenuFlyout>
-        {IS_CLAIMING_ENABLED && (
-          <CowClaimButton
-            isClaimPage={isClaimPage}
-            handleOnClickClaim={handleOnClickClaim}
-            account={account}
-            chainId={chainId}
-          />
-        )}
+        <CowClaimButton
+          isClaimPage={isClaimPage}
+          handleOnClickClaim={handleOnClickClaim}
+          account={account}
+          chainId={chainId}
+        />
 
         <ResponsiveInternalMenuItem to="/" onClick={close}>
           <Repeat size={14} /> Swap

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -11,7 +11,6 @@ import { version } from '@src/../package.json'
 import { environmentName } from 'utils/environments'
 import { useFilterEmptyQueryParams } from 'hooks/useFilterEmptyQueryParams'
 import RedirectAnySwapAffectedUsers from 'pages/error/AnySwapAffectedUsers/RedirectAnySwapAffectedUsers'
-import { IS_CLAIMING_ENABLED } from 'pages/Claim/const'
 
 const SENTRY_DSN = process.env.REACT_APP_SENTRY_DSN
 const SENTRY_TRACES_SAMPLE_RATE = process.env.REACT_APP_SENTRY_TRACES_SAMPLE_RATE
@@ -84,7 +83,7 @@ export default function App() {
             <Route exact strict path="/swap" component={Swap} />
             <Route exact strict path="/swap/:outputCurrency" component={RedirectToSwap} />
             <Route exact strict path="/send" component={RedirectPathToSwapOnly} />
-            {IS_CLAIMING_ENABLED && <Route exact strict path="/claim" component={Claim} />}
+            <Route exact strict path="/claim" component={Claim} />}
             <Route exact strict path="/about" component={About} />
             <Route exact strict path="/profile" component={Profile} />
             <Route exact strict path="/faq" component={Faq} />

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -83,7 +83,7 @@ export default function App() {
             <Route exact strict path="/swap" component={Swap} />
             <Route exact strict path="/swap/:outputCurrency" component={RedirectToSwap} />
             <Route exact strict path="/send" component={RedirectPathToSwapOnly} />
-            <Route exact strict path="/claim" component={Claim} />}
+            <Route exact strict path="/claim" component={Claim} />
             <Route exact strict path="/about" component={About} />
             <Route exact strict path="/profile" component={Profile} />
             <Route exact strict path="/faq" component={Faq} />

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -34,8 +34,6 @@ import { useTokenBalance } from 'state/wallet/hooks'
 import { V_COW } from 'constants/tokens'
 import VCOWDropdown from './VCOWDropdown'
 
-import { IS_CLAIMING_ENABLED } from 'pages/Claim/const'
-
 export default function Profile() {
   const referralLink = useReferralLink()
   const { account, chainId } = useActiveWeb3React()
@@ -69,7 +67,7 @@ export default function Profile() {
           <CardHead>
             <Title>Profile</Title>
           </CardHead>
-          {IS_CLAIMING_ENABLED && vCowBalance && <VCOWDropdown balance={vCowBalance} />}
+          {vCowBalance && <VCOWDropdown balance={vCowBalance} />}
         </ProfileGridWrap>
       </ProfileWrapper>
       <Wrapper>


### PR DESCRIPTION
# Summary

Removes the hack we did to hide the claiming page in Barn so its not exposed before time. 

<img width="757" alt="image" src="https://user-images.githubusercontent.com/2352112/158909209-6737f14f-f662-4ae6-9734-effc6ca8cad1.png">


# To Test

Please review the code, and that nothing is broken

@elena-zh u only will be able to test this when it gets to staging, in that moment you will see the claim button again :) 