### PR TITLE
[Subsidy] - Show fee breakdown adjusted for subsidy!

### DIFF
--- a/src/custom/components/swap/FeeInformationTooltip.tsx
+++ b/src/custom/components/swap/FeeInformationTooltip.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import TradeGp from 'state/swap/TradeGp'
 import QuestionHelper from 'components/QuestionHelper'
 import styled from 'styled-components/macro'
@@ -6,6 +6,9 @@ import { formatMax, formatSmart } from 'utils/format'
 import useTheme from 'hooks/useTheme'
 import { FIAT_PRECISION } from 'constants/index'
 import { CurrencyAmount, Token } from '@uniswap/sdk-core'
+import useCowBalanceAndSubsidy from 'hooks/useCowBalanceAndSubsidy'
+import { BigNumber } from 'bignumber.js'
+import { ONE_BIG_NUMBER } from '@gnosis.pm/dex-js'
 
 interface FeeInformationTooltipProps {
   trade?: TradeGp
@@ -31,13 +34,15 @@ export const FeeInformationTooltipWrapper = styled.div`
   height: 60px;
 `
 
-const FeeTooltipLine = styled.p`
+const FeeTooltipLine = styled.p<{ discount?: boolean }>`
   display: flex;
   flex-flow: row nowrap;
   justify-content: space-between;
   align-items: center;
   margin: 0;
   gap: 0 8px;
+
+  ${({ discount = false }) => discount && 'text-decoration: line-through;'}
 
   font-size: small;
 
@@ -75,13 +80,68 @@ const FeeInnerWrapper = styled.div`
   gap: 2px;
 `
 
+const FeeBreakdownLine = ({
+  feeAmount,
+  discount,
+  type,
+  symbol,
+}: FeeInformationTooltipProps & { symbol: string | undefined; discount: number }) => {
+  const typeString = type === 'From' ? '+' : '-'
+
+  const FeeAmount = useCallback(() => {
+    // 1 + DISCOUNT/100 e.g 1 + 0.15 = 1.15
+    const discountBn = ONE_BIG_NUMBER.plus(new BigNumber(discount).div(new BigNumber('100')))
+    // we need the fee BEFORE the discount as the backend will return us the adjusted fee with discount
+    const adjustedFee = feeAmount ? new BigNumber(feeAmount).times(discountBn).toString(10) : undefined
+
+    return (
+      <>
+        <span>Fee</span>
+        {adjustedFee ? (
+          <span>
+            {typeString}
+            {adjustedFee} {symbol}
+          </span>
+        ) : (
+          <strong className="green">Free</strong>
+        )}
+      </>
+    )
+  }, [discount, feeAmount, symbol, typeString])
+
+  const FeeDiscountedAmount = useCallback(
+    () => (
+      <>
+        <strong className="green">Fee [-{discount}%]</strong>
+        <span>
+          {typeString}
+          {feeAmount} {symbol}
+        </span>
+      </>
+    ),
+    [discount, feeAmount, symbol, typeString]
+  )
+
+  return (
+    <>
+      <FeeTooltipLine discount={!!discount}>
+        <FeeAmount />
+      </FeeTooltipLine>
+      {!!discount && (
+        <FeeTooltipLine>
+          <FeeDiscountedAmount />
+        </FeeTooltipLine>
+      )}
+    </>
+  )
+}
+
 export default function FeeInformationTooltip(props: FeeInformationTooltipProps) {
   const {
     trade,
     label,
     amountBeforeFees,
     amountAfterFees,
-    feeAmount,
     type,
     showHelper,
     fiatValue,
@@ -90,6 +150,8 @@ export default function FeeInformationTooltip(props: FeeInformationTooltipProps)
   } = props
 
   const theme = useTheme()
+
+  const { subsidy } = useCowBalanceAndSubsidy()
 
   const [symbol, fullFeeAmount] = useMemo(() => {
     const amount = trade?.[type === 'From' ? 'inputAmount' : 'outputAmount']
@@ -113,17 +175,7 @@ export default function FeeInformationTooltip(props: FeeInformationTooltipProps)
                   {amountBeforeFees} {symbol}
                 </span>{' '}
               </FeeTooltipLine>
-              <FeeTooltipLine>
-                <span>Fee</span>
-                {feeAmount ? (
-                  <span>
-                    {type === 'From' ? '+' : '-'}
-                    {feeAmount} {symbol}
-                  </span>
-                ) : (
-                  <strong className="green">Free</strong>
-                )}{' '}
-              </FeeTooltipLine>
+              <FeeBreakdownLine {...props} discount={subsidy.discount} symbol={symbol} />
               {/* TODO: Add gas costs when available (wait for design) */}
               {allowsOffchainSigning && (
                 <FeeTooltipLine>

--- a/src/custom/components/swap/FeeInformationTooltip.tsx
+++ b/src/custom/components/swap/FeeInformationTooltip.tsx
@@ -80,19 +80,19 @@ const FeeInnerWrapper = styled.div`
   gap: 2px;
 `
 
-const FeeBreakdownLine = ({
-  feeAmount,
-  discount,
-  type,
-  symbol,
-}: FeeInformationTooltipProps & { symbol: string | undefined; discount: number }) => {
+type FeeBreakdownProps = FeeInformationTooltipProps & {
+  symbol: string | undefined
+  discount: number
+  fullFeeAmount: string | undefined
+}
+const FeeBreakdownLine = ({ feeAmount, discount, type, symbol, fullFeeAmount }: FeeBreakdownProps) => {
   const typeString = type === 'From' ? '+' : '-'
 
   const FeeAmount = useCallback(() => {
     // 1 + DISCOUNT/100 e.g 1 + 0.15 = 1.15
     const discountBn = ONE_BIG_NUMBER.plus(new BigNumber(discount).div(new BigNumber('100')))
     // we need the fee BEFORE the discount as the backend will return us the adjusted fee with discount
-    const adjustedFee = feeAmount ? new BigNumber(feeAmount).times(discountBn).toString(10) : undefined
+    const adjustedFee = fullFeeAmount ? new BigNumber(fullFeeAmount).times(discountBn).toString(10) : undefined
 
     return (
       <>
@@ -107,7 +107,7 @@ const FeeBreakdownLine = ({
         )}
       </>
     )
-  }, [discount, feeAmount, symbol, typeString])
+  }, [discount, fullFeeAmount, symbol, typeString])
 
   const FeeDiscountedAmount = useCallback(
     () => (
@@ -124,10 +124,10 @@ const FeeBreakdownLine = ({
 
   return (
     <>
-      <FeeTooltipLine discount={!!discount}>
+      <FeeTooltipLine discount={!!fullFeeAmount && !!discount}>
         <FeeAmount />
       </FeeTooltipLine>
-      {!!discount && (
+      {!!fullFeeAmount && !!discount && (
         <FeeTooltipLine>
           <FeeDiscountedAmount />
         </FeeTooltipLine>
@@ -175,8 +175,7 @@ export default function FeeInformationTooltip(props: FeeInformationTooltipProps)
                   {amountBeforeFees} {symbol}
                 </span>{' '}
               </FeeTooltipLine>
-              <FeeBreakdownLine {...props} discount={subsidy.discount} symbol={symbol} />
-              {/* TODO: Add gas costs when available (wait for design) */}
+              <FeeBreakdownLine {...props} fullFeeAmount={fullFeeAmount} discount={subsidy.discount} symbol={symbol} />
               {allowsOffchainSigning && (
                 <FeeTooltipLine>
                   <span>Gas costs</span>

--- a/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
+++ b/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
@@ -154,7 +154,7 @@ SwapModalHeaderProps) {
           <FeeInformationTooltip
             amountAfterFees={formatSmart(trade.inputAmountWithFee, AMOUNT_PRECISION)}
             amountBeforeFees={formatSmart(trade.inputAmountWithoutFee, AMOUNT_PRECISION)}
-            feeAmount={formatSmart(trade.fee.feeAsCurrency, AMOUNT_PRECISION)}
+            feeAmount={trade.fee.feeAsCurrency}
             allowsOffchainSigning={allowsOffchainSigning}
             label={exactInLabel}
             showHelper
@@ -205,7 +205,7 @@ SwapModalHeaderProps) {
           <FeeInformationTooltip
             amountAfterFees={formatSmart(trade.outputAmount, AMOUNT_PRECISION)}
             amountBeforeFees={formatSmart(trade.outputAmountWithoutFee, AMOUNT_PRECISION)}
-            feeAmount={formatSmart(trade.outputAmountWithoutFee?.subtract(trade.outputAmount), AMOUNT_PRECISION)}
+            feeAmount={trade.outputAmountWithoutFee?.subtract(trade.outputAmount)}
             label={exactOutLabel}
             allowsOffchainSigning={allowsOffchainSigning}
             showHelper

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -573,7 +573,7 @@ export default function Swap({
                       amountBeforeFees={amountBeforeFees}
                       amountAfterFees={formatSmart(trade?.inputAmountWithFee, AMOUNT_PRECISION)}
                       type="From"
-                      feeAmount={formatSmart(trade?.fee?.feeAsCurrency, AMOUNT_PRECISION)}
+                      feeAmount={trade?.fee?.feeAsCurrency}
                       allowsOffchainSigning={allowsOffchainSigning}
                       fiatValue={fiatValueInput}
                     />
@@ -633,10 +633,7 @@ export default function Swap({
                       amountBeforeFees={formatSmart(trade?.outputAmountWithoutFee, AMOUNT_PRECISION)}
                       amountAfterFees={formatSmart(trade?.outputAmount, AMOUNT_PRECISION)}
                       type="To"
-                      feeAmount={formatSmart(
-                        trade?.outputAmountWithoutFee?.subtract(trade?.outputAmount),
-                        AMOUNT_PRECISION
-                      )}
+                      feeAmount={trade?.outputAmountWithoutFee?.subtract(trade?.outputAmount)}
                       allowsOffchainSigning={allowsOffchainSigning}
                       fiatValue={fiatValueOutput}
                     />


### PR DESCRIPTION
# Summary

Adjusts fee breakdown tooltip to show optimistically the fees discounted

Explanation of maths:
- we get fee amount from backend, we have to be optimistic and assume the fee was/is adjusted and returned properly factoring in discount. 
- we take the returned `feeAmount` and `multiply` that amount by `1 + discount` to get the `preSubsidyFeeAmount` and show that as the crossed out "previous fee" even tho that amount is never officially returned from the backend
- e.g user has 35% discount
- trading GNO <> WETH
- fee is shown as `0.0046` WETH (backend returned amount)
- to calculate `preSubsidyFeeAmount` we simply do: `0.0046 * 1.35 // 0.00621 ` (in atomic maths using bigint)

NO DISCOUNT
<img width="620" alt="image" src="https://user-images.githubusercontent.com/21335563/160127501-bdfa7061-7713-4b5a-976b-9ac0854df6c1.png">

35% DISCOUNT
<img width="565" alt="image" src="https://user-images.githubusercontent.com/21335563/160127557-7bb544ea-3b6b-4795-bf7b-55f20af698dd.png">

## To Test
1. use an acct with no discount
2. check fee breakdown
3. switch to an account with discount
4. check fee breakdown
5. should match screenshots
