### PR TITLE
[Logging] - Only hide logs in production and ens environments

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -2,6 +2,7 @@ import 'polyfill-object.fromentries'
 
 import flat from 'array.prototype.flat'
 import flatMap from 'array.prototype.flatmap'
+import { isEns, isProd } from './custom/utils/environments'
 
 flat.shim()
 flatMap.shim()
@@ -10,7 +11,8 @@ const originalConsole = window.console
 // define a new console
 const proxiedConsole = new Proxy(window.console, {
   get(obj, prop: keyof Console) {
-    if (process.env.NODE_ENV !== 'production') {
+    // show logs in all environments EXCEPT production & ens
+    if (!isProd || !isEns) {
       return obj[prop]
     } else {
       return () => undefined

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -2,7 +2,7 @@ import 'polyfill-object.fromentries'
 
 import flat from 'array.prototype.flat'
 import flatMap from 'array.prototype.flatmap'
-import { isEns, isProd } from './custom/utils/environments'
+import { isEns, isProd } from 'utils/environments'
 
 flat.shim()
 flatMap.shim()

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -2,7 +2,7 @@ import 'polyfill-object.fromentries'
 
 import flat from 'array.prototype.flat'
 import flatMap from 'array.prototype.flatmap'
-import { isEns, isProd } from 'utils/environments'
+import { isEns, isProd, isStaging } from 'utils/environments'
 
 flat.shim()
 flatMap.shim()
@@ -12,7 +12,7 @@ const originalConsole = window.console
 const proxiedConsole = new Proxy(window.console, {
   get(obj, prop: keyof Console) {
     // show logs in all environments EXCEPT production & ens
-    if (!isProd || !isEns) {
+    if (!isProd || !isEns || !isStaging) {
       return obj[prop]
     } else {
       return () => undefined


### PR DESCRIPTION
# Summary

Allows logs in all environments except `production` and `ens` i.e `barn` & `pr` will show logs

## Testing
- barn should show logs