### PR TITLE
Improve loading

### DIFF
--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -64,12 +64,24 @@ export const BodyWrapper = styled.div`
   `}
 `
 
+export const LoadingWrapper = styled.div`
+  animation: blinker 2s linear infinite;
+
+  @keyframes blinker {
+    50% {
+      opacity: 0;
+    }
+  }
+`
+
 function createRedirectExternal(url: string) {
   return () => {
     window.location.replace(url)
     return null
   }
 }
+
+const Loading = <LoadingWrapper>Loading...</LoadingWrapper>
 
 export default function App() {
   // Dealing with empty URL queryParameters
@@ -79,7 +91,7 @@ export default function App() {
     <>
       <RedirectAnySwapAffectedUsers />
       <Wrapper>
-        <Suspense fallback={<div>Loading...</div>}>
+        <Suspense fallback={Loading}>
           <Switch>
             <Route exact strict path="/swap" component={Swap} />
             <Route exact strict path="/swap/:outputCurrency" component={RedirectToSwap} />


### PR DESCRIPTION
# Summary

Add loading a blinking effect while loading for the "Loading ..." message.

After adding Lazy-loading and code-splitting we were showing this message. This PR is just a small improvement on handing the app boot.


https://user-images.githubusercontent.com/2352112/160285511-fc6b0f43-ea15-4d0d-8700-545cd87dcc34.mp4


https://user-images.githubusercontent.com/2352112/160285512-886a385a-4e26-4e69-9ec1-d93fc5823073.mp4


# To Test
Just throttle the internet a little bit

<img width="654" alt="image" src="https://user-images.githubusercontent.com/2352112/160285454-0ccd79df-ab73-4535-98c8-14cb4ed085e1.png">

Observe loading message is now loading